### PR TITLE
Link dashboard Settings tab to profile page (TRU-66)

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -537,10 +537,10 @@ function renderDashboard() {
 
     <!-- Settings placeholder -->
     <div class="tab-content" id="tab-settings">
-      <div class="placeholder-card">
-        <div class="ph-icon">⚙️</div>
-        <h3>Settings coming soon</h3>
-        <p>Change your password, update your email and phone number, and manage notification preferences.</p>
+      <div class="card">
+        <div class="card-title">Profile &amp; account details</div>
+        <p style="font-size:0.88rem;color:var(--text-secondary);line-height:1.55;margin-bottom:1rem;">Update your name, email, phone, suburb and profile photo from your profile page.</p>
+        <a href="/profile/" class="bc-btn start-walk" style="text-decoration:none;display:inline-block;">Edit your profile &amp; settings</a>
       </div>
       <div style="margin-top:1rem;text-align:center;">
         <a href="#" onclick="logout()" style="font-size:0.85rem;color:var(--error);text-decoration:none;">Sign out of your account</a>


### PR DESCRIPTION
## Summary
The provider dashboard's **Settings** tab showed a "coming soon" placeholder, even though profile/account editing already exists at `/profile/`. This points Settings at the real page.

## Change (`dashboard/index.html`)
- Replace the placeholder card with a card linking to `/profile/` ("Edit your profile & settings").
- Sign-out link retained.

Reuses existing CSS classes only; no JS changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)