### PR TITLE
Fix mobile header: inline logo+actions + clean search pill

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -356,15 +356,16 @@
 
     /* ── RESPONSIVE ── */
     @media (max-width: 960px) {
-      nav { padding: 12px 24px; height: auto; gap: 12px; }
+      nav { padding: 12px 20px; height: auto; gap: 12px; }
       .nav-links { display: none; }
-      .nav-left { flex: 1 0 100%; justify-content: space-between; }
-      .nav-actions { order: 2; }
-      .nav-search-pill { order: 3; flex: 1 1 100%; max-width: 100%; grid-template-columns: auto 1fr auto; gap: 10px; padding: 8px 8px 8px 14px; }
-      .nsp-divider:nth-of-type(2), .nsp-divider:nth-of-type(3) { display: none; }
-      .nsp-field:nth-of-type(2), .nsp-field:nth-of-type(3) { display: none; }
-      .nsp-field:first-of-type .nsp-eyebrow { display: none; }
-      .nsp-svc-label { font-size: 13.5px; }
+      .nav-left { flex: 0 1 auto; }
+      .nav-logo svg { width: 116px; }
+      .nav-actions { order: 2; gap: 10px; font-size: 12px; }
+      .nav-actions .btn-primary { padding: 8px 14px; font-size: 12px; }
+      .nav-search-pill { order: 3; flex: 1 1 100%; max-width: 100%; grid-template-columns: 1fr auto; gap: 10px; padding: 10px 10px 10px 16px; }
+      .nsp-divider { display: none; }
+      .nsp-field { display: none; }
+      .nsp-svc-label { font-size: 14px; }
       .popover { top: auto; left: 0; right: 0; bottom: 0; border-radius: 22px 22px 0 0; padding: 18px 18px 24px; max-height: 88vh; transform: translateY(100%); }
       .popover.open { transform: translateY(0); }
       .popover-close { top: 14px; right: 14px; width: 32px; height: 32px; }

--- a/index.html
+++ b/index.html
@@ -237,10 +237,12 @@
 
     /* ── RESPONSIVE ── */
     @media (max-width: 960px) {
-      nav { padding: 12px 24px; height: auto; gap: 12px; }
+      nav { padding: 12px 20px; height: auto; gap: 12px; }
       .nav-links { display: none; }
-      .nav-left { flex: 1 0 100%; justify-content: space-between; }
-      .nav-actions { order: 2; }
+      .nav-left { flex: 0 1 auto; }
+      .nav-logo svg { width: 116px; }
+      .nav-actions { order: 2; gap: 10px; font-size: 12px; }
+      .nav-actions .btn-primary { padding: 8px 14px; font-size: 12px; }
       .nav-search-pill { order: 3; flex: 1 1 100%; max-width: 100%; }
       .hero { grid-template-columns: 1fr; }
       .hero-left { padding: 40px 24px 28px; }
@@ -257,11 +259,10 @@
       .svc-row { gap: 6px; }
       .svc-chip { padding: 9px 12px; font-size: 12.5px; }
       .svc-chip .svc-sub { display: none; }
-      .nsp-divider:nth-of-type(2), .nsp-divider:nth-of-type(3) { display: none; }
-      .nav-search-pill { grid-template-columns: auto 1fr auto; gap: 10px; padding: 8px 8px 8px 14px; }
-      .nsp-field:nth-of-type(2), .nsp-field:nth-of-type(3) { display: none; }
-      .nsp-field:first-of-type .nsp-eyebrow { display: none; }
-      .nsp-svc-label { font-size: 13.5px; }
+      .nav-search-pill { grid-template-columns: 1fr auto; gap: 10px; padding: 10px 10px 10px 16px; }
+      .nsp-divider { display: none; }
+      .nsp-field { display: none; }
+      .nsp-svc-label { font-size: 14px; }
       .strip { padding: 14px 24px; }
       .strip-item { padding: 6px 14px; font-size: 10px; }
       .services { padding: 72px 24px; }


### PR DESCRIPTION
## Problem
On mobile the home (and about-us) header had two issues:
1. **Sign in / Book a carer wrapped onto a row below the logo** instead of sitting inline with it.
2. **The search pill rendered as a broken multi-row grid** (service + When + Pet split awkwardly).

## Fix (`index.html` + `about-us/index.html` — shared header)
- `nav-left` sizes to content (not 100% width), logo shrunk to 116px, and the actions/Book-a-carer button tightened so **logo + Sign in + Book a carer fit on one row**.
- Search pill collapses to a clean **single-line bar** on mobile: service label + search icon (`grid-template-columns: 1fr auto`), hiding the where/when/pet fields — all still editable in the popover that opens on tap.

## Testing
Verified at 375px (mobile preset): logo + actions on one row; pill is a clean "🦮 Dog walking … 🔍" bar. Desktop layout unchanged (changes are inside the `max-width: 960px` media query).

🤖 Generated with [Claude Code](https://claude.com/claude-code)