### PR TITLE
Homepage: replace overlap widget with nav-pill + popover pattern

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,16 +53,63 @@
     .btn-ghost { background: transparent; color: var(--brown); border: 1.5px solid rgba(92,64,51,0.25); padding: 13px 26px; border-radius: 40px; font-size: 15px; cursor: pointer; letter-spacing: 0.02em; font-family: 'DM Sans', sans-serif; transition: border-color 0.2s, transform 0.15s; display: inline-block; }
     .btn-ghost:hover { border-color: var(--brown); transform: translateY(-1px); }
 
+    /* ── NAV SEARCH PILL ── */
+    nav { gap: 24px; flex-wrap: wrap; }
+    .nav-search-pill {
+      flex: 1 1 320px; max-width: 720px; min-width: 0;
+      display: grid; grid-template-columns: auto 1px 1fr 1px 1fr 1px 1fr auto; align-items: center; gap: 14px;
+      padding: 6px 6px 6px 16px; border-radius: 999px;
+      background: #fff; border: 1px solid var(--border);
+      cursor: pointer; text-align: left; font-family: 'DM Sans', sans-serif; color: var(--text);
+      box-shadow: 0 2px 6px -3px rgba(61,43,31,0.08); transition: box-shadow 0.2s, border-color 0.2s;
+    }
+    .nav-search-pill:hover { box-shadow: 0 4px 14px -6px rgba(61,43,31,0.14); border-color: var(--terracotta); }
+    .nsp-svc { display: flex; align-items: center; gap: 8px; min-width: 0; }
+    .nsp-svc-emoji { font-size: 15px; line-height: 1; }
+    .nsp-svc-label { font-size: 13px; font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .nsp-divider { width: 1px; height: 22px; background: var(--border); }
+    .nsp-field { min-width: 0; }
+    .nsp-eyebrow { font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-light); display: block; line-height: 1; margin-bottom: 3px; }
+    .nsp-value { font-size: 13px; color: var(--text-mid); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .nsp-go { width: 38px; height: 38px; border-radius: 999px; background: var(--terracotta); color: #fff; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+
+    /* ── SEARCH POPOVER ── */
+    .popover-scrim { position: fixed; inset: 0; background: rgba(40,28,20,0.32); -webkit-backdrop-filter: blur(2px); backdrop-filter: blur(2px); opacity: 0; pointer-events: none; transition: opacity 0.22s ease; z-index: 200; }
+    .popover-scrim.open { opacity: 1; pointer-events: auto; }
+    .popover {
+      position: fixed; top: 110px; left: 56px; right: 56px; z-index: 201;
+      background: #fff; border-radius: 22px; padding: 28px 32px 30px;
+      box-shadow: 0 30px 80px -30px rgba(61,43,31,0.35), 0 8px 20px -10px rgba(61,43,31,0.12);
+      border: 1px solid var(--border);
+      transform: translateY(-12px); opacity: 0; pointer-events: none;
+      transition: transform 0.22s ease, opacity 0.22s ease;
+      max-height: calc(100vh - 130px); overflow-y: auto;
+    }
+    .popover.open { transform: translateY(0); opacity: 1; pointer-events: auto; }
+    .popover-close { position: absolute; top: 18px; right: 18px; width: 34px; height: 34px; border-radius: 999px; background: var(--cream); border: 1px solid var(--border); cursor: pointer; display: flex; align-items: center; justify-content: center; padding: 0; color: var(--text); }
+    .popover-close:hover { border-color: var(--text-mid); }
+
+    .popover-suggestions { margin-top: 24px; padding-top: 22px; border-top: 1px solid var(--border); }
+    .popover-suggestions-label { font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--text-light); margin-bottom: 12px; font-weight: 500; }
+    .popover-suggestions-row { display: flex; gap: 10px; flex-wrap: wrap; }
+    .suggestion-chip { padding: 9px 16px; border-radius: 999px; background: var(--cream); border: 1px solid var(--border); font-family: 'DM Sans', sans-serif; font-size: 13px; color: var(--text); display: inline-flex; align-items: center; gap: 8px; cursor: pointer; transition: border-color 0.18s, color 0.18s; }
+    .suggestion-chip:hover { border-color: var(--terracotta); color: var(--terracotta-dark); }
+
     /* ── HERO ── */
-    .hero { display: grid; grid-template-columns: 1fr 1fr; gap: 0; align-items: stretch; padding-bottom: 112px; }
-    .hero-left { display: flex; flex-direction: column; justify-content: center; padding: 78px 56px 60px; }
+    .hero { display: grid; grid-template-columns: 1fr 1fr; gap: 0; align-items: stretch; }
+    .hero-left { display: flex; flex-direction: column; justify-content: center; padding: 92px 56px 80px; }
     .eyebrow { font-size: 11px; letter-spacing: 0.32em; text-transform: uppercase; color: var(--sage-dark); font-weight: 500; margin-bottom: 22px; }
     .hero-h1 { font-family: 'Cormorant Garamond', Georgia, serif; font-size: 72px; line-height: 1.02; color: var(--brown); margin-bottom: 24px; font-weight: 400; letter-spacing: -0.015em; }
     .hero-h1 em { font-style: italic; color: var(--terracotta); }
     .hero-body { font-size: 17px; color: var(--text-mid); line-height: 1.55; max-width: 460px; margin-bottom: 38px; font-weight: 300; }
-    .hero-trust { display: flex; gap: 28px; flex-wrap: wrap; align-items: center; }
+    .hero-trust { display: flex; gap: 28px; flex-wrap: wrap; align-items: center; margin-bottom: 38px; }
     .trust-item { display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--text-mid); }
     .trust-dot { width: 6px; height: 6px; border-radius: 3px; background: var(--sage-dark); flex-shrink: 0; }
+    .hero-actions { display: flex; gap: 14px; flex-wrap: wrap; align-items: center; }
+    .hero-cta { padding: 15px 28px; border-radius: 999px; background: var(--terracotta); color: #fff; border: 0; cursor: pointer; font-family: 'DM Sans', sans-serif; font-size: 15px; font-weight: 500; display: inline-flex; align-items: center; gap: 10px; box-shadow: 0 8px 20px -8px rgba(196,134,106,0.5); transition: background 0.2s, transform 0.15s; }
+    .hero-cta:hover { background: var(--terracotta-dark); transform: translateY(-1px); }
+    .hero-cta-ghost { padding: 14px 26px; border-radius: 999px; background: transparent; color: var(--text); border: 1px solid var(--border); cursor: pointer; font-family: 'DM Sans', sans-serif; font-size: 14px; transition: border-color 0.2s; text-decoration: none; }
+    .hero-cta-ghost:hover { border-color: var(--text-mid); }
 
     .hero-right { position: relative; overflow: hidden; background: var(--warm); min-height: 560px; }
     .hero-scene { width: 100%; height: 100%; position: relative; }
@@ -78,9 +125,7 @@
     .hc-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
     .hc-time { font-size: 10px; color: var(--text-light); margin-top: 10px; padding-top: 10px; border-top: 1px solid rgba(92,64,51,0.08); }
 
-    /* ── SEARCH WIDGET (overlaps hero) ── */
-    .widget-wrap { padding: 0 56px; margin-top: -110px; position: relative; z-index: 2; }
-    .widget { background: #fff; border: 1px solid var(--border); border-radius: 22px; padding: 28px 32px; box-shadow: 0 30px 60px -30px rgba(61,43,31,0.18), 0 8px 20px -10px rgba(61,43,31,0.08); }
+    /* ── FORM CONTROLS (used inside popover) ── */
     .widget-title { font-family: 'Cormorant Garamond', Georgia, serif; font-style: italic; font-size: 22px; color: var(--brown); margin-bottom: 14px; }
     .svc-row { display: flex; gap: 8px; flex-wrap: wrap; }
     .svc-chip { display: inline-flex; align-items: center; gap: 8px; padding: 10px 14px; border-radius: 999px; background: #fff; border: 1px solid var(--border); color: var(--text); font-family: 'DM Sans', sans-serif; font-size: 13px; cursor: pointer; transition: all 0.18s; user-select: none; }
@@ -192,22 +237,31 @@
 
     /* ── RESPONSIVE ── */
     @media (max-width: 960px) {
-      nav { padding: 0 24px; }
+      nav { padding: 12px 24px; height: auto; gap: 12px; }
       .nav-links { display: none; }
-      .hero { grid-template-columns: 1fr; padding-bottom: 64px; }
-      .hero-left { padding: 56px 24px 32px; }
+      .nav-left { flex: 1 0 100%; justify-content: space-between; }
+      .nav-actions { order: 2; }
+      .nav-search-pill { order: 3; flex: 1 1 100%; max-width: 100%; }
+      .hero { grid-template-columns: 1fr; }
+      .hero-left { padding: 40px 24px 28px; }
       .hero-h1 { font-size: 44px; line-height: 1.06; }
       .hero-body { font-size: 15px; }
       .hero-right { min-height: 320px; height: 320px; }
-      .widget-wrap { padding: 0 16px; margin-top: -52px; }
-      .widget { padding: 20px 18px; border-radius: 18px; }
+      /* Popover becomes a bottom sheet */
+      .popover { top: auto; left: 0; right: 0; bottom: 0; border-radius: 22px 22px 0 0; padding: 18px 18px 24px; max-height: 88vh; transform: translateY(100%); }
+      .popover.open { transform: translateY(0); }
+      .popover-close { top: 14px; right: 14px; width: 32px; height: 32px; }
       .widget-title { font-size: 18px; }
       .when-row { grid-template-columns: 1fr; gap: 14px; }
       .find-btn { width: 100%; justify-content: center; }
       .svc-row { gap: 6px; }
       .svc-chip { padding: 9px 12px; font-size: 12.5px; }
       .svc-chip .svc-sub { display: none; }
-      .trust-strip { gap: 18px; padding: 24px 16px 4px; font-size: 10px; letter-spacing: 0.12em; }
+      .nsp-divider:nth-of-type(2), .nsp-divider:nth-of-type(3) { display: none; }
+      .nav-search-pill { grid-template-columns: auto 1fr auto; gap: 10px; padding: 8px 8px 8px 14px; }
+      .nsp-field:nth-of-type(2), .nsp-field:nth-of-type(3) { display: none; }
+      .nsp-field:first-of-type .nsp-eyebrow { display: none; }
+      .nsp-svc-label { font-size: 13.5px; }
       .strip { padding: 14px 24px; }
       .strip-item { padding: 6px 14px; font-size: 10px; }
       .services { padding: 72px 24px; }
@@ -253,6 +307,32 @@
         <a href="#how">How it works</a>
       </div>
     </div>
+
+    <button type="button" class="nav-search-pill" id="searchPill" aria-haspopup="dialog" aria-expanded="false" aria-controls="searchPopover">
+      <span class="nsp-svc">
+        <span class="nsp-svc-emoji" id="pillSvcEmoji">🦮</span>
+        <span class="nsp-svc-label" id="pillSvcLabel">Dog walking</span>
+      </span>
+      <span class="nsp-divider" aria-hidden="true"></span>
+      <span class="nsp-field">
+        <span class="nsp-eyebrow">Where</span>
+        <span class="nsp-value" id="pillWhere">Add suburb</span>
+      </span>
+      <span class="nsp-divider" aria-hidden="true"></span>
+      <span class="nsp-field">
+        <span class="nsp-eyebrow">When</span>
+        <span class="nsp-value" id="pillWhen">Any time</span>
+      </span>
+      <span class="nsp-divider" aria-hidden="true"></span>
+      <span class="nsp-field">
+        <span class="nsp-eyebrow">Pet</span>
+        <span class="nsp-value">Add pet</span>
+      </span>
+      <span class="nsp-go" aria-hidden="true">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      </span>
+    </button>
+
     <div class="nav-actions">
       <a href="/signup/">Sign in</a>
       <a href="/search/" class="btn-primary">Book a carer</a>
@@ -269,6 +349,13 @@
         <div class="trust-item"><div class="trust-dot"></div>Police checked</div>
         <div class="trust-item"><div class="trust-dot"></div>GPS tracked walks</div>
         <div class="trust-item"><div class="trust-dot"></div>Photo updates</div>
+      </div>
+      <div class="hero-actions fade-up delay-5">
+        <button type="button" class="hero-cta" id="heroOpenSearch">
+          Find a carer
+          <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+        </button>
+        <a href="#how" class="hero-cta-ghost">How Truffl works</a>
       </div>
     </div>
 
@@ -299,9 +386,13 @@
     </div>
   </section>
 
-  <!-- SEARCH WIDGET -->
-  <div class="widget-wrap fade-up delay-5">
-    <form class="widget" id="searchWidget" action="/search/" method="get" novalidate>
+  <!-- SEARCH POPOVER (hidden until pill or hero CTA opens it) -->
+  <div class="popover-scrim" id="popoverScrim" aria-hidden="true"></div>
+  <div class="popover" id="searchPopover" role="dialog" aria-modal="true" aria-label="Find a carer" aria-hidden="true">
+    <button type="button" class="popover-close" id="popoverClose" aria-label="Close search">
+      <svg width="13" height="13" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"><path d="M2 2 L12 12 M12 2 L2 12"/></svg>
+    </button>
+    <form id="searchWidget" action="/search/" method="get" novalidate>
       <div class="widget-title">What service do you need?</div>
       <div class="svc-row" id="svcRow" role="radiogroup" aria-label="Service">
         <button type="button" class="svc-chip active" data-svc="dog_walking" role="radio" aria-checked="true"><span class="svc-icon-emoji">🦮</span> Dog walking <span class="svc-sub">· 30 or 60 mins</span></button>
@@ -354,11 +445,34 @@
       </div>
     </form>
 
-    <div class="trust-strip">
-      <span>★ 4.9 from local owners</span>
-      <span>· 100% police-checked carers ·</span>
-      <span>Insured up to $20,000</span>
+    <div class="popover-suggestions">
+      <div class="popover-suggestions-label">Popular near you</div>
+      <div class="popover-suggestions-row">
+        <button type="button" class="suggestion-chip" data-suggest="weekday-walks">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+          Weekday morning walks
+        </button>
+        <button type="button" class="suggestion-chip" data-suggest="boarding-holidays">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+          Boarding for school holidays
+        </button>
+        <button type="button" class="suggestion-chip" data-suggest="daycare-inner-west">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+          Daycare in Inner West
+        </button>
+        <button type="button" class="suggestion-chip" data-suggest="cat-weekend">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+          Cat sitting · weekend away
+        </button>
+      </div>
     </div>
+  </div>
+
+  <!-- Trust strip below hero -->
+  <div class="trust-strip">
+    <span>★ 4.9 from local owners</span>
+    <span>· 100% police-checked carers ·</span>
+    <span>Insured up to $20,000</span>
   </div>
 
   <script>
@@ -366,19 +480,76 @@
     const form = document.getElementById('searchWidget');
     if (!form) return;
 
+    const SERVICE_META = {
+      dog_walking:  { label: 'Dog walking',   emoji: '🦮' },
+      dog_boarding: { label: 'Dog boarding',  emoji: '🏠' },
+      dog_sitting:  { label: 'Dog sitting',   emoji: '🛋️' },
+      dog_daycare:  { label: 'Dog daycare',   emoji: '☀️' },
+      drop_in:      { label: 'Drop-in visit', emoji: '🐾' },
+      cat_sitting:  { label: 'Cat sitting',   emoji: '🐱' },
+    };
+    const DAY_FULL = { mon:'Mon', tue:'Tue', wed:'Wed', thu:'Thu', fri:'Fri', sat:'Sat', sun:'Sun' };
+
     const state = { service: 'dog_walking', recurring: false, days: [], date: '', time: '', suburb: '' };
 
-    // Time dropdown options (30-min intervals, 6:00 AM – 9:00 PM)
+    // Time options
     const timeSel = document.getElementById('timeInput');
-    timeSel.innerHTML = '<option value="">Any time</option>' +
+    const TIME_HTML = '<option value="">Any time</option>' +
       Array.from({ length: 31 }, (_, i) => 6 * 2 + i).map(slot => {
         const h = Math.floor(slot / 2), m = (slot % 2) * 30;
         const v = String(h).padStart(2,'0') + ':' + String(m).padStart(2,'0');
         const display = ((h % 12) || 12) + ':' + String(m).padStart(2,'0') + ' ' + (h < 12 ? 'AM' : 'PM');
         return '<option value="' + v + '">' + display + '</option>';
       }).join('');
+    timeSel.innerHTML = TIME_HTML;
 
-    // Service chips (single-select)
+    /* ── Pill summary ── */
+    function updatePillSummary() {
+      const meta = SERVICE_META[state.service] || SERVICE_META.dog_walking;
+      document.getElementById('pillSvcEmoji').textContent = meta.emoji;
+      document.getElementById('pillSvcLabel').textContent = meta.label;
+      document.getElementById('pillWhere').textContent = state.suburb || 'Add suburb';
+      let when = 'Any time';
+      if (state.recurring) {
+        when = state.days.length ? state.days.map(d => DAY_FULL[d]).join('·') : 'Recurring';
+      } else if (state.date || state.time) {
+        const parts = [];
+        if (state.date) {
+          try { parts.push(new Date(state.date).toLocaleDateString('en-AU', { weekday: 'short', day: 'numeric', month: 'short' })); } catch (e) { parts.push(state.date); }
+        }
+        if (state.time) {
+          const [hh, mm] = state.time.split(':').map(Number);
+          parts.push(((hh % 12) || 12) + ':' + String(mm).padStart(2,'0') + ' ' + (hh < 12 ? 'AM' : 'PM'));
+        }
+        when = parts.join(' · ');
+      }
+      document.getElementById('pillWhen').textContent = when;
+    }
+
+    /* ── Open / close popover ── */
+    const scrim = document.getElementById('popoverScrim');
+    const pop = document.getElementById('searchPopover');
+    function openPopover() {
+      scrim.classList.add('open'); scrim.setAttribute('aria-hidden', 'false');
+      pop.classList.add('open');   pop.setAttribute('aria-hidden', 'false');
+      document.getElementById('searchPill').setAttribute('aria-expanded', 'true');
+      document.body.style.overflow = 'hidden';
+      // Focus the suburb input on open for fast typing
+      setTimeout(() => { const s = document.getElementById('suburbInput'); if (s) s.focus(); }, 60);
+    }
+    function closePopover() {
+      scrim.classList.remove('open'); scrim.setAttribute('aria-hidden', 'true');
+      pop.classList.remove('open');   pop.setAttribute('aria-hidden', 'true');
+      document.getElementById('searchPill').setAttribute('aria-expanded', 'false');
+      document.body.style.overflow = '';
+    }
+    document.getElementById('searchPill').addEventListener('click', openPopover);
+    document.getElementById('heroOpenSearch').addEventListener('click', openPopover);
+    document.getElementById('popoverClose').addEventListener('click', closePopover);
+    scrim.addEventListener('click', closePopover);
+    document.addEventListener('keydown', e => { if (e.key === 'Escape' && pop.classList.contains('open')) closePopover(); });
+
+    /* ── Service chips ── */
     document.getElementById('svcRow').addEventListener('click', e => {
       const btn = e.target.closest('.svc-chip');
       if (!btn) return;
@@ -388,9 +559,10 @@
         c.classList.toggle('active', on);
         c.setAttribute('aria-checked', on ? 'true' : 'false');
       });
+      updatePillSummary();
     });
 
-    // Mode segmented
+    /* ── Mode segmented ── */
     const seg = document.getElementById('modeSeg');
     seg.addEventListener('click', e => {
       const btn = e.target.closest('button[data-rec]');
@@ -402,6 +574,7 @@
         b.setAttribute('aria-selected', on ? 'true' : 'false');
       });
       renderWhenFields();
+      updatePillSummary();
     });
 
     function renderWhenFields() {
@@ -423,6 +596,7 @@
           const on = state.days.includes(d);
           btn.classList.toggle('active', on);
           btn.setAttribute('aria-pressed', on ? 'true' : 'false');
+          updatePillSummary();
         });
       } else {
         wrap.classList.add('when-fields');
@@ -440,19 +614,57 @@
             <select id="timeInput" name="time" aria-label="Time"></select>
           </div>`;
         const sel = wrap.querySelector('#timeInput');
-        sel.innerHTML = timeSel.innerHTML; // copy options from the original
+        sel.innerHTML = TIME_HTML;
         sel.value = state.time || '';
-        sel.addEventListener('change', e => state.time = e.target.value);
-        wrap.querySelector('#dateInput').addEventListener('change', e => state.date = e.target.value);
+        sel.addEventListener('change', e => { state.time = e.target.value; updatePillSummary(); });
+        wrap.querySelector('#dateInput').addEventListener('change', e => { state.date = e.target.value; updatePillSummary(); });
       }
     }
 
-    // Track date/time when in one-off mode
-    document.getElementById('dateInput').addEventListener('change', e => state.date = e.target.value);
-    timeSel.addEventListener('change', e => state.time = e.target.value);
-    document.getElementById('suburbInput').addEventListener('input', e => state.suburb = e.target.value.trim());
+    // Initial one-off bindings (fields are already in DOM)
+    document.getElementById('dateInput').addEventListener('change', e => { state.date = e.target.value; updatePillSummary(); });
+    timeSel.addEventListener('change', e => { state.time = e.target.value; updatePillSummary(); });
+    document.getElementById('suburbInput').addEventListener('input', e => { state.suburb = e.target.value.trim(); updatePillSummary(); });
 
-    // Submit → /search/?…
+    /* ── Suggestions: pre-fill state then submit ── */
+    document.querySelectorAll('.suggestion-chip').forEach(chip => {
+      chip.addEventListener('click', () => {
+        const k = chip.dataset.suggest;
+        if (k === 'weekday-walks') {
+          state.service = 'dog_walking'; state.recurring = true; state.days = ['mon','tue','wed','thu','fri']; state.time = '09:00';
+        } else if (k === 'boarding-holidays') {
+          state.service = 'dog_boarding'; state.recurring = false;
+        } else if (k === 'daycare-inner-west') {
+          state.service = 'dog_daycare'; state.suburb = 'Inner West';
+        } else if (k === 'cat-weekend') {
+          state.service = 'cat_sitting'; state.recurring = false;
+        }
+        applyStateToFormUI();
+        form.requestSubmit();
+      });
+    });
+
+    function applyStateToFormUI() {
+      // Service chip
+      document.querySelectorAll('.svc-chip').forEach(c => {
+        const on = c.dataset.svc === state.service;
+        c.classList.toggle('active', on);
+        c.setAttribute('aria-checked', on ? 'true' : 'false');
+      });
+      // Suburb
+      const sub = document.getElementById('suburbInput');
+      if (sub) sub.value = state.suburb || '';
+      // Mode + when
+      seg.querySelectorAll('button').forEach(b => {
+        const on = (b.dataset.rec === 'true') === state.recurring;
+        b.classList.toggle('active', on);
+        b.setAttribute('aria-selected', on ? 'true' : 'false');
+      });
+      renderWhenFields();
+      updatePillSummary();
+    }
+
+    /* ── Submit → /search/?… ── */
     form.addEventListener('submit', e => {
       e.preventDefault();
       const params = new URLSearchParams();
@@ -461,12 +673,15 @@
       if (state.recurring) {
         params.set('recurring', 'true');
         if (state.days.length) params.set('days', state.days.join(','));
+        if (state.time) params.set('time', state.time);
       } else {
         if (state.date) params.set('date', state.date);
         if (state.time) params.set('time', state.time);
       }
       window.location.href = '/search/' + (params.toString() ? '?' + params.toString() : '');
     });
+
+    updatePillSummary();
   })();
   </script>
 


### PR DESCRIPTION
- Slim search pill in nav (Service · Where · When · Pet · go button) always visible above the fold. Click opens a popover dropdown on desktop, bottom sheet on mobile.
- Hero is now full-bleed two-column with primary 'Find a carer' CTA and a ghost 'How Truffl works' link. Existing dog-hero.png + live pill + walk-update card preserved.
- Popover contains the same form (service tiles, suburb, one-off / recurring, date+time or day picker, find button) plus a Popular- near-you suggestion strip that pre-fills + submits in one click.
- Pill summary text updates live as state changes.
- Esc key, scrim click, and close button all dismiss the popover.
- Mobile breakpoint reflows nav into two rows (logo + actions on top, pill below) and turns the popover into a bottom sheet.