### PR TITLE
Add customer dashboard and fix booking flow (TRU-5)

### DIFF
--- a/book/index.html
+++ b/book/index.html
@@ -356,9 +356,10 @@ async function submitBooking() {
         <div class="success-icon"><svg width="28" height="28" viewBox="0 0 24 24" fill="none"><path d="M5 13l4 4L19 7" stroke="#5B8C5A" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/></svg></div>
         <h2>Booking request sent!</h2>
         <p>${providerData.first_name} will review your request and confirm. We'll let you know once they respond.</p>
+        <p style="margin-top:0.75rem;font-size:0.82rem;color:var(--text-muted);">You can track the booking status and live walk from your dashboard.</p>
         <div style="margin-top:2rem;display:flex;gap:12px;justify-content:center;flex-wrap:wrap;">
-          <a href="/search/" style="display:inline-block;padding:12px 28px;background:var(--terracotta);color:white;border-radius:10px;font-weight:500;text-decoration:none;font-size:0.9rem;">Browse more carers</a>
-          <a href="/carer/?id=${new URLSearchParams(window.location.search).get('provider')}" style="display:inline-block;padding:12px 28px;border:1px solid var(--border);color:var(--text-secondary);border-radius:10px;font-weight:500;text-decoration:none;font-size:0.9rem;">Back to profile</a>
+          <a href="/my/" style="display:inline-block;padding:12px 28px;background:var(--terracotta);color:white;border-radius:10px;font-weight:500;text-decoration:none;font-size:0.9rem;">View my bookings</a>
+          <a href="/search/" style="display:inline-block;padding:12px 28px;border:1px solid var(--border);color:var(--text-secondary);border-radius:10px;font-weight:500;text-decoration:none;font-size:0.9rem;">Browse more carers</a>
         </div>
       </div>
     `;

--- a/login/index.html
+++ b/login/index.html
@@ -597,7 +597,7 @@ async function doLogin() {
     const redirectTo = new URLSearchParams(window.location.search).get('redirect');
     if (redirectTo) window.location.href = redirectTo;
     else if (role === 'provider') window.location.href = '/dashboard/';
-    else window.location.href = '/search/';
+    else window.location.href = '/my/';
   } catch (e) { showMsg(e.message, 'error'); }
   finally { setLoading(btn, false); }
 }

--- a/my/index.html
+++ b/my/index.html
@@ -1,0 +1,576 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>My Dashboard — Truffl Pets</title>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=DM+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --cream:#FAF7F2; --warm-white:#FFFDF9; --sage:#8B9E7E; --sage-light:#C2D1B5;
+    --sage-dark:#6B7E5E; --terracotta:#C4755B; --terracotta-light:#D4917B;
+    --blush:#E8C4B8; --brown:#3D2B1F; --brown-muted:#8B7355;
+    --text-primary:#3D2B1F; --text-secondary:#6B5B4E; --text-muted:#9B8B7E;
+    --border:#E8E0D6; --border-focus:#C4755B;
+    --error:#C0392B; --error-bg:#FDF0EE; --success:#5B8C5A; --success-bg:#EDF5ED;
+    --warning:#C0862B; --warning-bg:#FEF3E2;
+  }
+  *{margin:0;padding:0;box-sizing:border-box;}
+  body{font-family:'DM Sans',sans-serif;background:var(--cream);color:var(--text-primary);min-height:100vh;-webkit-font-smoothing:antialiased;}
+
+  .nav{position:sticky;top:0;z-index:100;background:var(--warm-white);border-bottom:1px solid var(--border);padding:0 1.5rem;height:64px;display:flex;align-items:center;justify-content:space-between;}
+  .nav-logo{display:flex;align-items:center;text-decoration:none;}
+  .nav-right{display:flex;align-items:center;gap:8px;}
+  .nav-avatar{width:32px;height:32px;border-radius:50%;background:var(--blush);display:flex;align-items:center;justify-content:center;font-size:0.75rem;font-weight:600;color:var(--brown);}
+  .nav-name{font-size:0.85rem;font-weight:500;color:var(--text-primary);}
+
+  .page-wrapper{max-width:560px;margin:0 auto;padding:1.5rem 1rem 4rem;}
+
+  .welcome{margin-bottom:1.5rem;}
+  .welcome h1{font-family:'Cormorant Garamond',serif;font-weight:500;font-size:1.8rem;color:var(--brown);margin-bottom:4px;}
+  .welcome p{color:var(--text-muted);font-size:0.9rem;}
+
+  .tabs{display:flex;gap:4px;margin-bottom:1.5rem;border-bottom:1px solid var(--border);}
+  .tab{padding:10px 18px;font-size:0.85rem;font-weight:500;color:var(--text-muted);cursor:pointer;transition:all 0.2s;border-bottom:2px solid transparent;white-space:nowrap;background:none;border-top:none;border-left:none;border-right:none;font-family:'DM Sans',sans-serif;}
+  .tab:hover{color:var(--text-secondary);}
+  .tab.active{color:var(--terracotta);border-bottom-color:var(--terracotta);}
+  .tab-content{display:none;}
+  .tab-content.active{display:block;animation:fadeIn 0.25s ease;}
+
+  .section-heading{font-family:'Cormorant Garamond',serif;font-weight:500;font-size:1.1rem;color:var(--brown);margin-bottom:0.75rem;}
+
+  /* Booking cards */
+  .booking-card{background:var(--warm-white);border:1px solid var(--border);border-radius:14px;padding:1.25rem;margin-bottom:0.75rem;}
+  .bc-pet-name{font-size:0.95rem;font-weight:500;color:var(--text-primary);margin-bottom:2px;}
+  .bc-meta{font-size:0.82rem;color:var(--text-secondary);margin-bottom:4px;}
+  .bc-time{font-size:0.82rem;color:var(--text-muted);margin-bottom:8px;}
+
+  .status-badge{display:inline-flex;align-items:center;gap:5px;font-size:0.72rem;font-weight:600;padding:2px 10px;border-radius:20px;text-transform:uppercase;letter-spacing:0.03em;}
+  .badge-pending{background:var(--warning-bg);color:var(--warning);}
+  .badge-confirmed{background:var(--success-bg);color:var(--success);}
+  .badge-in-progress{background:var(--success-bg);color:var(--success);}
+  .badge-completed{background:rgba(139,158,126,0.12);color:var(--sage-dark);}
+  .badge-cancelled{background:var(--error-bg);color:var(--error);}
+  .badge-pulse{width:6px;height:6px;border-radius:50%;background:currentColor;animation:pulse 1.5s infinite;}
+  @keyframes pulse{0%,100%{opacity:1;}50%{opacity:0.3;}}
+
+  .bc-service{display:inline-block;font-size:0.75rem;padding:3px 10px;background:rgba(139,158,126,0.1);border-radius:20px;color:var(--sage-dark);margin-bottom:8px;}
+
+  .bc-actions{display:flex;gap:8px;flex-wrap:wrap;margin-top:12px;}
+  .btn-track{display:inline-block;padding:10px 18px;background:var(--terracotta);color:white;border-radius:10px;font-size:0.85rem;font-weight:600;text-decoration:none;border:none;cursor:pointer;font-family:'DM Sans',sans-serif;transition:background 0.2s;}
+  .btn-track:hover{background:var(--terracotta-light);}
+  .btn-ghost{padding:8px 14px;background:transparent;border:1px solid var(--border);color:var(--text-secondary);border-radius:8px;font-size:0.82rem;font-weight:500;cursor:pointer;font-family:'DM Sans',sans-serif;text-decoration:none;display:inline-block;transition:border-color 0.2s,color 0.2s;}
+  .btn-ghost:hover{border-color:var(--text-muted);}
+  .btn-ghost.danger{color:var(--error);}
+  .btn-ghost.danger:hover{border-color:var(--error);}
+
+  .cancel-confirm{display:flex;align-items:center;gap:8px;flex-wrap:wrap;}
+  .cancel-confirm span{font-size:0.82rem;color:var(--text-secondary);}
+  .btn-cancel-yes{padding:8px 14px;background:var(--error);color:white;border:none;border-radius:8px;font-size:0.82rem;font-weight:500;cursor:pointer;font-family:'DM Sans',sans-serif;}
+  .btn-cancel-yes:hover{opacity:0.9;}
+  .btn-cancel-keep{padding:8px 14px;background:transparent;border:1px solid var(--border);color:var(--text-muted);border-radius:8px;font-size:0.82rem;cursor:pointer;font-family:'DM Sans',sans-serif;}
+
+  /* Pet cards */
+  .pet-card{background:var(--warm-white);border:1px solid var(--border);border-radius:12px;padding:1rem 1.25rem;margin-bottom:0.75rem;}
+  .pet-card-header{display:flex;align-items:center;justify-content:space-between;gap:12px;}
+  .pet-name{font-size:0.95rem;font-weight:500;color:var(--text-primary);}
+  .pet-meta{font-size:0.8rem;color:var(--text-muted);margin-top:2px;}
+  .pet-actions{display:flex;gap:8px;flex-shrink:0;}
+  .pet-edit-form{margin-top:12px;padding-top:12px;border-top:1px solid var(--border);}
+
+  /* Inline form elements */
+  .inline-field{margin-bottom:10px;}
+  .inline-field label{display:block;font-size:0.78rem;font-weight:500;color:var(--text-secondary);margin-bottom:4px;}
+  .inline-field input{width:100%;padding:8px 12px;border:1px solid var(--border);border-radius:8px;font-family:'DM Sans',sans-serif;font-size:0.88rem;color:var(--text-primary);background:var(--warm-white);outline:none;transition:border-color 0.2s;}
+  .inline-field input:focus{border-color:var(--border-focus);}
+  .inline-form-actions{display:flex;gap:8px;margin-top:12px;}
+  .btn-save{padding:8px 18px;background:var(--terracotta);color:white;border:none;border-radius:8px;font-size:0.82rem;font-weight:500;cursor:pointer;font-family:'DM Sans',sans-serif;transition:background 0.2s;}
+  .btn-save:hover{background:var(--terracotta-light);}
+  .btn-discard{padding:8px 14px;background:transparent;border:1px solid var(--border);color:var(--text-muted);border-radius:8px;font-size:0.82rem;cursor:pointer;font-family:'DM Sans',sans-serif;}
+
+  .btn-add-pet{display:flex;align-items:center;gap:8px;padding:12px 16px;background:transparent;border:1.5px dashed var(--border);border-radius:12px;color:var(--text-muted);font-size:0.85rem;cursor:pointer;width:100%;font-family:'DM Sans',sans-serif;transition:all 0.2s;}
+  .btn-add-pet:hover{border-color:var(--terracotta);color:var(--terracotta);}
+
+  /* Details card */
+  .details-card{background:var(--warm-white);border:1px solid var(--border);border-radius:12px;padding:1.25rem;margin-bottom:0.75rem;}
+  .detail-row{display:flex;justify-content:space-between;align-items:center;padding:5px 0;font-size:0.88rem;}
+  .detail-label{color:var(--text-muted);}
+  .detail-value{color:var(--text-primary);font-weight:500;}
+
+  .sign-out-btn{display:block;width:100%;padding:12px;background:transparent;border:1px solid var(--border);color:var(--error);border-radius:10px;font-size:0.88rem;font-weight:500;cursor:pointer;font-family:'DM Sans',sans-serif;text-align:center;margin-top:1.5rem;transition:border-color 0.2s;}
+  .sign-out-btn:hover{border-color:var(--error);}
+
+  .section-divider{margin:1.5rem 0;border:none;border-top:1px solid var(--border);}
+
+  /* Empty state */
+  .empty{text-align:center;padding:3rem 1rem;}
+  .empty-emoji{font-size:2rem;margin-bottom:0.75rem;opacity:0.6;}
+  .empty h3{font-family:'Cormorant Garamond',serif;font-size:1.3rem;color:var(--brown);margin-bottom:0.5rem;}
+  .empty p{font-size:0.88rem;color:var(--text-muted);margin-bottom:1.5rem;}
+  .btn-primary{display:inline-block;padding:12px 28px;background:var(--terracotta);color:white;border-radius:10px;font-weight:500;text-decoration:none;font-size:0.9rem;border:none;cursor:pointer;font-family:'DM Sans',sans-serif;transition:background 0.2s;}
+  .btn-primary:hover{background:var(--terracotta-light);}
+
+  .msg{padding:12px 16px;border-radius:10px;font-size:0.85rem;margin-bottom:1rem;display:none;line-height:1.5;}
+  .msg.error{background:var(--error-bg);color:var(--error);display:block;}
+  .msg.success{background:var(--success-bg);color:var(--success);display:block;}
+
+  .login-prompt{text-align:center;padding:4rem 2rem;}
+  .login-prompt h2{font-family:'Cormorant Garamond',serif;font-size:1.6rem;color:var(--brown);margin-bottom:0.5rem;}
+  .login-prompt p{color:var(--text-muted);font-size:0.9rem;margin-bottom:1.5rem;}
+  .login-prompt a{display:inline-block;padding:12px 32px;background:var(--terracotta);color:white;border-radius:10px;font-weight:500;text-decoration:none;}
+
+  @keyframes fadeIn{from{opacity:0;transform:translateY(6px);}to{opacity:1;transform:translateY(0);}}
+
+  @media(max-width:600px){
+    .page-wrapper{padding:1rem 0.75rem 3rem;}
+    .nav{padding:0 1rem;}
+    .btn-track{width:100%;text-align:center;}
+    .nav-name{display:none;}
+  }
+</style>
+</head>
+<body>
+
+<nav class="nav">
+  <a href="/" class="nav-logo" aria-label="Truffl Pets home">
+    <svg width="150" height="48" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <circle cx="20" cy="5.5" r="6" fill="none" stroke="#C4866A" stroke-width="2.5"/>
+      <circle cx="20" cy="5.5" r="2.8" fill="#FFFDF9"/>
+      <rect x="16.5" y="10.5" width="7" height="9" rx="3" fill="#C4866A"/>
+      <circle cx="20" cy="33" r="20" fill="#C4866A"/>
+      <circle cx="20" cy="33" r="15.5" fill="none" stroke="#B8795C" stroke-width="0.6" opacity="0.45"/>
+      <line x1="7" y1="33" x2="33" y2="33" stroke="#FFFDF9" stroke-width="0.5" opacity="0.3"/>
+      <text x="20" y="35.5" font-family="'Cormorant Garamond', Georgia, serif" font-size="14" font-style="italic" font-weight="400" fill="#FFFDF9" text-anchor="middle" letter-spacing="-0.3">truffl</text>
+      <text x="52" y="30" font-family="'Cormorant Garamond', Georgia, serif" font-size="32" font-style="italic" font-weight="400" fill="#3D2B1F" letter-spacing="-0.5">truffl</text>
+      <text x="52" y="50" font-family="'DM Sans', sans-serif" font-size="12" font-weight="600" fill="#B0A090" letter-spacing="4">PETS</text>
+    </svg>
+  </a>
+  <div class="nav-right" id="navUser"></div>
+</nav>
+
+<div class="page-wrapper">
+  <div id="myContent">
+    <div style="text-align:center;padding:3rem;color:var(--text-muted);font-size:0.85rem;">Loading your dashboard...</div>
+  </div>
+</div>
+
+<script>
+const SUPABASE_URL = 'https://gadflsntbnbnnxbpiral.supabase.co';
+const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdhZGZsc250Ym5ibm54YnBpcmFsIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzUwNjcwNTcsImV4cCI6MjA5MDY0MzA1N30.g5ZrqeAX9U5l7oDZEbQFrU5j10828dUF0QuJ0ZlHXK8';
+
+const SERVICE_LABELS = {
+  dog_walking:'Dog walking', dog_sitting:'Dog sitting', dog_boarding:'Dog boarding',
+  cat_sitting:'Cat sitting', cat_boarding:'Cat boarding', pet_sitting:'Other pet sitting'
+};
+
+let authToken = null, authUid = null;
+let userData = null, customerProfile = null;
+let bookings = [], pets = [];
+let pendingCancelId = null, editingPetId = null, addingPet = false, editingDetails = false;
+
+function h(token) {
+  const hd = { 'Content-Type': 'application/json', 'apikey': SUPABASE_ANON_KEY, 'Authorization': `Bearer ${SUPABASE_ANON_KEY}` };
+  if (token) hd['Authorization'] = `Bearer ${token}`;
+  return hd;
+}
+async function sbGet(t, p) {
+  const r = await fetch(`${SUPABASE_URL}/rest/v1/${t}?${p}`, { headers: h(authToken) });
+  if (!r.ok) { const e = await r.json(); throw new Error(e.message); }
+  return await r.json();
+}
+async function sbPatch(t, col, val, upd) {
+  const r = await fetch(`${SUPABASE_URL}/rest/v1/${t}?${col}=eq.${val}`, { method: 'PATCH', headers: { ...h(authToken), 'Prefer': 'return=representation' }, body: JSON.stringify(upd) });
+  if (!r.ok) { const e = await r.json(); throw new Error(e.message); }
+  return await r.json();
+}
+async function sbInsert(t, row) {
+  const r = await fetch(`${SUPABASE_URL}/rest/v1/${t}`, { method: 'POST', headers: { ...h(authToken), 'Prefer': 'return=representation' }, body: JSON.stringify(row) });
+  if (!r.ok) { const e = await r.json(); throw new Error(e.message); }
+  return await r.json();
+}
+
+function esc(s) {
+  return (s || '').toString().replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+}
+
+function showMsg(t, type) {
+  const el = document.getElementById('myMsg');
+  if (!el) return;
+  el.textContent = t;
+  el.className = `msg ${type}`;
+}
+function clearMsg() {
+  const el = document.getElementById('myMsg');
+  if (el) el.className = 'msg';
+}
+
+function formatScheduledAt(iso) {
+  const d = new Date(iso);
+  const weekday = d.toLocaleDateString('en-AU', { weekday: 'long' });
+  const day = d.toLocaleDateString('en-AU', { day: 'numeric' });
+  const month = d.toLocaleDateString('en-AU', { month: 'long' });
+  const time = d.toLocaleTimeString('en-AU', { hour: 'numeric', minute: '2-digit', hour12: true });
+  return `${weekday} ${day} ${month} · ${time}`;
+}
+
+function statusBadge(status) {
+  if (status === 'in_progress') {
+    return `<div style="margin-bottom:10px;"><span class="status-badge badge-in-progress"><span class="badge-pulse"></span>Walk in progress</span></div>`;
+  }
+  const map = {
+    pending: ['badge-pending', 'Awaiting confirmation'],
+    confirmed: ['badge-confirmed', 'Confirmed'],
+    completed: ['badge-completed', 'Completed'],
+    cancelled: ['badge-cancelled', 'Cancelled']
+  };
+  const [cls, label] = map[status] || ['', status];
+  return `<div style="margin-bottom:10px;"><span class="status-badge ${cls}">${label}</span></div>`;
+}
+
+function actionButtons(b) {
+  if (b.status === 'in_progress') {
+    return b._has_active_walk
+      ? `<a href="/track/?booking=${b.id}" class="btn-track">Track live walk →</a>`
+      : `<a href="/track/?booking=${b.id}" class="btn-ghost">View walk</a>`;
+  }
+  if (b.status === 'confirmed') {
+    if (pendingCancelId === b.id) return cancelConfirmHtml(b.id);
+    return `<a href="/track/?booking=${b.id}" class="btn-ghost">View booking</a><button class="btn-ghost danger" onclick="showCancelConfirm('${b.id}')">Cancel</button>`;
+  }
+  if (b.status === 'pending') {
+    if (pendingCancelId === b.id) return cancelConfirmHtml(b.id);
+    return `<button class="btn-ghost danger" onclick="showCancelConfirm('${b.id}')">Cancel</button>`;
+  }
+  if (b.status === 'completed' && b._provider_user_id) {
+    return `<a href="/book/?provider=${b._provider_user_id}" class="btn-ghost">Book again</a>`;
+  }
+  return '';
+}
+
+function cancelConfirmHtml(id) {
+  return `<div class="cancel-confirm"><span>Are you sure?</span><button class="btn-cancel-yes" onclick="doCancelBooking('${id}')">Yes, cancel</button><button class="btn-cancel-keep" onclick="dismissCancel()">Keep booking</button></div>`;
+}
+
+function bookingCardHtml(b) {
+  const petLabel = esc(b._pet_name || 'Your pet') + (b._pet_breed ? ' · ' + esc(b._pet_breed) : '');
+  const serviceLabel = SERVICE_LABELS[b._service_type] || esc(b._service_type) || 'Service';
+  const provLabel = esc(b._provider_name || 'Your carer');
+  const dateStr = b.scheduled_at ? formatScheduledAt(b.scheduled_at) : '';
+  const actions = actionButtons(b);
+  return `
+    <div class="booking-card">
+      <div class="bc-pet-name">${petLabel}</div>
+      <div class="bc-meta">${serviceLabel} · ${provLabel}</div>
+      <div class="bc-time">${esc(dateStr)}</div>
+      ${statusBadge(b.status)}
+      ${actions ? `<div class="bc-actions">${actions}</div>` : ''}
+    </div>
+  `;
+}
+
+function switchTab(name) {
+  document.querySelectorAll('.tab').forEach(t => t.classList.toggle('active', t.dataset.tab === name));
+  document.querySelectorAll('.tab-content').forEach(t => t.classList.toggle('active', t.id === `tab-${name}`));
+}
+
+function renderBookingsTab() {
+  const area = document.getElementById('tab-bookings');
+  if (!area) return;
+
+  const active = bookings
+    .filter(b => ['pending', 'confirmed', 'in_progress'].includes(b.status))
+    .sort((a, b) => new Date(a.scheduled_at) - new Date(b.scheduled_at));
+
+  const past = bookings
+    .filter(b => ['completed', 'cancelled'].includes(b.status))
+    .sort((a, b) => new Date(b.scheduled_at) - new Date(a.scheduled_at))
+    .slice(0, 10);
+
+  if (bookings.length === 0) {
+    area.innerHTML = `
+      <div class="empty">
+        <div class="empty-emoji">🐾</div>
+        <h3>No bookings yet</h3>
+        <p>Find a trusted carer and book your first walk.</p>
+        <a href="/search/" class="btn-primary">Find a carer</a>
+      </div>
+    `;
+    return;
+  }
+
+  let html = '';
+  if (active.length > 0) {
+    html += `<div class="section-heading">Active &amp; upcoming</div>`;
+    html += active.map(bookingCardHtml).join('');
+  }
+  if (past.length > 0) {
+    html += `<div class="section-heading" style="margin-top:${active.length > 0 ? '1.5rem' : '0'};">Past bookings</div>`;
+    html += past.map(bookingCardHtml).join('');
+  }
+  area.innerHTML = html;
+}
+
+function renderAccountTab() {
+  const area = document.getElementById('tab-account');
+  if (!area) return;
+
+  let petsHtml = '';
+  if (pets.length === 0 && !addingPet) {
+    petsHtml = `<div style="text-align:center;padding:1.5rem;color:var(--text-muted);font-size:0.88rem;">No pets added yet</div>`;
+  } else {
+    petsHtml = pets.map(p => {
+      if (editingPetId === p.id) {
+        return `
+          <div class="pet-card">
+            <div class="pet-card-header">
+              <div><div class="pet-name">${esc(p.name)}</div></div>
+            </div>
+            <div class="pet-edit-form">
+              <div class="inline-field"><label>Name</label><input id="pet-edit-name-${p.id}" value="${esc(p.name)}"></div>
+              <div class="inline-field"><label>Breed</label><input id="pet-edit-breed-${p.id}" value="${esc(p.breed || '')}"></div>
+              <div class="inline-form-actions">
+                <button class="btn-save" onclick="savePet('${p.id}')">Save</button>
+                <button class="btn-discard" onclick="cancelPetEdit()">Cancel</button>
+              </div>
+            </div>
+          </div>
+        `;
+      }
+      const meta = [p.breed, p.species].filter(Boolean).map(esc).join(' · ');
+      return `
+        <div class="pet-card">
+          <div class="pet-card-header">
+            <div>
+              <div class="pet-name">${esc(p.name)}</div>
+              ${meta ? `<div class="pet-meta">${meta}</div>` : ''}
+            </div>
+            <div class="pet-actions">
+              <button class="btn-ghost" onclick="showPetEdit('${p.id}')">Edit</button>
+              <button class="btn-ghost danger" onclick="removePet('${p.id}')">Remove</button>
+            </div>
+          </div>
+        </div>
+      `;
+    }).join('');
+  }
+
+  const addPetHtml = addingPet ? `
+    <div class="pet-card" style="margin-top:0.5rem;">
+      <div class="inline-field"><label>Name</label><input id="new-pet-name" placeholder="e.g. Flick"></div>
+      <div class="inline-field"><label>Breed <span style="color:var(--text-muted);font-weight:400;">(optional)</span></label><input id="new-pet-breed" placeholder="e.g. Springer Spaniel"></div>
+      <div class="inline-form-actions">
+        <button class="btn-save" onclick="submitAddPet()">Add pet</button>
+        <button class="btn-discard" onclick="cancelAddPet()">Cancel</button>
+      </div>
+    </div>
+  ` : `
+    <button class="btn-add-pet" onclick="showAddPet()" style="margin-top:0.5rem;">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+      Add a pet
+    </button>
+  `;
+
+  const detailsHtml = editingDetails ? `
+    <div class="details-card">
+      <div class="inline-field"><label>First name</label><input id="edit-first-name" value="${esc(userData.first_name || '')}"></div>
+      <div class="inline-field"><label>Last name</label><input id="edit-last-name" value="${esc(userData.last_name || '')}"></div>
+      <div class="inline-form-actions">
+        <button class="btn-save" onclick="saveDetails()">Save</button>
+        <button class="btn-discard" onclick="cancelDetailsEdit()">Cancel</button>
+      </div>
+    </div>
+  ` : `
+    <div class="details-card">
+      <div class="detail-row"><span class="detail-label">Name</span><span class="detail-value">${esc(userData.first_name)} ${esc(userData.last_name)}</span></div>
+      <div style="margin-top:10px;"><button class="btn-ghost" onclick="showDetailsEdit()">Edit details</button></div>
+    </div>
+  `;
+
+  area.innerHTML = `
+    <div class="section-heading">My pets</div>
+    ${petsHtml}
+    ${addPetHtml}
+    <hr class="section-divider">
+    <div class="section-heading">My details</div>
+    ${detailsHtml}
+    <button class="sign-out-btn" onclick="signOut()">Sign out</button>
+  `;
+}
+
+function renderDashboard() {
+  const initials = ((userData.first_name || '')[0] || '').toUpperCase() + ((userData.last_name || '')[0] || '').toUpperCase();
+  document.getElementById('navUser').innerHTML = `<div class="nav-avatar">${esc(initials)}</div><span class="nav-name">${esc(userData.first_name)}</span>`;
+
+  const inProgress = bookings.filter(b => b.status === 'in_progress');
+  const welcomeSub = inProgress.length > 0
+    ? `${esc(inProgress[0]._pet_name || 'Your pet')}'s walk is in progress right now.`
+    : 'Manage your bookings, pets, and account details.';
+
+  document.getElementById('myContent').innerHTML = `
+    <div class="welcome">
+      <h1>Hey, ${esc(userData.first_name)}</h1>
+      <p>${welcomeSub}</p>
+    </div>
+    <div id="myMsg" class="msg"></div>
+    <div class="tabs">
+      <button class="tab active" data-tab="bookings" onclick="switchTab('bookings')">My bookings</button>
+      <button class="tab" data-tab="account" onclick="switchTab('account')">My account</button>
+    </div>
+    <div class="tab-content active" id="tab-bookings"></div>
+    <div class="tab-content" id="tab-account"></div>
+  `;
+
+  renderBookingsTab();
+  renderAccountTab();
+}
+
+/* ── Cancel flow ── */
+function showCancelConfirm(id) {
+  pendingCancelId = id;
+  renderBookingsTab();
+}
+function dismissCancel() {
+  pendingCancelId = null;
+  renderBookingsTab();
+}
+async function doCancelBooking(id) {
+  try {
+    await sbPatch('bookings', 'id', id, { status: 'cancelled' });
+    const b = bookings.find(x => x.id === id);
+    if (b) b.status = 'cancelled';
+    pendingCancelId = null;
+    renderBookingsTab();
+  } catch(e) { showMsg(e.message, 'error'); }
+}
+
+/* ── Pet management ── */
+function showPetEdit(id) { editingPetId = id; renderAccountTab(); }
+function cancelPetEdit() { editingPetId = null; renderAccountTab(); }
+
+async function savePet(id) {
+  const name = (document.getElementById(`pet-edit-name-${id}`) || {}).value?.trim();
+  const breed = (document.getElementById(`pet-edit-breed-${id}`) || {}).value?.trim();
+  if (!name) return showMsg('Pet name is required.', 'error');
+  try {
+    await sbPatch('pets', 'id', id, { name, breed: breed || null });
+    const p = pets.find(x => x.id === id);
+    if (p) { p.name = name; p.breed = breed || null; }
+    editingPetId = null;
+    clearMsg();
+    renderAccountTab();
+  } catch(e) { showMsg(e.message, 'error'); }
+}
+
+async function removePet(id) {
+  try {
+    await sbPatch('pets', 'id', id, { is_active: false });
+    pets = pets.filter(p => p.id !== id);
+    renderAccountTab();
+  } catch(e) { showMsg(e.message, 'error'); }
+}
+
+function showAddPet() { addingPet = true; renderAccountTab(); }
+function cancelAddPet() { addingPet = false; renderAccountTab(); }
+
+async function submitAddPet() {
+  const name = (document.getElementById('new-pet-name') || {}).value?.trim();
+  const breed = (document.getElementById('new-pet-breed') || {}).value?.trim();
+  if (!name) return showMsg('Pet name is required.', 'error');
+  try {
+    const result = await sbInsert('pets', { customer_id: customerProfile.id, name, breed: breed || null, is_active: true });
+    const newPet = Array.isArray(result) ? result[0] : result;
+    if (newPet) pets.push(newPet);
+    addingPet = false;
+    clearMsg();
+    renderAccountTab();
+  } catch(e) { showMsg(e.message, 'error'); }
+}
+
+/* ── User details ── */
+function showDetailsEdit() { editingDetails = true; renderAccountTab(); }
+function cancelDetailsEdit() { editingDetails = false; renderAccountTab(); }
+
+async function saveDetails() {
+  const fn = (document.getElementById('edit-first-name') || {}).value?.trim();
+  const ln = (document.getElementById('edit-last-name') || {}).value?.trim();
+  if (!fn || !ln) return showMsg('Name fields are required.', 'error');
+  try {
+    await sbPatch('users', 'id', authUid, { first_name: fn, last_name: ln });
+    userData.first_name = fn; userData.last_name = ln;
+    editingDetails = false;
+    clearMsg();
+    const initials = (fn[0] || '').toUpperCase() + (ln[0] || '').toUpperCase();
+    document.getElementById('navUser').innerHTML = `<div class="nav-avatar">${esc(initials)}</div><span class="nav-name">${esc(fn)}</span>`;
+    renderAccountTab();
+  } catch(e) { showMsg(e.message, 'error'); }
+}
+
+function signOut() {
+  localStorage.removeItem('truffl_session');
+  window.location.href = '/';
+}
+
+/* ── Init ── */
+async function init() {
+  const area = document.getElementById('myContent');
+  const stored = localStorage.getItem('truffl_session');
+  if (stored) { try { const s = JSON.parse(stored); authToken = s.access_token; authUid = s.user_id; } catch(e) {} }
+
+  if (!authToken) {
+    area.innerHTML = `<div class="login-prompt"><h2>Sign in required</h2><p>You need to be logged in to view your dashboard.</p><a href="/login/?redirect=/my/">Sign in</a></div>`;
+    return;
+  }
+
+  try {
+    const users = await sbGet('users', `id=eq.${authUid}&select=first_name,last_name,role`);
+    if (!users.length) { signOut(); return; }
+    userData = users[0];
+
+    if (userData.role === 'provider') {
+      window.location.href = '/dashboard/';
+      return;
+    }
+
+    const profiles = await sbGet('customer_profiles', `user_id=eq.${authUid}&select=id`);
+    if (!profiles.length) {
+      area.innerHTML = `<div class="login-prompt"><h2>Profile not set up</h2><p>Your customer profile isn't set up yet.</p><a href="/login/">Complete registration</a></div>`;
+      return;
+    }
+    customerProfile = profiles[0];
+
+    const rawBookings = await sbGet('bookings', `customer_id=eq.${customerProfile.id}&select=*&order=scheduled_at.desc`);
+
+    for (const b of rawBookings) {
+      try {
+        const provProfiles = await sbGet('provider_profiles', `id=eq.${b.provider_id}&select=user_id`);
+        if (provProfiles.length) {
+          b._provider_user_id = provProfiles[0].user_id;
+          const pUsers = await sbGet('users', `id=eq.${provProfiles[0].user_id}&select=first_name,last_name`);
+          if (pUsers.length) b._provider_name = `${pUsers[0].first_name} ${pUsers[0].last_name}`;
+        }
+        const petRows = await sbGet('pets', `id=eq.${b.pet_id}&select=name,breed`);
+        if (petRows.length) { b._pet_name = petRows[0].name; b._pet_breed = petRows[0].breed; }
+        const svcs = await sbGet('provider_services', `id=eq.${b.service_id}&select=service_type`);
+        if (svcs.length) b._service_type = svcs[0].service_type;
+        if (b.status === 'in_progress') {
+          const sessions = await sbGet('walk_sessions', `booking_id=eq.${b.id}&status=eq.active&select=id&limit=1`);
+          b._has_active_walk = sessions.length > 0;
+        }
+      } catch(e) {}
+    }
+    bookings = rawBookings;
+
+    pets = await sbGet('pets', `customer_id=eq.${customerProfile.id}&is_active=eq.true&select=*`);
+
+    renderDashboard();
+  } catch(e) {
+    area.innerHTML = `<div class="login-prompt"><h2>Something went wrong</h2><p>${esc(e.message)}</p><a href="/login/">Try signing in again</a></div>`;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', init);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Fixes the gap where customers had no path to reach the live walk tracking page (`/track/`). After this PR, customers land on a dashboard after login and see a "Track live walk →" button on any booking that's currently in progress.

- New customer dashboard at `/my/index.html` with **My bookings** (active/upcoming + past) and **My account** (pets + details + sign out) tabs
- Customers redirect to `/my/` after login (was `/search/`)
- Booking success screen now shows "View my bookings" as the primary CTA with a note about live walk tracking

## What changed

| File | Change |
|---|---|
| `my/index.html` | **New.** Customer dashboard. |
| `login/index.html` | One-line: post-login redirect for customers → `/my/`. |
| `book/index.html` | Booking success screen: primary CTA is now "View my bookings"; new note explaining tracking is available from dashboard. |

## Booking actions by status

- `in_progress` + active walk session → prominent terracotta **Track live walk →** button (full-width on mobile)
- `confirmed` → "View booking" + "Cancel" (with inline "Are you sure?" confirmation before patching)
- `pending` → "Cancel" with same inline confirmation
- `completed` → "Book again" linking to `/book/?provider={user_id}`
- `cancelled` → no action

## Access control

- Unauthenticated users see a sign-in prompt at `/my/`
- Providers visiting `/my/` are redirected to `/dashboard/`
- Customers without a `customer_profiles` row see a "complete registration" prompt

## Test plan

- [ ] Sign in as a customer → lands on `/my/`, sees their bookings
- [ ] Sign in as a provider → lands on `/dashboard/` (unchanged), and visiting `/my/` redirects to `/dashboard/`
- [ ] Create a booking via `/book/` → success screen shows "View my bookings" + tracking note
- [ ] Booking with `status='in_progress'` and an active `walk_sessions` row shows the prominent "Track live walk →" button → clicking opens `/track/?booking={id}`
- [ ] "Cancel" on a `pending` or `confirmed` booking shows inline confirmation; confirming patches `status='cancelled'`
- [ ] "Book again" on a completed booking opens the booking form pre-filled with that provider
- [ ] My account tab: add pet, edit pet, remove pet — all work and persist
- [ ] My account tab: edit name → persists and updates nav avatar/name
- [ ] Sign out clears `localStorage.truffl_session` and returns to `/`
- [ ] Mobile (375px viewport): track button is full-width, tabs and cards don't overflow

https://claude.ai/code/session_01UmSbhmbBKQz7ism4Pz6fhz

---
_Generated by [Claude Code](https://claude.ai/code/session_01UmSbhmbBKQz7ism4Pz6fhz)_