### PR TITLE
Show uploaded profile photo on search tiles (TRU-67)

### DIFF
--- a/search/index.html
+++ b/search/index.html
@@ -691,7 +691,7 @@ async function fallbackSearch() {
   const userIds = profiles.map(p => p.user_id).filter(Boolean);
   const profileIds = profiles.map(p => p.id);
 
-  const users = userIds.length ? await sbPublic('users', `id=in.(${userIds.join(',')})&select=id,first_name,last_name`) : [];
+  const users = userIds.length ? await sbPublic('users', `id=in.(${userIds.join(',')})&select=id,first_name,last_name,avatar_url`) : [];
   const services = profileIds.length ? await sbPublic('provider_services', `provider_id=in.(${profileIds.join(',')})&is_available=eq.true&select=provider_id,service_type`) : [];
 
   const userMap = Object.fromEntries(users.map(u => [u.id, u]));
@@ -711,6 +711,7 @@ async function fallbackSearch() {
     is_verified: p.is_verified,
     first_name: userMap[p.user_id]?.first_name || '',
     last_name: userMap[p.user_id]?.last_name || '',
+    avatar_url: userMap[p.user_id]?.avatar_url || null,
     services: serviceMap[p.id] || [],
     created_at: p.created_at,
   }));


### PR DESCRIPTION
## Problem
A provider uploads a profile photo (TRU-31), but their **search result tile still shows initials**. The card markup already supports an image — the photo just never reached it.

## Root cause
`provider_search_view` (the search data source) didn't expose `avatar_url`, and the unauthenticated fallback query didn't fetch it either. So `p.avatar_url` was always undefined in `renderCard`.

## Fix
- **DB**: migration `add_avatar_url_to_provider_search_view` recreates the view with `u.avatar_url` (security_invoker preserved). *(Already applied to the project.)*
- **Frontend** (`search/index.html`): the fallback path now selects `avatar_url` from `users` and maps it onto each provider.

No card-rendering changes were needed — it already does `p.avatar_url ? <img> : initials`.

## Testing
Set a test avatar on one provider and loaded `/search/`:
- ✅ View returns `avatar_url`
- ✅ That provider's tile renders `<img>`; all others still show initials (14 cards, 1 with image)
- Test avatar reverted afterwards

⚠️ Note: the DB migration is already live on the project (can't be staged on a branch).
🤖 Generated with [Claude Code](https://claude.com/claude-code)