### PR TITLE
Rebuild homepage hero + inline search widget (TRU-followup)

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,20 +54,19 @@
     .btn-ghost:hover { border-color: var(--brown); transform: translateY(-1px); }
 
     /* ── HERO ── */
-    .hero { display: grid; grid-template-columns: 1fr 1fr; min-height: calc(100vh - 100px); overflow: hidden; }
-    .hero-left { background: var(--warm); display: flex; flex-direction: column; justify-content: center; padding: 80px 72px 80px 56px; }
-    .eyebrow { font-size: 11px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--sage-dark); font-weight: 500; margin-bottom: 20px; }
-    .hero-h1 { font-family: 'Cormorant Garamond', Georgia, serif; font-size: 58px; line-height: 1.08; color: var(--brown); margin-bottom: 24px; font-weight: 400; }
+    .hero { display: grid; grid-template-columns: 1fr 1fr; gap: 0; align-items: stretch; padding-bottom: 112px; }
+    .hero-left { display: flex; flex-direction: column; justify-content: center; padding: 78px 56px 60px; }
+    .eyebrow { font-size: 11px; letter-spacing: 0.32em; text-transform: uppercase; color: var(--sage-dark); font-weight: 500; margin-bottom: 22px; }
+    .hero-h1 { font-family: 'Cormorant Garamond', Georgia, serif; font-size: 72px; line-height: 1.02; color: var(--brown); margin-bottom: 24px; font-weight: 400; letter-spacing: -0.015em; }
     .hero-h1 em { font-style: italic; color: var(--terracotta); }
-    .hero-body { font-size: 15px; color: var(--text-mid); line-height: 1.75; max-width: 380px; margin-bottom: 40px; font-weight: 300; }
-    .hero-actions { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
-    .hero-trust { display: flex; gap: 24px; margin-top: 52px; padding-top: 32px; border-top: 1px solid var(--border); flex-wrap: wrap; }
-    .trust-item { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--text-light); }
-    .trust-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--sage-dark); flex-shrink: 0; }
+    .hero-body { font-size: 17px; color: var(--text-mid); line-height: 1.55; max-width: 460px; margin-bottom: 38px; font-weight: 300; }
+    .hero-trust { display: flex; gap: 28px; flex-wrap: wrap; align-items: center; }
+    .trust-item { display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--text-mid); }
+    .trust-dot { width: 6px; height: 6px; border-radius: 3px; background: var(--sage-dark); flex-shrink: 0; }
 
-    .hero-right { position: relative; overflow: hidden; background: #F7F3EE; display: flex; align-items: center; justify-content: center; }
-    .hero-scene { width: 100%; height: 100%; position: relative; display: flex; align-items: center; justify-content: center; }
-    .hero-scene svg.bg-illo { position: absolute; inset: 0; width: 100%; height: 100%; }
+    .hero-right { position: relative; overflow: hidden; background: var(--warm); min-height: 560px; }
+    .hero-scene { width: 100%; height: 100%; position: relative; }
+    .hero-scene img { width: 100%; height: 100%; object-fit: cover; object-position: center; display: block; }
 
     .live-pill { position: absolute; top: 40px; left: 36px; background: white; border-radius: 40px; padding: 9px 16px; display: flex; align-items: center; gap: 8px; font-size: 13px; font-weight: 500; color: var(--text); box-shadow: 0 4px 20px rgba(60,40,30,0.10); }
     .live-blink { width: 8px; height: 8px; border-radius: 50%; background: var(--sage-dark); animation: blink 1.6s ease-in-out infinite; flex-shrink: 0; }
@@ -78,6 +77,47 @@
     .hc-row { display: flex; align-items: center; gap: 7px; font-size: 12px; color: var(--text-mid); margin-bottom: 6px; }
     .hc-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
     .hc-time { font-size: 10px; color: var(--text-light); margin-top: 10px; padding-top: 10px; border-top: 1px solid rgba(92,64,51,0.08); }
+
+    /* ── SEARCH WIDGET (overlaps hero) ── */
+    .widget-wrap { padding: 0 56px; margin-top: -110px; position: relative; z-index: 2; }
+    .widget { background: #fff; border: 1px solid var(--border); border-radius: 22px; padding: 28px 32px; box-shadow: 0 30px 60px -30px rgba(61,43,31,0.18), 0 8px 20px -10px rgba(61,43,31,0.08); }
+    .widget-title { font-family: 'Cormorant Garamond', Georgia, serif; font-style: italic; font-size: 22px; color: var(--brown); margin-bottom: 14px; }
+    .svc-row { display: flex; gap: 8px; flex-wrap: wrap; }
+    .svc-chip { display: inline-flex; align-items: center; gap: 8px; padding: 10px 14px; border-radius: 999px; background: #fff; border: 1px solid var(--border); color: var(--text); font-family: 'DM Sans', sans-serif; font-size: 13px; cursor: pointer; transition: all 0.18s; user-select: none; }
+    .svc-chip:hover { border-color: var(--sage-dark); }
+    .svc-chip.active { background: rgba(196,134,106,0.10); border-color: var(--terracotta); color: var(--terracotta-dark); }
+    .svc-chip .svc-icon-emoji { font-size: 16px; line-height: 1; }
+    .svc-chip .svc-sub { color: var(--text-light); font-size: 12px; opacity: 0.85; }
+    .svc-chip.active .svc-sub { color: var(--terracotta-dark); }
+
+    .when-row { display: grid; grid-template-columns: 1.1fr 1.4fr auto; gap: 14px; margin-top: 22px; align-items: end; }
+    .field-eyebrow { font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--text-light); margin-bottom: 8px; font-weight: 500; }
+    .when-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; }
+    .seg { display: inline-flex; background: var(--cream); padding: 3px; border-radius: 999px; border: 1px solid var(--border); }
+    .seg button { padding: 5px 14px; border-radius: 999px; border: 0; background: transparent; cursor: pointer; font-family: 'DM Sans', sans-serif; font-size: 11.5px; letter-spacing: 0.04em; color: var(--text-mid); }
+    .seg button.active { background: var(--brown); color: var(--cream); }
+
+    .input-line { position: relative; }
+    .input-line .input-icon { position: absolute; left: 14px; top: 50%; transform: translateY(-50%); color: var(--terracotta); pointer-events: none; }
+    .input-line input { width: 100%; padding: 14px 16px 14px 42px; border-radius: 12px; border: 1px solid var(--border); background: var(--cream); font-family: 'DM Sans', sans-serif; font-size: 15px; color: var(--text); outline: none; transition: border-color 0.2s, box-shadow 0.2s; }
+    .input-line input:focus { border-color: var(--terracotta); box-shadow: 0 0 0 3px rgba(196,134,106,0.12); }
+
+    .when-fields { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+    .when-fields .input-line .input-icon { color: var(--text-mid); }
+    .when-fields input, .when-fields select { width: 100%; padding: 14px 16px 14px 40px; border-radius: 12px; border: 1px solid var(--border); background: var(--cream); font-family: 'DM Sans', sans-serif; font-size: 14px; color: var(--text); outline: none; transition: border-color 0.2s; }
+    .when-fields input:focus, .when-fields select:focus { border-color: var(--terracotta); }
+
+    .days { display: flex; gap: 6px; }
+    .day-btn { flex: 1; height: 48px; display: flex; align-items: center; justify-content: center; border-radius: 12px; border: 1px solid var(--border); background: var(--cream); color: var(--text-mid); font-family: 'DM Sans', sans-serif; font-size: 14px; font-weight: 500; cursor: pointer; transition: all 0.18s; user-select: none; }
+    .day-btn:hover { border-color: var(--sage-dark); }
+    .day-btn.active { background: var(--sage); border-color: var(--sage-dark); color: var(--brown); }
+
+    .find-btn { padding: 15px 28px; border-radius: 999px; background: var(--terracotta); color: #fff; border: 0; cursor: pointer; font-family: 'DM Sans', sans-serif; font-size: 15px; font-weight: 500; display: inline-flex; align-items: center; gap: 10px; box-shadow: 0 8px 20px -8px rgba(196,134,106,0.5); transition: background 0.2s, transform 0.15s; white-space: nowrap; }
+    .find-btn:hover { background: var(--terracotta-dark); transform: translateY(-1px); }
+    .find-btn:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
+
+    .trust-strip { display: flex; justify-content: center; gap: 44px; padding: 36px 56px 8px; font-size: 12px; color: var(--text-light); letter-spacing: 0.16em; text-transform: uppercase; flex-wrap: wrap; }
+    .trust-strip span { display: inline-flex; align-items: center; }
 
     /* ── STRIP ── */
     .strip { background: var(--sage); padding: 16px 56px; display: flex; justify-content: center; align-items: center; flex-wrap: wrap; }
@@ -154,10 +194,20 @@
     @media (max-width: 960px) {
       nav { padding: 0 24px; }
       .nav-links { display: none; }
-      .hero { grid-template-columns: 1fr; min-height: auto; }
-      .hero-left { padding: 64px 32px; }
-      .hero-h1 { font-size: 44px; }
-      .hero-right { height: 420px; }
+      .hero { grid-template-columns: 1fr; padding-bottom: 64px; }
+      .hero-left { padding: 56px 24px 32px; }
+      .hero-h1 { font-size: 44px; line-height: 1.06; }
+      .hero-body { font-size: 15px; }
+      .hero-right { min-height: 320px; height: 320px; }
+      .widget-wrap { padding: 0 16px; margin-top: -52px; }
+      .widget { padding: 20px 18px; border-radius: 18px; }
+      .widget-title { font-size: 18px; }
+      .when-row { grid-template-columns: 1fr; gap: 14px; }
+      .find-btn { width: 100%; justify-content: center; }
+      .svc-row { gap: 6px; }
+      .svc-chip { padding: 9px 12px; font-size: 12.5px; }
+      .svc-chip .svc-sub { display: none; }
+      .trust-strip { gap: 18px; padding: 24px 16px 4px; font-size: 10px; letter-spacing: 0.12em; }
       .strip { padding: 14px 24px; }
       .strip-item { padding: 6px 14px; font-size: 10px; }
       .services { padding: 72px 24px; }
@@ -213,13 +263,9 @@
   <section class="hero">
     <div class="hero-left">
       <p class="eyebrow fade-up delay-1">Sydney's trusted pet care</p>
-      <h1 class="hero-h1 fade-up delay-2">Your pet,<br>looked after <em>properly.</em></h1>
-      <p class="hero-body fade-up delay-3">Every carer is vetted, every walk is GPS tracked, and you'll get real updates — not silence. Pet care the way it should be.</p>
-      <div class="hero-actions fade-up delay-4">
-        <a href="/search/" class="btn-primary btn-primary-lg">Find a carer near you</a>
-        <a href="#how" class="btn-ghost">How it works</a>
-      </div>
-      <div class="hero-trust fade-up delay-5">
+      <h1 class="hero-h1 fade-up delay-2">Find a carer your dog will <em>love.</em></h1>
+      <p class="hero-body fade-up delay-3">Every carer is interviewed, police-checked and vetted by us. No bidding wars, no guesswork — just thoughtful pet care, on your terms.</p>
+      <div class="hero-trust fade-up delay-4">
         <div class="trust-item"><div class="trust-dot"></div>Police checked</div>
         <div class="trust-item"><div class="trust-dot"></div>GPS tracked walks</div>
         <div class="trust-item"><div class="trust-dot"></div>Photo updates</div>
@@ -228,7 +274,7 @@
 
     <div class="hero-right">
       <div class="hero-scene">
-        <img src="dog-hero.png" alt="Illustrated dog" style="width: 100%; height: 100%; object-fit: cover; object-position: center;">
+        <img src="dog-hero.png" alt="Dog being looked after by a Truffl carer">
 
         <!-- Live pill -->
         <div class="live-pill">
@@ -252,6 +298,177 @@
       </div>
     </div>
   </section>
+
+  <!-- SEARCH WIDGET -->
+  <div class="widget-wrap fade-up delay-5">
+    <form class="widget" id="searchWidget" action="/search/" method="get" novalidate>
+      <div class="widget-title">What service do you need?</div>
+      <div class="svc-row" id="svcRow" role="radiogroup" aria-label="Service">
+        <button type="button" class="svc-chip active" data-svc="dog_walking" role="radio" aria-checked="true"><span class="svc-icon-emoji">🦮</span> Dog walking <span class="svc-sub">· 30 or 60 mins</span></button>
+        <button type="button" class="svc-chip" data-svc="dog_boarding" role="radio" aria-checked="false"><span class="svc-icon-emoji">🏠</span> Dog boarding <span class="svc-sub">· At carer's home</span></button>
+        <button type="button" class="svc-chip" data-svc="dog_sitting" role="radio" aria-checked="false"><span class="svc-icon-emoji">🛋️</span> Dog sitting <span class="svc-sub">· In your home</span></button>
+        <button type="button" class="svc-chip" data-svc="dog_daycare" role="radio" aria-checked="false"><span class="svc-icon-emoji">☀️</span> Dog daycare <span class="svc-sub">· Work hours</span></button>
+        <button type="button" class="svc-chip" data-svc="drop_in" role="radio" aria-checked="false"><span class="svc-icon-emoji">🐾</span> Drop-in visit <span class="svc-sub">· Check on your pet</span></button>
+        <button type="button" class="svc-chip" data-svc="cat_sitting" role="radio" aria-checked="false"><span class="svc-icon-emoji">🐱</span> Cat sitting <span class="svc-sub">· In your home</span></button>
+      </div>
+
+      <div class="when-row">
+        <div>
+          <div class="field-eyebrow">Your suburb</div>
+          <div class="input-line">
+            <span class="input-icon">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>
+            </span>
+            <input type="text" id="suburbInput" name="suburb" placeholder="e.g. Newington, Balmain…" autocomplete="off">
+          </div>
+        </div>
+
+        <div>
+          <div class="when-head">
+            <div class="field-eyebrow" style="margin-bottom:0;">When do you need care?</div>
+            <div class="seg" id="modeSeg" role="tablist" aria-label="Booking type">
+              <button type="button" class="active" data-rec="false" role="tab" aria-selected="true">One-off</button>
+              <button type="button" data-rec="true" role="tab" aria-selected="false">Recurring</button>
+            </div>
+          </div>
+          <div id="whenFields" class="when-fields">
+            <div class="input-line">
+              <span class="input-icon">
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+              </span>
+              <input type="date" id="dateInput" name="date" aria-label="Date">
+            </div>
+            <div class="input-line">
+              <span class="input-icon">
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+              </span>
+              <select id="timeInput" name="time" aria-label="Time"></select>
+            </div>
+          </div>
+        </div>
+
+        <button type="submit" class="find-btn" id="findBtn">
+          Find a carer
+          <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+        </button>
+      </div>
+    </form>
+
+    <div class="trust-strip">
+      <span>★ 4.9 from local owners</span>
+      <span>· 100% police-checked carers ·</span>
+      <span>Insured up to $20,000</span>
+    </div>
+  </div>
+
+  <script>
+  (function() {
+    const form = document.getElementById('searchWidget');
+    if (!form) return;
+
+    const state = { service: 'dog_walking', recurring: false, days: [], date: '', time: '', suburb: '' };
+
+    // Time dropdown options (30-min intervals, 6:00 AM – 9:00 PM)
+    const timeSel = document.getElementById('timeInput');
+    timeSel.innerHTML = '<option value="">Any time</option>' +
+      Array.from({ length: 31 }, (_, i) => 6 * 2 + i).map(slot => {
+        const h = Math.floor(slot / 2), m = (slot % 2) * 30;
+        const v = String(h).padStart(2,'0') + ':' + String(m).padStart(2,'0');
+        const display = ((h % 12) || 12) + ':' + String(m).padStart(2,'0') + ' ' + (h < 12 ? 'AM' : 'PM');
+        return '<option value="' + v + '">' + display + '</option>';
+      }).join('');
+
+    // Service chips (single-select)
+    document.getElementById('svcRow').addEventListener('click', e => {
+      const btn = e.target.closest('.svc-chip');
+      if (!btn) return;
+      state.service = btn.dataset.svc;
+      document.querySelectorAll('.svc-chip').forEach(c => {
+        const on = c === btn;
+        c.classList.toggle('active', on);
+        c.setAttribute('aria-checked', on ? 'true' : 'false');
+      });
+    });
+
+    // Mode segmented
+    const seg = document.getElementById('modeSeg');
+    seg.addEventListener('click', e => {
+      const btn = e.target.closest('button[data-rec]');
+      if (!btn) return;
+      state.recurring = btn.dataset.rec === 'true';
+      seg.querySelectorAll('button').forEach(b => {
+        const on = b === btn;
+        b.classList.toggle('active', on);
+        b.setAttribute('aria-selected', on ? 'true' : 'false');
+      });
+      renderWhenFields();
+    });
+
+    function renderWhenFields() {
+      const wrap = document.getElementById('whenFields');
+      if (state.recurring) {
+        wrap.classList.remove('when-fields');
+        wrap.innerHTML = '<div class="days" id="daysRow">' +
+          ['mon','tue','wed','thu','fri','sat','sun'].map(d => {
+            const label = d === 'thu' ? 'T' : d === 'sat' ? 'S' : d === 'sun' ? 'S' : d[0].toUpperCase();
+            const active = state.days.includes(d);
+            return '<button type="button" class="day-btn' + (active ? ' active' : '') + '" data-day="' + d + '" aria-pressed="' + (active ? 'true' : 'false') + '">' + label + '</button>';
+          }).join('') + '</div>';
+        wrap.querySelector('#daysRow').addEventListener('click', e => {
+          const btn = e.target.closest('[data-day]');
+          if (!btn) return;
+          const d = btn.dataset.day;
+          const i = state.days.indexOf(d);
+          if (i >= 0) state.days.splice(i, 1); else state.days.push(d);
+          const on = state.days.includes(d);
+          btn.classList.toggle('active', on);
+          btn.setAttribute('aria-pressed', on ? 'true' : 'false');
+        });
+      } else {
+        wrap.classList.add('when-fields');
+        wrap.innerHTML = `
+          <div class="input-line">
+            <span class="input-icon">
+              <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+            </span>
+            <input type="date" id="dateInput" name="date" value="` + (state.date || '') + `" aria-label="Date">
+          </div>
+          <div class="input-line">
+            <span class="input-icon">
+              <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+            </span>
+            <select id="timeInput" name="time" aria-label="Time"></select>
+          </div>`;
+        const sel = wrap.querySelector('#timeInput');
+        sel.innerHTML = timeSel.innerHTML; // copy options from the original
+        sel.value = state.time || '';
+        sel.addEventListener('change', e => state.time = e.target.value);
+        wrap.querySelector('#dateInput').addEventListener('change', e => state.date = e.target.value);
+      }
+    }
+
+    // Track date/time when in one-off mode
+    document.getElementById('dateInput').addEventListener('change', e => state.date = e.target.value);
+    timeSel.addEventListener('change', e => state.time = e.target.value);
+    document.getElementById('suburbInput').addEventListener('input', e => state.suburb = e.target.value.trim());
+
+    // Submit → /search/?…
+    form.addEventListener('submit', e => {
+      e.preventDefault();
+      const params = new URLSearchParams();
+      if (state.service) params.set('service', state.service);
+      if (state.suburb) params.set('suburb', state.suburb);
+      if (state.recurring) {
+        params.set('recurring', 'true');
+        if (state.days.length) params.set('days', state.days.join(','));
+      } else {
+        if (state.date) params.set('date', state.date);
+        if (state.time) params.set('time', state.time);
+      }
+      window.location.href = '/search/' + (params.toString() ? '?' + params.toString() : '');
+    });
+  })();
+  </script>
 
   <!-- STRIP -->
   <div class="strip">


### PR DESCRIPTION
- New hero: large italic headline matching the design language, body copy, trust-dot row. Existing dog-hero.png + live pill + walk-update card kept as the right-column image.
- Search widget overlaps hero with negative margin: 6 service chips (single- select), suburb input with pin icon, One-off / Recurring segmented control. One-off shows date + 30-min time picker; Recurring shows M T W T F S S day picker.
- Submits as a form to /search/ with URL params (service, suburb, recurring, date, time, days) which the rebuilt search page already reads on load.
- Trust strip below the widget. Mobile breakpoint reflows to a single column, widget margin reduced, button full-width.