### PR TITLE
Match about page header to home page (TRU-63)

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -36,7 +36,7 @@
     nav {
       background: var(--cream);
       padding: 0 56px;
-      height: 68px;
+      height: 82px;
       display: flex;
       align-items: center;
       justify-content: space-between;
@@ -44,13 +44,16 @@
       position: sticky;
       top: 0;
       z-index: 100;
+      gap: 24px;
+      flex-wrap: wrap;
     }
-    .nav-links { display: flex; gap: 36px; font-size: 13px; color: var(--text-mid); }
+    .nav-left { display: flex; align-items: center; gap: 32px; }
+    .nav-links { display: flex; gap: 28px; font-size: 13px; color: var(--text-mid); }
     .nav-links a { transition: color 0.2s; letter-spacing: 0.02em; }
     .nav-links a:hover { color: var(--text); }
     .nav-links a.active { color: var(--text); font-weight: 500; }
     .nav-logo { display: flex; align-items: center; cursor: pointer; }
-    .nav-logo svg { width: 130px; height: auto; }
+    .nav-logo svg { width: 150px; height: auto; }
     .nav-actions { display: flex; gap: 24px; align-items: center; font-size: 13px; color: var(--text-mid); }
     .nav-actions a { transition: color 0.2s; }
     .nav-actions a:hover { color: var(--text); }
@@ -63,6 +66,77 @@
     }
     .btn-primary:hover { background: var(--terracotta-dark); transform: translateY(-1px); }
     .btn-primary-lg { padding: 13px 28px; font-size: 14px; }
+
+    /* ── NAV SEARCH PILL ── */
+    .nav-search-pill {
+      flex: 1 1 320px; max-width: 720px; min-width: 0;
+      display: grid; grid-template-columns: auto 1px 1fr 1px 1fr 1px 1fr auto; align-items: center; gap: 14px;
+      padding: 6px 6px 6px 16px; border-radius: 999px;
+      background: #fff; border: 1px solid var(--border);
+      cursor: pointer; text-align: left; font-family: 'DM Sans', sans-serif; color: var(--text);
+      box-shadow: 0 2px 6px -3px rgba(61,43,31,0.08); transition: box-shadow 0.2s, border-color 0.2s;
+    }
+    .nav-search-pill:hover { box-shadow: 0 4px 14px -6px rgba(61,43,31,0.14); border-color: var(--terracotta); }
+    .nsp-svc { display: flex; align-items: center; gap: 8px; min-width: 0; }
+    .nsp-svc-emoji { font-size: 15px; line-height: 1; }
+    .nsp-svc-label { font-size: 13px; font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .nsp-divider { width: 1px; height: 22px; background: var(--border); }
+    .nsp-field { min-width: 0; }
+    .nsp-eyebrow { font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-light); display: block; line-height: 1; margin-bottom: 3px; }
+    .nsp-value { font-size: 13px; color: var(--text-mid); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .nsp-go { width: 38px; height: 38px; border-radius: 999px; background: var(--terracotta); color: #fff; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+
+    /* ── SEARCH POPOVER ── */
+    .popover-scrim { position: fixed; inset: 0; background: rgba(40,28,20,0.32); -webkit-backdrop-filter: blur(2px); backdrop-filter: blur(2px); opacity: 0; pointer-events: none; transition: opacity 0.22s ease; z-index: 200; }
+    .popover-scrim.open { opacity: 1; pointer-events: auto; }
+    .popover {
+      position: fixed; top: 110px; left: 56px; right: 56px; z-index: 201;
+      background: #fff; border-radius: 22px; padding: 28px 32px 30px;
+      box-shadow: 0 30px 80px -30px rgba(61,43,31,0.35), 0 8px 20px -10px rgba(61,43,31,0.12);
+      border: 1px solid var(--border);
+      transform: translateY(-12px); opacity: 0; pointer-events: none;
+      transition: transform 0.22s ease, opacity 0.22s ease;
+      max-height: calc(100vh - 130px); overflow-y: auto;
+    }
+    .popover.open { transform: translateY(0); opacity: 1; pointer-events: auto; }
+    .popover-close { position: absolute; top: 18px; right: 18px; width: 34px; height: 34px; border-radius: 999px; background: var(--cream); border: 1px solid var(--border); cursor: pointer; display: flex; align-items: center; justify-content: center; padding: 0; color: var(--text); }
+    .popover-close:hover { border-color: var(--text-mid); }
+    .popover-suggestions { margin-top: 24px; padding-top: 22px; border-top: 1px solid var(--border); }
+    .popover-suggestions-label { font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--text-light); margin-bottom: 12px; font-weight: 500; }
+    .popover-suggestions-row { display: flex; gap: 10px; flex-wrap: wrap; }
+    .suggestion-chip { padding: 9px 16px; border-radius: 999px; background: var(--cream); border: 1px solid var(--border); font-family: 'DM Sans', sans-serif; font-size: 13px; color: var(--text); display: inline-flex; align-items: center; gap: 8px; cursor: pointer; transition: border-color 0.18s, color 0.18s; }
+    .suggestion-chip:hover { border-color: var(--terracotta); color: var(--terracotta-dark); }
+
+    /* ── FORM CONTROLS (used inside popover) ── */
+    .widget-title { font-family: 'Cormorant Garamond', Georgia, serif; font-style: italic; font-size: 22px; color: var(--brown); margin-bottom: 14px; }
+    .svc-row { display: flex; gap: 8px; flex-wrap: wrap; }
+    .svc-chip { display: inline-flex; align-items: center; gap: 8px; padding: 10px 14px; border-radius: 999px; background: #fff; border: 1px solid var(--border); color: var(--text); font-family: 'DM Sans', sans-serif; font-size: 13px; cursor: pointer; transition: all 0.18s; user-select: none; }
+    .svc-chip:hover { border-color: var(--sage-dark); }
+    .svc-chip.active { background: rgba(196,134,106,0.10); border-color: var(--terracotta); color: var(--terracotta-dark); }
+    .svc-chip .svc-icon-emoji { font-size: 16px; line-height: 1; }
+    .svc-chip .svc-sub { color: var(--text-light); font-size: 12px; opacity: 0.85; }
+    .svc-chip.active .svc-sub { color: var(--terracotta-dark); }
+    .when-row { display: grid; grid-template-columns: 1.1fr 1.4fr auto; gap: 14px; margin-top: 22px; align-items: end; }
+    .field-eyebrow { font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--text-light); margin-bottom: 8px; font-weight: 500; }
+    .when-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; }
+    .seg { display: inline-flex; background: var(--cream); padding: 3px; border-radius: 999px; border: 1px solid var(--border); }
+    .seg button { padding: 5px 14px; border-radius: 999px; border: 0; background: transparent; cursor: pointer; font-family: 'DM Sans', sans-serif; font-size: 11.5px; letter-spacing: 0.04em; color: var(--text-mid); }
+    .seg button.active { background: var(--brown); color: var(--cream); }
+    .input-line { position: relative; }
+    .input-line .input-icon { position: absolute; left: 14px; top: 50%; transform: translateY(-50%); color: var(--terracotta); pointer-events: none; }
+    .input-line input { width: 100%; padding: 14px 16px 14px 42px; border-radius: 12px; border: 1px solid var(--border); background: var(--cream); font-family: 'DM Sans', sans-serif; font-size: 15px; color: var(--text); outline: none; transition: border-color 0.2s, box-shadow 0.2s; }
+    .input-line input:focus { border-color: var(--terracotta); box-shadow: 0 0 0 3px rgba(196,134,106,0.12); }
+    .when-fields { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+    .when-fields .input-line .input-icon { color: var(--text-mid); }
+    .when-fields input, .when-fields select { width: 100%; padding: 14px 16px 14px 40px; border-radius: 12px; border: 1px solid var(--border); background: var(--cream); font-family: 'DM Sans', sans-serif; font-size: 14px; color: var(--text); outline: none; transition: border-color 0.2s; }
+    .when-fields input:focus, .when-fields select:focus { border-color: var(--terracotta); }
+    .days { display: flex; gap: 6px; }
+    .day-btn { flex: 1; height: 48px; display: flex; align-items: center; justify-content: center; border-radius: 12px; border: 1px solid var(--border); background: var(--cream); color: var(--text-mid); font-family: 'DM Sans', sans-serif; font-size: 14px; font-weight: 500; cursor: pointer; transition: all 0.18s; user-select: none; }
+    .day-btn:hover { border-color: var(--sage-dark); }
+    .day-btn.active { background: var(--sage); border-color: var(--sage-dark); color: var(--brown); }
+    .find-btn { padding: 15px 28px; border-radius: 999px; background: var(--terracotta); color: #fff; border: 0; cursor: pointer; font-family: 'DM Sans', sans-serif; font-size: 15px; font-weight: 500; display: inline-flex; align-items: center; gap: 10px; box-shadow: 0 8px 20px -8px rgba(196,134,106,0.5); transition: background 0.2s, transform 0.15s; white-space: nowrap; }
+    .find-btn:hover { background: var(--terracotta-dark); transform: translateY(-1px); }
+    .find-btn:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
 
     .btn-ghost {
       background: transparent; color: var(--brown);
@@ -282,8 +356,24 @@
 
     /* ── RESPONSIVE ── */
     @media (max-width: 960px) {
-      nav { padding: 0 24px; }
+      nav { padding: 12px 24px; height: auto; gap: 12px; }
       .nav-links { display: none; }
+      .nav-left { flex: 1 0 100%; justify-content: space-between; }
+      .nav-actions { order: 2; }
+      .nav-search-pill { order: 3; flex: 1 1 100%; max-width: 100%; grid-template-columns: auto 1fr auto; gap: 10px; padding: 8px 8px 8px 14px; }
+      .nsp-divider:nth-of-type(2), .nsp-divider:nth-of-type(3) { display: none; }
+      .nsp-field:nth-of-type(2), .nsp-field:nth-of-type(3) { display: none; }
+      .nsp-field:first-of-type .nsp-eyebrow { display: none; }
+      .nsp-svc-label { font-size: 13.5px; }
+      .popover { top: auto; left: 0; right: 0; bottom: 0; border-radius: 22px 22px 0 0; padding: 18px 18px 24px; max-height: 88vh; transform: translateY(100%); }
+      .popover.open { transform: translateY(0); }
+      .popover-close { top: 14px; right: 14px; width: 32px; height: 32px; }
+      .widget-title { font-size: 18px; }
+      .when-row { grid-template-columns: 1fr; gap: 14px; }
+      .find-btn { width: 100%; justify-content: center; }
+      .svc-row { gap: 6px; }
+      .svc-chip { padding: 9px 12px; font-size: 12.5px; }
+      .svc-chip .svc-sub { display: none; }
       .hero-band { grid-template-columns: 1fr; min-height: auto; }
       .hero-band-text { padding: 64px 32px; }
       .flick-panel { height: 60vw; min-height: 320px; }
@@ -310,14 +400,8 @@
 
   <!-- NAV -->
   <nav>
-    <div class="nav-links">
-      <a href="/">Home</a>
-      <a href="/about-us/" class="active">About</a>
-      <a href="/#services">Services</a>
-      <a href="/#how">How it works</a>
-    </div>
-
-    <a href="/" class="nav-logo" aria-label="Truffl Pets home">
+    <div class="nav-left">
+      <a href="/" class="nav-logo" aria-label="Truffl Pets home">
       <svg width="180" height="56" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
         <circle cx="20" cy="5.5" r="6" fill="none" stroke="#C4866A" stroke-width="2.5"/>
         <circle cx="20" cy="5.5" r="2.8" fill="#F7F3EE"/>
@@ -329,13 +413,127 @@
         <text x="52" y="30" font-family="'Cormorant Garamond', Georgia, serif" font-size="32" font-style="italic" font-weight="400" fill="#5C4033" letter-spacing="-0.5">truffl</text>
         <text x="52" y="50" font-family="'DM Sans', sans-serif" font-size="12" font-weight="600" fill="#B0A090" letter-spacing="4">PETS</text>
       </svg>
-    </a>
+      </a>
+      <div class="nav-links">
+        <a href="/">Home</a>
+        <a href="/about-us/" class="active">About</a>
+        <a href="/#services">Services</a>
+        <a href="/#how">How it works</a>
+      </div>
+    </div>
+
+    <button type="button" class="nav-search-pill" id="searchPill" aria-haspopup="dialog" aria-expanded="false" aria-controls="searchPopover">
+      <span class="nsp-svc">
+        <span class="nsp-svc-emoji" id="pillSvcEmoji">🦮</span>
+        <span class="nsp-svc-label" id="pillSvcLabel">Dog walking</span>
+      </span>
+      <span class="nsp-divider" aria-hidden="true"></span>
+      <span class="nsp-field">
+        <span class="nsp-eyebrow">Where</span>
+        <span class="nsp-value" id="pillWhere">Add suburb</span>
+      </span>
+      <span class="nsp-divider" aria-hidden="true"></span>
+      <span class="nsp-field">
+        <span class="nsp-eyebrow">When</span>
+        <span class="nsp-value" id="pillWhen">Any time</span>
+      </span>
+      <span class="nsp-divider" aria-hidden="true"></span>
+      <span class="nsp-field">
+        <span class="nsp-eyebrow">Pet</span>
+        <span class="nsp-value">Add pet</span>
+      </span>
+      <span class="nsp-go" aria-hidden="true">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      </span>
+    </button>
 
     <div class="nav-actions">
       <a href="/login/">Sign in</a>
       <a href="/search/" class="btn-primary">Book a carer</a>
     </div>
   </nav>
+
+  <!-- SEARCH POPOVER (hidden until the pill opens it) -->
+  <div class="popover-scrim" id="popoverScrim" aria-hidden="true"></div>
+  <div class="popover" id="searchPopover" role="dialog" aria-modal="true" aria-label="Find a carer" aria-hidden="true">
+    <button type="button" class="popover-close" id="popoverClose" aria-label="Close search">
+      <svg width="13" height="13" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"><path d="M2 2 L12 12 M12 2 L2 12"/></svg>
+    </button>
+    <form id="searchWidget" action="/search/" method="get" novalidate>
+      <div class="widget-title">What service do you need?</div>
+      <div class="svc-row" id="svcRow" role="radiogroup" aria-label="Service">
+        <button type="button" class="svc-chip active" data-svc="dog_walking" role="radio" aria-checked="true"><span class="svc-icon-emoji">🦮</span> Dog walking <span class="svc-sub">· 30 or 60 mins</span></button>
+        <button type="button" class="svc-chip" data-svc="dog_boarding" role="radio" aria-checked="false"><span class="svc-icon-emoji">🏠</span> Dog boarding <span class="svc-sub">· At carer's home</span></button>
+        <button type="button" class="svc-chip" data-svc="dog_sitting" role="radio" aria-checked="false"><span class="svc-icon-emoji">🛋️</span> Dog sitting <span class="svc-sub">· In your home</span></button>
+        <button type="button" class="svc-chip" data-svc="dog_daycare" role="radio" aria-checked="false"><span class="svc-icon-emoji">☀️</span> Dog daycare <span class="svc-sub">· Work hours</span></button>
+        <button type="button" class="svc-chip" data-svc="drop_in" role="radio" aria-checked="false"><span class="svc-icon-emoji">🐾</span> Drop-in visit <span class="svc-sub">· Check on your pet</span></button>
+        <button type="button" class="svc-chip" data-svc="cat_sitting" role="radio" aria-checked="false"><span class="svc-icon-emoji">🐱</span> Cat sitting <span class="svc-sub">· In your home</span></button>
+      </div>
+
+      <div class="when-row">
+        <div>
+          <div class="field-eyebrow">Your suburb</div>
+          <div class="input-line">
+            <span class="input-icon">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>
+            </span>
+            <input type="text" id="suburbInput" name="suburb" placeholder="e.g. Newington, Balmain…" autocomplete="off">
+          </div>
+        </div>
+
+        <div>
+          <div class="when-head">
+            <div class="field-eyebrow" style="margin-bottom:0;">When do you need care?</div>
+            <div class="seg" id="modeSeg" role="tablist" aria-label="Booking type">
+              <button type="button" class="active" data-rec="false" role="tab" aria-selected="true">One-off</button>
+              <button type="button" data-rec="true" role="tab" aria-selected="false">Recurring</button>
+            </div>
+          </div>
+          <div id="whenFields" class="when-fields">
+            <div class="input-line">
+              <span class="input-icon">
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+              </span>
+              <input type="date" id="dateInput" name="date" aria-label="Date">
+            </div>
+            <div class="input-line">
+              <span class="input-icon">
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+              </span>
+              <select id="timeInput" name="time" aria-label="Time"></select>
+            </div>
+          </div>
+        </div>
+
+        <button type="submit" class="find-btn" id="findBtn">
+          Find a carer
+          <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+        </button>
+      </div>
+    </form>
+
+    <div class="popover-suggestions">
+      <div class="popover-suggestions-label">Popular near you</div>
+      <div class="popover-suggestions-row">
+        <button type="button" class="suggestion-chip" data-suggest="weekday-walks">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+          Weekday morning walks
+        </button>
+        <button type="button" class="suggestion-chip" data-suggest="boarding-holidays">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+          Boarding for school holidays
+        </button>
+        <button type="button" class="suggestion-chip" data-suggest="daycare-inner-west">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+          Daycare in Inner West
+        </button>
+        <button type="button" class="suggestion-chip" data-suggest="cat-weekend">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+          Cat sitting · weekend away
+        </button>
+      </div>
+    </div>
+  </div>
 
   <!-- HERO BAND -->
   <section class="hero-band">
@@ -510,6 +708,205 @@
     </div>
     <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>
   </footer>
+
+  <script>
+  (function() {
+    const form = document.getElementById('searchWidget');
+    if (!form) return;
+
+    const SERVICE_META = {
+      dog_walking:  { label: 'Dog walking',   emoji: '🦮' },
+      dog_boarding: { label: 'Dog boarding',  emoji: '🏠' },
+      dog_sitting:  { label: 'Dog sitting',   emoji: '🛋️' },
+      dog_daycare:  { label: 'Dog daycare',   emoji: '☀️' },
+      drop_in:      { label: 'Drop-in visit', emoji: '🐾' },
+      cat_sitting:  { label: 'Cat sitting',   emoji: '🐱' },
+    };
+    const DAY_FULL = { mon:'Mon', tue:'Tue', wed:'Wed', thu:'Thu', fri:'Fri', sat:'Sat', sun:'Sun' };
+
+    const state = { service: 'dog_walking', recurring: false, days: [], date: '', time: '', suburb: '' };
+
+    const timeSel = document.getElementById('timeInput');
+    const TIME_HTML = '<option value="">Any time</option>' +
+      Array.from({ length: 31 }, (_, i) => 6 * 2 + i).map(slot => {
+        const h = Math.floor(slot / 2), m = (slot % 2) * 30;
+        const v = String(h).padStart(2,'0') + ':' + String(m).padStart(2,'0');
+        const display = ((h % 12) || 12) + ':' + String(m).padStart(2,'0') + ' ' + (h < 12 ? 'AM' : 'PM');
+        return '<option value="' + v + '">' + display + '</option>';
+      }).join('');
+    timeSel.innerHTML = TIME_HTML;
+
+    function updatePillSummary() {
+      const meta = SERVICE_META[state.service] || SERVICE_META.dog_walking;
+      document.getElementById('pillSvcEmoji').textContent = meta.emoji;
+      document.getElementById('pillSvcLabel').textContent = meta.label;
+      document.getElementById('pillWhere').textContent = state.suburb || 'Add suburb';
+      let when = 'Any time';
+      if (state.recurring) {
+        when = state.days.length ? state.days.map(d => DAY_FULL[d]).join('·') : 'Recurring';
+      } else if (state.date || state.time) {
+        const parts = [];
+        if (state.date) {
+          try { parts.push(new Date(state.date).toLocaleDateString('en-AU', { weekday: 'short', day: 'numeric', month: 'short' })); } catch (e) { parts.push(state.date); }
+        }
+        if (state.time) {
+          const [hh, mm] = state.time.split(':').map(Number);
+          parts.push(((hh % 12) || 12) + ':' + String(mm).padStart(2,'0') + ' ' + (hh < 12 ? 'AM' : 'PM'));
+        }
+        when = parts.join(' · ');
+      }
+      document.getElementById('pillWhen').textContent = when;
+    }
+
+    const scrim = document.getElementById('popoverScrim');
+    const pop = document.getElementById('searchPopover');
+    function openPopover() {
+      scrim.classList.add('open'); scrim.setAttribute('aria-hidden', 'false');
+      pop.classList.add('open');   pop.setAttribute('aria-hidden', 'false');
+      document.getElementById('searchPill').setAttribute('aria-expanded', 'true');
+      document.body.style.overflow = 'hidden';
+      setTimeout(() => { const s = document.getElementById('suburbInput'); if (s) s.focus(); }, 60);
+    }
+    function closePopover() {
+      scrim.classList.remove('open'); scrim.setAttribute('aria-hidden', 'true');
+      pop.classList.remove('open');   pop.setAttribute('aria-hidden', 'true');
+      document.getElementById('searchPill').setAttribute('aria-expanded', 'false');
+      document.body.style.overflow = '';
+    }
+    document.getElementById('searchPill').addEventListener('click', openPopover);
+    const heroBtn = document.getElementById('heroOpenSearch');
+    if (heroBtn) heroBtn.addEventListener('click', openPopover);
+    document.getElementById('popoverClose').addEventListener('click', closePopover);
+    scrim.addEventListener('click', closePopover);
+    document.addEventListener('keydown', e => { if (e.key === 'Escape' && pop.classList.contains('open')) closePopover(); });
+
+    document.getElementById('svcRow').addEventListener('click', e => {
+      const btn = e.target.closest('.svc-chip');
+      if (!btn) return;
+      state.service = btn.dataset.svc;
+      document.querySelectorAll('.svc-chip').forEach(c => {
+        const on = c === btn;
+        c.classList.toggle('active', on);
+        c.setAttribute('aria-checked', on ? 'true' : 'false');
+      });
+      updatePillSummary();
+    });
+
+    const seg = document.getElementById('modeSeg');
+    seg.addEventListener('click', e => {
+      const btn = e.target.closest('button[data-rec]');
+      if (!btn) return;
+      state.recurring = btn.dataset.rec === 'true';
+      seg.querySelectorAll('button').forEach(b => {
+        const on = b === btn;
+        b.classList.toggle('active', on);
+        b.setAttribute('aria-selected', on ? 'true' : 'false');
+      });
+      renderWhenFields();
+      updatePillSummary();
+    });
+
+    function renderWhenFields() {
+      const wrap = document.getElementById('whenFields');
+      if (state.recurring) {
+        wrap.classList.remove('when-fields');
+        wrap.innerHTML = '<div class="days" id="daysRow">' +
+          ['mon','tue','wed','thu','fri','sat','sun'].map(d => {
+            const label = d === 'thu' ? 'T' : d === 'sat' ? 'S' : d === 'sun' ? 'S' : d[0].toUpperCase();
+            const active = state.days.includes(d);
+            return '<button type="button" class="day-btn' + (active ? ' active' : '') + '" data-day="' + d + '" aria-pressed="' + (active ? 'true' : 'false') + '">' + label + '</button>';
+          }).join('') + '</div>';
+        wrap.querySelector('#daysRow').addEventListener('click', e => {
+          const btn = e.target.closest('[data-day]');
+          if (!btn) return;
+          const d = btn.dataset.day;
+          const i = state.days.indexOf(d);
+          if (i >= 0) state.days.splice(i, 1); else state.days.push(d);
+          const on = state.days.includes(d);
+          btn.classList.toggle('active', on);
+          btn.setAttribute('aria-pressed', on ? 'true' : 'false');
+          updatePillSummary();
+        });
+      } else {
+        wrap.classList.add('when-fields');
+        wrap.innerHTML = `
+          <div class="input-line">
+            <span class="input-icon">
+              <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+            </span>
+            <input type="date" id="dateInput" name="date" value="` + (state.date || '') + `" aria-label="Date">
+          </div>
+          <div class="input-line">
+            <span class="input-icon">
+              <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+            </span>
+            <select id="timeInput" name="time" aria-label="Time"></select>
+          </div>`;
+        const sel = wrap.querySelector('#timeInput');
+        sel.innerHTML = TIME_HTML;
+        sel.value = state.time || '';
+        sel.addEventListener('change', e => { state.time = e.target.value; updatePillSummary(); });
+        wrap.querySelector('#dateInput').addEventListener('change', e => { state.date = e.target.value; updatePillSummary(); });
+      }
+    }
+
+    document.getElementById('dateInput').addEventListener('change', e => { state.date = e.target.value; updatePillSummary(); });
+    timeSel.addEventListener('change', e => { state.time = e.target.value; updatePillSummary(); });
+    document.getElementById('suburbInput').addEventListener('input', e => { state.suburb = e.target.value.trim(); updatePillSummary(); });
+
+    document.querySelectorAll('.suggestion-chip').forEach(chip => {
+      chip.addEventListener('click', () => {
+        const k = chip.dataset.suggest;
+        if (k === 'weekday-walks') {
+          state.service = 'dog_walking'; state.recurring = true; state.days = ['mon','tue','wed','thu','fri']; state.time = '09:00';
+        } else if (k === 'boarding-holidays') {
+          state.service = 'dog_boarding'; state.recurring = false;
+        } else if (k === 'daycare-inner-west') {
+          state.service = 'dog_daycare'; state.suburb = 'Inner West';
+        } else if (k === 'cat-weekend') {
+          state.service = 'cat_sitting'; state.recurring = false;
+        }
+        applyStateToFormUI();
+        form.requestSubmit();
+      });
+    });
+
+    function applyStateToFormUI() {
+      document.querySelectorAll('.svc-chip').forEach(c => {
+        const on = c.dataset.svc === state.service;
+        c.classList.toggle('active', on);
+        c.setAttribute('aria-checked', on ? 'true' : 'false');
+      });
+      const sub = document.getElementById('suburbInput');
+      if (sub) sub.value = state.suburb || '';
+      seg.querySelectorAll('button').forEach(b => {
+        const on = (b.dataset.rec === 'true') === state.recurring;
+        b.classList.toggle('active', on);
+        b.setAttribute('aria-selected', on ? 'true' : 'false');
+      });
+      renderWhenFields();
+      updatePillSummary();
+    }
+
+    form.addEventListener('submit', e => {
+      e.preventDefault();
+      const params = new URLSearchParams();
+      if (state.service) params.set('service', state.service);
+      if (state.suburb) params.set('suburb', state.suburb);
+      if (state.recurring) {
+        params.set('recurring', 'true');
+        if (state.days.length) params.set('days', state.days.join(','));
+        if (state.time) params.set('time', state.time);
+      } else {
+        if (state.date) params.set('date', state.date);
+        if (state.time) params.set('time', state.time);
+      }
+      window.location.href = '/search/' + (params.toString() ? '?' + params.toString() : '');
+    });
+
+    updatePillSummary();
+  })();
+  </script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
Brings the `/about-us/` header to parity with the home page — including the **logo** and the **search box** (the nav search pill that opens the full search popover).

## Changes (`about-us/index.html` only)
- Restructured the nav into the home layout: `nav-left` (logo + links), centre **search pill**, then Sign in / Book a carer.
- Added the **search popover** (service chips, suburb, one-off/recurring date + time, popular-search shortcuts) + scrim.
- Ported the matching CSS (search pill, popover, form controls) and the responsive rules (pill collapses, popover becomes a bottom sheet on mobile).
- Ported the search JS; the home-only `#heroOpenSearch` hook is made **null-safe** so it doesn't error on this page.
- Design tokens are already identical between the two pages, so no colour remapping was needed.

## Testing (verified locally at 1280px)
- ✅ Header matches home: logo + links (Home / **About** active / Services / How it works) + search pill, nav 82px on one row
- ✅ Pill opens the popover; service chips, suburb input update the pill summary
- ✅ Submitting routes to `/search/?service=…&suburb=…` (e.g. `dog_boarding` + `Balmain`)
- ✅ No console errors
- ✅ Page content (hero band, story, etc.) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)