### PR TITLE
Fix duplicate services in booking grid (TRU-49)

### DIFF
--- a/book/index.html
+++ b/book/index.html
@@ -221,7 +221,11 @@ function renderBookingForm() {
   const initials = ((providerData.first_name||'')[0]||'') + ((providerData.last_name||'')[0]||'');
   const verified = providerProfile.is_verified ? `<span class="ps-verified"><svg width="8" height="8" viewBox="0 0 12 12" fill="none"><path d="M2.5 6.5L5 9L9.5 3.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>Verified</span>` : '';
 
-  const servicesHtml = providerServices.map(s => `
+  const uniqueServices = providerServices.filter(
+    (s, i, arr) => arr.findIndex(x => x.service_type === s.service_type) === i
+  );
+
+  const servicesHtml = uniqueServices.map(s => `
     <label class="service-option" onclick="selectService(this, '${s.id}')">
       <input type="radio" name="service" value="${s.id}">
       <div class="svc-name">${SERVICE_LABELS[s.service_type] || s.service_type.replace(/_/g, ' ')}</div>


### PR DESCRIPTION
## Summary

- Providers can have multiple `provider_services` rows with the same `service_type` (e.g. two `dog_walking` records)
- The booking page was mapping directly over the raw array, causing duplicate options to appear in the service selection grid
- Fix: deduplicate by `service_type` in JS before rendering, keeping the first occurrence of each type

## Test plan

- [ ] Open the booking page for a provider who has duplicate `service_type` rows in `provider_services`
- [ ] Confirm each service type appears at most once in the grid
- [ ] Confirm selecting a service and completing a booking still works correctly
- [ ] Confirm providers with no duplicate services are unaffected

https://claude.ai/code/session_01UmSbhmbBKQz7ism4Pz6fhz

---
_Generated by [Claude Code](https://claude.ai/code/session_01UmSbhmbBKQz7ism4Pz6fhz)_