### PR TITLE
Fix: search service filter not applying on dropdown change

### DIFF
--- a/search/index.html
+++ b/search/index.html
@@ -591,6 +591,9 @@ async function fallbackSearch() {
   }));
 }
 
+// Re-run search immediately when the service filter changes
+document.getElementById('filterService').addEventListener('change', () => searchProviders());
+
 // Also search when pressing Enter in the suburb field
 document.getElementById('filterSuburb').addEventListener('keydown', e => {
   if (e.key === 'Enter') searchProviders();


### PR DESCRIPTION
The service dropdown had no change handler, so selecting a different service did nothing until the Search button was clicked manually — making it appear results wouldn't update. Add a change listener that re-runs searchProviders() immediately on selection.