### PR TITLE
Profile & settings page with photo upload (TRU-30, TRU-31)

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -455,7 +455,7 @@ function renderBookingsTab() {
 
 function renderDashboard() {
   const initials = ((userData.first_name||'')[0]||'') + ((userData.last_name||'')[0]||'');
-  document.getElementById('navUser').innerHTML = `<div class="nav-avatar">${initials}</div><span class="nav-name">${userData.first_name}</span>`;
+  document.getElementById('navUser').innerHTML = `<a href="/profile/" title="Your profile" style="display:flex;align-items:center;gap:8px;text-decoration:none;color:inherit;"><div class="nav-avatar">${initials}</div><span class="nav-name">${userData.first_name}</span></a>`;
 
   const pending = bookings.filter(b => b.status === 'pending');
   const confirmed = bookings.filter(b => b.status === 'confirmed');

--- a/my/index.html
+++ b/my/index.html
@@ -406,7 +406,7 @@ function renderAccountTab() {
 
 function renderDashboard() {
   const initials = ((userData.first_name || '')[0] || '').toUpperCase() + ((userData.last_name || '')[0] || '').toUpperCase();
-  document.getElementById('navUser').innerHTML = `<div class="nav-avatar">${esc(initials)}</div><span class="nav-name">${esc(userData.first_name)}</span>`;
+  document.getElementById('navUser').innerHTML = `<a href="/profile/" title="Your profile" style="display:flex;align-items:center;gap:8px;text-decoration:none;color:inherit;"><div class="nav-avatar">${esc(initials)}</div><span class="nav-name">${esc(userData.first_name)}</span></a>`;
 
   const inProgress = bookings.filter(b => b.status === 'in_progress');
   const welcomeSub = inProgress.length > 0
@@ -507,7 +507,7 @@ async function saveDetails() {
     editingDetails = false;
     clearMsg();
     const initials = (fn[0] || '').toUpperCase() + (ln[0] || '').toUpperCase();
-    document.getElementById('navUser').innerHTML = `<div class="nav-avatar">${esc(initials)}</div><span class="nav-name">${esc(fn)}</span>`;
+    document.getElementById('navUser').innerHTML = `<a href="/profile/" title="Your profile" style="display:flex;align-items:center;gap:8px;text-decoration:none;color:inherit;"><div class="nav-avatar">${esc(initials)}</div><span class="nav-name">${esc(fn)}</span></a>`;
     renderAccountTab();
   } catch(e) { showMsg(e.message, 'error'); }
 }

--- a/profile/index.html
+++ b/profile/index.html
@@ -1,0 +1,423 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Your Profile — Truffl Pets</title>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=DM+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --cream:#FAF7F2; --warm-white:#FFFDF9; --sage:#8B9E7E; --sage-light:#C2D1B5;
+    --sage-dark:#6B7E5E; --terracotta:#C4755B; --terracotta-light:#D4917B;
+    --blush:#E8C4B8; --brown:#3D2B1F; --brown-muted:#8B7355;
+    --text-primary:#3D2B1F; --text-secondary:#6B5B4E; --text-muted:#9B8B7E;
+    --border:#E8E0D6; --border-focus:#C4755B;
+    --error:#C0392B; --error-bg:#FDF0EE; --success:#5B8C5A; --success-bg:#EDF5ED;
+    --warning:#C0862B; --warning-bg:#FEF3E2;
+  }
+  *{margin:0;padding:0;box-sizing:border-box;}
+  body{font-family:'DM Sans',sans-serif;background:var(--cream);color:var(--text-primary);min-height:100vh;-webkit-font-smoothing:antialiased;}
+
+  .nav{position:sticky;top:0;z-index:100;background:var(--warm-white);border-bottom:1px solid var(--border);padding:0 1.5rem;height:64px;display:flex;align-items:center;justify-content:space-between;}
+  .nav-logo{display:flex;align-items:center;text-decoration:none;}
+  .nav-right{display:flex;align-items:center;gap:8px;}
+  .nav-link{font-size:0.85rem;color:var(--text-secondary);text-decoration:none;transition:color 0.2s;}
+  .nav-link:hover{color:var(--terracotta);}
+
+  .page-wrapper{max-width:560px;margin:0 auto;padding:1.5rem 1rem 4rem;}
+
+  .welcome{margin-bottom:1.5rem;}
+  .welcome h1{font-family:'Cormorant Garamond',serif;font-weight:500;font-size:1.8rem;color:var(--brown);margin-bottom:4px;}
+  .welcome p{color:var(--text-muted);font-size:0.9rem;}
+
+  /* Avatar */
+  .avatar-section{display:flex;align-items:center;gap:18px;background:var(--warm-white);border:1px solid var(--border);border-radius:14px;padding:1.25rem;margin-bottom:1rem;}
+  .avatar-large{width:72px;height:72px;border-radius:50%;background:var(--blush);display:flex;align-items:center;justify-content:center;font-family:'Cormorant Garamond',serif;font-size:1.8rem;font-weight:600;color:var(--brown);overflow:hidden;flex-shrink:0;}
+  .avatar-large img{width:100%;height:100%;object-fit:cover;}
+  .avatar-meta{flex:1;}
+  .avatar-actions{display:flex;align-items:center;gap:10px;flex-wrap:wrap;}
+  .btn-photo{display:inline-block;padding:8px 16px;background:transparent;border:1px solid var(--border);color:var(--text-secondary);border-radius:8px;font-size:0.82rem;font-weight:500;cursor:pointer;font-family:'DM Sans',sans-serif;transition:border-color 0.2s,color 0.2s;}
+  .btn-photo:hover{border-color:var(--terracotta);color:var(--terracotta);}
+  .photo-hint{font-size:0.75rem;color:var(--text-muted);margin-top:6px;}
+  .uploading{font-size:0.78rem;color:var(--terracotta);}
+
+  /* Details card / form */
+  .details-card{background:var(--warm-white);border:1px solid var(--border);border-radius:14px;padding:1.5rem;margin-bottom:1rem;}
+  .field{margin-bottom:1rem;}
+  .field:last-child{margin-bottom:0;}
+  .field label{display:block;font-size:0.78rem;font-weight:500;color:var(--text-secondary);margin-bottom:5px;}
+  .field input{width:100%;padding:10px 12px;border:1px solid var(--border);border-radius:8px;font-family:'DM Sans',sans-serif;font-size:0.9rem;color:var(--text-primary);background:var(--warm-white);outline:none;transition:border-color 0.2s;}
+  .field input:focus{border-color:var(--border-focus);}
+  .field input.invalid{border-color:var(--error);background:var(--error-bg);}
+  .field .field-hint{font-size:0.74rem;color:var(--text-muted);margin-top:5px;}
+  .field .field-error{font-size:0.74rem;color:var(--error);margin-top:5px;display:none;}
+  .field .field-error.show{display:block;}
+  .row-2{display:grid;grid-template-columns:1fr 1fr;gap:12px;}
+
+  .form-actions{display:flex;gap:10px;margin-top:1.25rem;}
+  .btn-save{padding:11px 24px;background:var(--terracotta);color:white;border:none;border-radius:9px;font-size:0.88rem;font-weight:600;cursor:pointer;font-family:'DM Sans',sans-serif;transition:background 0.2s;}
+  .btn-save:hover{background:var(--terracotta-light);}
+  .btn-save:disabled{opacity:0.6;cursor:default;}
+  .btn-discard{padding:11px 18px;background:transparent;border:1px solid var(--border);color:var(--text-muted);border-radius:9px;font-size:0.88rem;cursor:pointer;font-family:'DM Sans',sans-serif;}
+  .btn-discard:hover{border-color:var(--text-muted);}
+
+  .sign-out-btn{display:block;width:100%;padding:12px;background:transparent;border:1px solid var(--border);color:var(--error);border-radius:10px;font-size:0.88rem;font-weight:500;cursor:pointer;font-family:'DM Sans',sans-serif;text-align:center;margin-top:1.5rem;transition:border-color 0.2s;}
+  .sign-out-btn:hover{border-color:var(--error);}
+
+  .msg{padding:12px 16px;border-radius:10px;font-size:0.85rem;margin-bottom:1rem;display:none;line-height:1.5;}
+  .msg.error{background:var(--error-bg);color:var(--error);display:block;}
+  .msg.success{background:var(--success-bg);color:var(--success);display:block;}
+  .msg.info{background:var(--warning-bg);color:var(--warning);display:block;}
+
+  .login-prompt{text-align:center;padding:4rem 2rem;}
+  .login-prompt h2{font-family:'Cormorant Garamond',serif;font-size:1.6rem;color:var(--brown);margin-bottom:0.5rem;}
+  .login-prompt p{color:var(--text-muted);font-size:0.9rem;margin-bottom:1.5rem;}
+  .login-prompt a{display:inline-block;padding:12px 32px;background:var(--terracotta);color:white;border-radius:10px;font-weight:500;text-decoration:none;}
+
+  @media(max-width:600px){
+    .page-wrapper{padding:1rem 0.75rem 3rem;}
+    .nav{padding:0 1rem;}
+    .row-2{grid-template-columns:1fr;}
+  }
+</style>
+</head>
+<body>
+
+<nav class="nav">
+  <a href="/" class="nav-logo" aria-label="Truffl Pets home">
+    <svg width="150" height="48" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <circle cx="20" cy="5.5" r="6" fill="none" stroke="#C4866A" stroke-width="2.5"/>
+      <circle cx="20" cy="5.5" r="2.8" fill="#FFFDF9"/>
+      <rect x="16.5" y="10.5" width="7" height="9" rx="3" fill="#C4866A"/>
+      <circle cx="20" cy="33" r="20" fill="#C4866A"/>
+      <circle cx="20" cy="33" r="15.5" fill="none" stroke="#B8795C" stroke-width="0.6" opacity="0.45"/>
+      <line x1="7" y1="33" x2="33" y2="33" stroke="#FFFDF9" stroke-width="0.5" opacity="0.3"/>
+      <text x="20" y="35.5" font-family="'Cormorant Garamond', Georgia, serif" font-size="14" font-style="italic" font-weight="400" fill="#FFFDF9" text-anchor="middle" letter-spacing="-0.3">truffl</text>
+      <text x="52" y="30" font-family="'Cormorant Garamond', Georgia, serif" font-size="32" font-style="italic" font-weight="400" fill="#3D2B1F" letter-spacing="-0.5">truffl</text>
+      <text x="52" y="50" font-family="'DM Sans', sans-serif" font-size="12" font-weight="600" fill="#B0A090" letter-spacing="4">PETS</text>
+    </svg>
+  </a>
+  <div class="nav-right" id="navRight"></div>
+</nav>
+
+<div class="page-wrapper">
+  <div id="profileContent">
+    <div style="text-align:center;padding:3rem;color:var(--text-muted);font-size:0.85rem;">Loading your profile…</div>
+  </div>
+</div>
+
+<script>
+const SUPABASE_URL = 'https://gadflsntbnbnnxbpiral.supabase.co';
+const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdhZGZsc250Ym5ibm54YnBpcmFsIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzUwNjcwNTcsImV4cCI6MjA5MDY0MzA1N30.g5ZrqeAX9U5l7oDZEbQFrU5j10828dUF0QuJ0ZlHXK8';
+
+let authToken = null, authUid = null;
+let userData = null;          // row from users
+let profileRow = null;        // row from customer_profiles or provider_profiles
+let profileTable = null;      // 'customer_profiles' | 'provider_profiles'
+
+function h(token) {
+  const hd = { 'Content-Type': 'application/json', 'apikey': SUPABASE_ANON_KEY, 'Authorization': `Bearer ${SUPABASE_ANON_KEY}` };
+  if (token) hd['Authorization'] = `Bearer ${token}`;
+  return hd;
+}
+async function sbGet(t, p) {
+  const r = await fetch(`${SUPABASE_URL}/rest/v1/${t}?${p}`, { headers: h(authToken) });
+  if (!r.ok) { const e = await r.json(); throw new Error(e.message); }
+  return await r.json();
+}
+async function sbPatch(t, col, val, upd) {
+  const r = await fetch(`${SUPABASE_URL}/rest/v1/${t}?${col}=eq.${val}`, { method: 'PATCH', headers: { ...h(authToken), 'Prefer': 'return=representation' }, body: JSON.stringify(upd) });
+  if (!r.ok) { const e = await r.json(); throw new Error(e.message); }
+  const data = await r.json();
+  if (Array.isArray(data) && data.length === 0) throw new Error("Couldn't save — you may not have permission, or the record no longer exists.");
+  return data;
+}
+
+function esc(s) {
+  return (s || '').toString().replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+}
+function showMsg(t, type) {
+  const el = document.getElementById('profileMsg');
+  if (!el) return;
+  el.textContent = t;
+  el.className = `msg ${type}`;
+  window.scrollTo({ top: 0, behavior: 'smooth' });
+}
+function clearMsg() {
+  const el = document.getElementById('profileMsg');
+  if (el) el.className = 'msg';
+}
+
+function initials(fn, ln) {
+  return ((fn || '')[0] || '').toUpperCase() + ((ln || '')[0] || '').toUpperCase();
+}
+
+/* ── Validation ── */
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const PHONE_RE = /^[+]?[\d][\d\s()-]{6,}$/;
+
+function validate() {
+  let ok = true;
+  const fn = document.getElementById('f-first').value.trim();
+  const ln = document.getElementById('f-last').value.trim();
+  const email = document.getElementById('f-email').value.trim();
+  const phone = document.getElementById('f-phone').value.trim();
+
+  setFieldError('first', !fn, 'First name is required.');
+  setFieldError('last', !ln, 'Last name is required.');
+  setFieldError('email', !EMAIL_RE.test(email), 'Enter a valid email address.');
+  setFieldError('phone', phone !== '' && !PHONE_RE.test(phone), 'Enter a valid phone number.');
+
+  if (!fn || !ln) ok = false;
+  if (!EMAIL_RE.test(email)) ok = false;
+  if (phone !== '' && !PHONE_RE.test(phone)) ok = false;
+  return ok;
+}
+function setFieldError(key, isError, text) {
+  const input = document.getElementById('f-' + key);
+  const err = document.getElementById('err-' + key);
+  if (!input || !err) return;
+  input.classList.toggle('invalid', isError);
+  err.textContent = text || '';
+  err.classList.toggle('show', isError);
+}
+
+/* ── Render ── */
+function renderAvatar() {
+  const el = document.getElementById('avatarDisplay');
+  if (!el) return;
+  if (userData.avatar_url) {
+    el.innerHTML = `<img src="${esc(userData.avatar_url)}" alt="Your profile photo">`;
+  } else {
+    el.textContent = initials(userData.first_name, userData.last_name) || '🐾';
+  }
+}
+function renderNav() {
+  const el = document.getElementById('navRight');
+  const home = userData && userData.role === 'provider' ? '/dashboard/' : '/my/';
+  el.innerHTML = `<a href="${home}" class="nav-link">${userData && userData.role === 'provider' ? 'Dashboard' : 'My bookings'}</a>`;
+}
+
+function renderProfile() {
+  const area = document.getElementById('profileContent');
+  const suburb = profileRow ? (profileRow.suburb || '') : '';
+  area.innerHTML = `
+    <div class="welcome">
+      <h1>Your profile</h1>
+      <p>Manage your account details${userData.role === 'provider' ? ' — visible to customers who book you' : ''}.</p>
+    </div>
+
+    <div id="profileMsg" class="msg"></div>
+
+    <div class="avatar-section">
+      <div class="avatar-large" id="avatarDisplay"></div>
+      <div class="avatar-meta">
+        <div class="avatar-actions">
+          <label class="btn-photo">
+            <span id="photoBtnLabel">${userData.avatar_url ? 'Change photo' : 'Upload photo'}</span>
+            <input type="file" accept="image/png,image/jpeg,image/webp" style="display:none;" onchange="uploadAvatar(this)">
+          </label>
+          <span id="uploadStatus"></span>
+        </div>
+        <div class="photo-hint">JPG, PNG or WebP — max 5MB.</div>
+      </div>
+    </div>
+
+    <div class="details-card">
+      <div class="row-2">
+        <div class="field">
+          <label for="f-first">First name</label>
+          <input id="f-first" type="text" value="${esc(userData.first_name)}" autocomplete="given-name">
+          <div class="field-error" id="err-first"></div>
+        </div>
+        <div class="field">
+          <label for="f-last">Last name</label>
+          <input id="f-last" type="text" value="${esc(userData.last_name)}" autocomplete="family-name">
+          <div class="field-error" id="err-last"></div>
+        </div>
+      </div>
+
+      <div class="field">
+        <label for="f-email">Email</label>
+        <input id="f-email" type="email" value="${esc(userData.email)}" autocomplete="email">
+        <div class="field-hint">Changing this updates your login email — you'll need to confirm it via a link we email you.</div>
+        <div class="field-error" id="err-email"></div>
+      </div>
+
+      <div class="field">
+        <label for="f-phone">Phone</label>
+        <input id="f-phone" type="tel" value="${esc(userData.phone)}" autocomplete="tel" placeholder="e.g. 0412 345 678">
+        <div class="field-error" id="err-phone"></div>
+      </div>
+
+      <div class="field">
+        <label for="f-suburb">Suburb</label>
+        <input id="f-suburb" type="text" value="${esc(suburb)}" autocomplete="address-level2" placeholder="e.g. Summer Hill">
+        <div class="field-error" id="err-suburb"></div>
+      </div>
+
+      <div class="form-actions">
+        <button class="btn-save" id="saveBtn" onclick="saveProfile()">Save changes</button>
+        <button class="btn-discard" onclick="resetForm()">Reset</button>
+      </div>
+    </div>
+
+    <button class="sign-out-btn" onclick="signOut()">Sign out</button>
+  `;
+  renderAvatar();
+}
+
+function resetForm() {
+  clearMsg();
+  renderProfile();
+}
+
+/* ── Save ── */
+async function updateAuthEmail(newEmail) {
+  const r = await fetch(`${SUPABASE_URL}/auth/v1/user`, {
+    method: 'PUT',
+    headers: { 'apikey': SUPABASE_ANON_KEY, 'Authorization': `Bearer ${authToken}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: newEmail })
+  });
+  if (!r.ok) {
+    const e = await r.json().catch(() => ({}));
+    throw new Error(e.msg || e.message || e.error_description || 'Could not update email.');
+  }
+  return await r.json();
+}
+
+async function saveProfile() {
+  clearMsg();
+  if (!validate()) { showMsg('Please fix the highlighted fields.', 'error'); return; }
+
+  const fn = document.getElementById('f-first').value.trim();
+  const ln = document.getElementById('f-last').value.trim();
+  const email = document.getElementById('f-email').value.trim();
+  const phone = document.getElementById('f-phone').value.trim();
+  const suburb = document.getElementById('f-suburb').value.trim();
+
+  const btn = document.getElementById('saveBtn');
+  btn.disabled = true; btn.textContent = 'Saving…';
+
+  const emailChanged = email.toLowerCase() !== (userData.email || '').toLowerCase();
+
+  try {
+    // 1. Core user fields
+    await sbPatch('users', 'id', authUid, { first_name: fn, last_name: ln, phone: phone || null });
+    userData.first_name = fn; userData.last_name = ln; userData.phone = phone || null;
+
+    // 2. Suburb on the role-specific profile row
+    if (profileRow) {
+      await sbPatch(profileTable, 'user_id', authUid, { suburb: suburb || null });
+      profileRow.suburb = suburb || null;
+    }
+
+    // 3. Email change goes through Supabase Auth (re-verification)
+    if (emailChanged) {
+      await updateAuthEmail(email);
+      // Optimistically reflect in the app-level users row; login email switches once confirmed.
+      try { await sbPatch('users', 'id', authUid, { email }); userData.email = email; } catch (e) { /* non-fatal */ }
+    }
+
+    renderAvatar();
+    renderNav();
+
+    if (emailChanged) {
+      showMsg(`Saved. We've sent a confirmation link to ${email} — your login email will update once you confirm it.`, 'info');
+    } else {
+      showMsg('Your profile has been saved.', 'success');
+    }
+  } catch (e) {
+    showMsg(e.message, 'error');
+  } finally {
+    btn.disabled = false; btn.textContent = 'Save changes';
+  }
+}
+
+/* ── Photo upload (TRU-31) ── */
+const MAX_PHOTO_BYTES = 5 * 1024 * 1024;
+const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+
+async function uploadAvatar(input) {
+  const file = input.files[0];
+  if (!file) return;
+  clearMsg();
+
+  if (!ALLOWED_TYPES.includes(file.type)) {
+    showMsg('Please choose a JPG, PNG or WebP image.', 'error');
+    input.value = ''; return;
+  }
+  if (file.size > MAX_PHOTO_BYTES) {
+    showMsg('That image is over 5MB — please choose a smaller file.', 'error');
+    input.value = ''; return;
+  }
+
+  const status = document.getElementById('uploadStatus');
+  status.innerHTML = '<span class="uploading">Uploading…</span>';
+
+  try {
+    const ext = (file.name.split('.').pop() || 'jpg').toLowerCase();
+    // Policy requires the first path segment to be the user's id.
+    const path = `${authUid}/avatar_${Date.now()}.${ext}`;
+    const up = await fetch(`${SUPABASE_URL}/storage/v1/object/profile-photos/${path}`, {
+      method: 'POST',
+      headers: { 'apikey': SUPABASE_ANON_KEY, 'Authorization': `Bearer ${authToken}`, 'Content-Type': file.type },
+      body: file
+    });
+    if (!up.ok) {
+      const e = await up.json().catch(() => ({}));
+      throw new Error(e.message || e.error || 'Upload failed.');
+    }
+    const publicUrl = `${SUPABASE_URL}/storage/v1/object/public/profile-photos/${path}`;
+    await sbPatch('users', 'id', authUid, { avatar_url: publicUrl });
+    userData.avatar_url = publicUrl;
+    renderAvatar();
+    document.getElementById('photoBtnLabel').textContent = 'Change photo';
+    status.innerHTML = '';
+    showMsg('Photo updated.', 'success');
+  } catch (e) {
+    status.innerHTML = '';
+    showMsg(e.message, 'error');
+  } finally {
+    input.value = '';
+  }
+}
+
+function signOut() {
+  localStorage.removeItem('truffl_session');
+  window.location.href = '/';
+}
+
+/* ── Init ── */
+async function init() {
+  const area = document.getElementById('profileContent');
+  const stored = localStorage.getItem('truffl_session');
+  if (stored) { try { const s = JSON.parse(stored); authToken = s.access_token; authUid = s.user_id; } catch (e) {} }
+
+  if (!authToken) {
+    area.innerHTML = `<div class="login-prompt"><h2>Sign in required</h2><p>You need to be logged in to manage your profile.</p><a href="/login/?redirect=/profile/">Sign in</a></div>`;
+    return;
+  }
+
+  try {
+    const users = await sbGet('users', `id=eq.${authUid}&select=first_name,last_name,email,phone,avatar_url,role`);
+    if (!users.length) { signOut(); return; }
+    userData = users[0];
+
+    profileTable = userData.role === 'provider' ? 'provider_profiles' : 'customer_profiles';
+    const profiles = await sbGet(profileTable, `user_id=eq.${authUid}&select=id,suburb`);
+    profileRow = profiles.length ? profiles[0] : null;
+
+    renderNav();
+    renderProfile();
+  } catch (e) {
+    area.innerHTML = `<div class="login-prompt"><h2>Something went wrong</h2><p>${esc(e.message)}</p><a href="/login/">Try signing in again</a></div>`;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', init);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
New `/profile/` page for all logged-in users (customers and providers), covering **TRU-30** (base profile) and **TRU-31** (photo upload).

### Features
- **Shared fields**: first/last name + phone (`users`), suburb (role-specific — `customer_profiles` or `provider_profiles`)
- **Email editing** via Supabase Auth (`PUT /auth/v1/user`) with re-verification. The app-level `users.email` is updated optimistically, with clear messaging that the **login** email switches only after the user confirms the link.
- **Profile photo upload** → `profile-photos` bucket at `{authUid}/avatar_*.ext` (satisfies the owner-folder storage policy), saved to `users.avatar_url`. Validates type (JPG/PNG/WebP) and size (≤5MB).
- **Validation**: email + phone format, required name fields, inline field errors.
- **Nav link**: the avatar/name in the header on `my/` and `dashboard/` now links to `/profile/`.

### Reuse / safety
- Reuses the existing design tokens + `sb*` REST helpers. `sbPatch` throws on a 0-row response (RLS-blocked save), consistent with the TRU-13 fix.

## Testing (provider account, verified in DB)
- ✅ Loads with current name/email/phone/suburb + initials avatar
- ✅ Validation blocks invalid email/phone
- ✅ Save persists name + phone (`users`) and suburb (`provider_profiles`)
- ✅ Photo upload → stored at `{uid}/…`, `avatar_url` saved, public URL returns `200 image/png`
- ✅ Email change triggers Supabase Auth re-verification (login email stays until confirmed; new address sits as `email_change` pending) with correct "info" messaging
- ✅ Nav avatar links to `/profile/` on both landing pages; no console errors
- Test data cleaned up afterwards

The customer path is symmetric (same code, `customer_profiles.suburb` + `/my/` nav home) and covered by schema.

## Known follow-up (not in scope)
Uploading a new photo leaves the previous file orphaned in storage (each upload is timestamped, and there's no client delete policy on `profile-photos`). Fine for MVP; worth a cleanup pass later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)