### PR TITLE
Add View walk link to completed bookings on customer dashboard

### DIFF
--- a/my/index.html
+++ b/my/index.html
@@ -243,8 +243,10 @@ function actionButtons(b) {
     if (pendingCancelId === b.id) return cancelConfirmHtml(b.id);
     return `<button class="btn-ghost danger" onclick="showCancelConfirm('${b.id}')">Cancel</button>`;
   }
-  if (b.status === 'completed' && b._provider_user_id) {
-    return `<a href="/book/?provider=${b._provider_user_id}" class="btn-ghost">Book again</a>`;
+  if (b.status === 'completed') {
+    const viewWalk = `<a href="/track/?booking=${b.id}" class="btn-ghost">View walk</a>`;
+    const bookAgain = b._provider_user_id ? `<a href="/book/?provider=${b._provider_user_id}" class="btn-ghost">Book again</a>` : '';
+    return [viewWalk, bookAgain].filter(Boolean).join('');
   }
   return '';
 }


### PR DESCRIPTION
## Summary

- Completed booking cards on `/my/` now show a **"View walk"** ghost button linking to `/track/?booking={id}`, alongside the existing "Book again" button
- Customers can revisit the full walk summary (route map, distance/duration stats, update feed) for any past booking
- "Book again" still appears when a provider user ID is available; "View walk" always appears for completed bookings

## Test plan

- [ ] Log in as a customer with at least one completed booking
- [ ] Navigate to `/my/` → "My bookings" tab → "Past bookings" section
- [ ] Confirm completed bookings show both "View walk" and "Book again" buttons
- [ ] Click "View walk" — confirm `/track/` loads the completed walk summary with route, stats, and update feed
- [ ] Confirm bookings without a provider user ID still show "View walk" only (no broken "Book again")
- [ ] Confirm active/upcoming booking actions are unchanged

https://claude.ai/code/session_01UmSbhmbBKQz7ism4Pz6fhz

---
_Generated by [Claude Code](https://claude.ai/code/session_01UmSbhmbBKQz7ism4Pz6fhz)_