### PR TITLE
Drop cat services for dogs-only MVP (TRU-68)

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -468,7 +468,6 @@
         <button type="button" class="svc-chip" data-svc="dog_sitting" role="radio" aria-checked="false"><span class="svc-icon-emoji">🛋️</span> Dog sitting <span class="svc-sub">· In your home</span></button>
         <button type="button" class="svc-chip" data-svc="dog_daycare" role="radio" aria-checked="false"><span class="svc-icon-emoji">☀️</span> Dog daycare <span class="svc-sub">· Work hours</span></button>
         <button type="button" class="svc-chip" data-svc="drop_in" role="radio" aria-checked="false"><span class="svc-icon-emoji">🐾</span> Drop-in visit <span class="svc-sub">· Check on your pet</span></button>
-        <button type="button" class="svc-chip" data-svc="cat_sitting" role="radio" aria-checked="false"><span class="svc-icon-emoji">🐱</span> Cat sitting <span class="svc-sub">· In your home</span></button>
       </div>
 
       <div class="when-row">
@@ -527,10 +526,6 @@
         <button type="button" class="suggestion-chip" data-suggest="daycare-inner-west">
           <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
           Daycare in Inner West
-        </button>
-        <button type="button" class="suggestion-chip" data-suggest="cat-weekend">
-          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
-          Cat sitting · weekend away
         </button>
       </div>
     </div>
@@ -721,7 +716,6 @@
       dog_sitting:  { label: 'Dog sitting',   emoji: '🛋️' },
       dog_daycare:  { label: 'Dog daycare',   emoji: '☀️' },
       drop_in:      { label: 'Drop-in visit', emoji: '🐾' },
-      cat_sitting:  { label: 'Cat sitting',   emoji: '🐱' },
     };
     const DAY_FULL = { mon:'Mon', tue:'Tue', wed:'Wed', thu:'Thu', fri:'Fri', sat:'Sat', sun:'Sun' };
 
@@ -864,8 +858,6 @@
           state.service = 'dog_boarding'; state.recurring = false;
         } else if (k === 'daycare-inner-west') {
           state.service = 'dog_daycare'; state.suburb = 'Inner West';
-        } else if (k === 'cat-weekend') {
-          state.service = 'cat_sitting'; state.recurring = false;
         }
         applyStateToFormUI();
         form.requestSubmit();

--- a/book/index.html
+++ b/book/index.html
@@ -169,7 +169,7 @@ const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBh
 
 const SERVICE_LABELS = {
   dog_walking: 'Dog walking', dog_sitting: 'Dog sitting', dog_boarding: 'Dog boarding',
-  cat_sitting: 'Cat sitting', cat_boarding: 'Cat boarding', pet_sitting: 'Other pet sitting'
+  pet_sitting: 'Other pet sitting'
 };
 
 const SPECIES_ICONS = { dog: '🐕', cat: '🐈', other: '🐾' };

--- a/carer/index.html
+++ b/carer/index.html
@@ -287,15 +287,13 @@ const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBh
 
 const SERVICE_LABELS = {
   dog_walking: 'Dog walking', dog_sitting: 'Dog sitting', dog_boarding: 'Dog boarding',
-  cat_sitting: 'Cat sitting', cat_boarding: 'Cat boarding', pet_sitting: 'Other pet sitting'
+  pet_sitting: 'Other pet sitting'
 };
 
 // Hint shown after non-walk services so customers know what the price covers.
 const SERVICE_UNIT_HINT = {
   dog_sitting:  'per visit',
   dog_boarding: 'per night',
-  cat_sitting:  'per visit',
-  cat_boarding: 'per night',
   pet_sitting:  'per visit',
 };
 
@@ -325,7 +323,7 @@ function formatPrice(cents) {
 
 const ATTR_LABELS = {
   has_car: 'Own vehicle', outdoor_space: 'Garden / yard', large_dogs_ok: 'Large dogs OK',
-  cat_experience: 'Cat experience', puppy_experience: 'Puppy experience',
+  puppy_experience: 'Puppy experience',
   senior_pets_ok: 'Senior / special needs', reactive_dogs_ok: 'Reactive dogs OK',
   water_confident: 'Water / swim confident'
 };

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -259,7 +259,7 @@ const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBh
 
 const SERVICE_LABELS = {
   dog_walking:'Dog walking', dog_sitting:'Dog sitting', dog_boarding:'Dog boarding',
-  cat_sitting:'Cat sitting', cat_boarding:'Cat boarding', pet_sitting:'Other pet sitting'
+  pet_sitting:'Other pet sitting'
 };
 
 let authToken = null, authUid = null;
@@ -314,8 +314,6 @@ const SERVICE_CATALOG = [
   { service_type: 'dog_walking',  label: 'Dog walks',          help: 'Choose the walk lengths you offer and set a price for each.', durations: WALK_DURATIONS },
   { service_type: 'dog_sitting',  label: 'Dog sitting',        help: 'Visiting a dog in their home.',                              unitHint: 'per visit' },
   { service_type: 'dog_boarding', label: 'Dog boarding',       help: 'Hosting a dog overnight at your home.',                      unitHint: 'per night' },
-  { service_type: 'cat_sitting',  label: 'Cat sitting',        help: 'Visiting a cat in their home.',                              unitHint: 'per visit' },
-  { service_type: 'cat_boarding', label: 'Cat boarding',       help: 'Hosting a cat overnight at your home.',                      unitHint: 'per night' },
   { service_type: 'pet_sitting',  label: 'Other pet sitting',  help: 'Caring for small pets — rabbits, birds, fish.',              unitHint: 'per visit' },
 ];
 

--- a/index.html
+++ b/index.html
@@ -401,7 +401,6 @@
         <button type="button" class="svc-chip" data-svc="dog_sitting" role="radio" aria-checked="false"><span class="svc-icon-emoji">🛋️</span> Dog sitting <span class="svc-sub">· In your home</span></button>
         <button type="button" class="svc-chip" data-svc="dog_daycare" role="radio" aria-checked="false"><span class="svc-icon-emoji">☀️</span> Dog daycare <span class="svc-sub">· Work hours</span></button>
         <button type="button" class="svc-chip" data-svc="drop_in" role="radio" aria-checked="false"><span class="svc-icon-emoji">🐾</span> Drop-in visit <span class="svc-sub">· Check on your pet</span></button>
-        <button type="button" class="svc-chip" data-svc="cat_sitting" role="radio" aria-checked="false"><span class="svc-icon-emoji">🐱</span> Cat sitting <span class="svc-sub">· In your home</span></button>
       </div>
 
       <div class="when-row">
@@ -461,10 +460,6 @@
           <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
           Daycare in Inner West
         </button>
-        <button type="button" class="suggestion-chip" data-suggest="cat-weekend">
-          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
-          Cat sitting · weekend away
-        </button>
       </div>
     </div>
   </div>
@@ -487,7 +482,6 @@
       dog_sitting:  { label: 'Dog sitting',   emoji: '🛋️' },
       dog_daycare:  { label: 'Dog daycare',   emoji: '☀️' },
       drop_in:      { label: 'Drop-in visit', emoji: '🐾' },
-      cat_sitting:  { label: 'Cat sitting',   emoji: '🐱' },
     };
     const DAY_FULL = { mon:'Mon', tue:'Tue', wed:'Wed', thu:'Thu', fri:'Fri', sat:'Sat', sun:'Sun' };
 
@@ -637,8 +631,6 @@
           state.service = 'dog_boarding'; state.recurring = false;
         } else if (k === 'daycare-inner-west') {
           state.service = 'dog_daycare'; state.suburb = 'Inner West';
-        } else if (k === 'cat-weekend') {
-          state.service = 'cat_sitting'; state.recurring = false;
         }
         applyStateToFormUI();
         form.requestSubmit();
@@ -729,15 +721,6 @@
         <div class="svc-name">Dog sitting</div>
         <div class="svc-desc">In-home visits so your dog stays comfortable in their own environment while you're away.</div>
         <div class="svc-price">From $40 / visit</div>
-      </a>
-      <a href="/search/" class="svc-card">
-        <div class="svc-num">04</div>
-        <div class="svc-icon">
-          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#7A6860" stroke-width="1.5" stroke-linecap="round"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><line x1="9" y1="9" x2="9.01" y2="9"/><line x1="15" y1="9" x2="15.01" y2="9"/></svg>
-        </div>
-        <div class="svc-name">Cat sitting</div>
-        <div class="svc-desc">Regular visits, feeding, play and photo updates so you know your cat is happy and settled.</div>
-        <div class="svc-price">From $30 / visit</div>
       </a>
     </div>
   </section>

--- a/login/index.html
+++ b/login/index.html
@@ -530,12 +530,11 @@ let customerProfileId = null;
 
 const SERVICES = [
   { key: 'dog_walking', label: 'Dog walking' }, { key: 'dog_sitting', label: 'Dog sitting' },
-  { key: 'dog_boarding', label: 'Dog boarding' }, { key: 'cat_sitting', label: 'Cat sitting' },
-  { key: 'cat_boarding', label: 'Cat boarding' }, { key: 'pet_sitting', label: 'Other pet sitting' }
+  { key: 'dog_boarding', label: 'Dog boarding' }, { key: 'pet_sitting', label: 'Other pet sitting' }
 ];
 const ATTRIBUTES = [
   { key: 'has_car', label: 'Own vehicle' }, { key: 'outdoor_space', label: 'Garden / yard' },
-  { key: 'large_dogs_ok', label: 'Large dogs OK' }, { key: 'cat_experience', label: 'Cat experience' },
+  { key: 'large_dogs_ok', label: 'Large dogs OK' },
   { key: 'puppy_experience', label: 'Puppy experience' }, { key: 'senior_pets_ok', label: 'Senior / special needs' },
   { key: 'reactive_dogs_ok', label: 'Reactive dogs OK' }, { key: 'water_confident', label: 'Water / swim confident' }
 ];

--- a/my/index.html
+++ b/my/index.html
@@ -162,7 +162,7 @@ const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBh
 
 const SERVICE_LABELS = {
   dog_walking:'Dog walking', dog_sitting:'Dog sitting', dog_boarding:'Dog boarding',
-  cat_sitting:'Cat sitting', cat_boarding:'Cat boarding', pet_sitting:'Other pet sitting'
+  pet_sitting:'Other pet sitting'
 };
 
 let authToken = null, authUid = null;

--- a/register/index.html
+++ b/register/index.html
@@ -629,8 +629,6 @@ const SERVICES = [
   { key: 'dog_walking', label: 'Dog walking' },
   { key: 'dog_sitting', label: 'Dog sitting' },
   { key: 'dog_boarding', label: 'Dog boarding' },
-  { key: 'cat_sitting', label: 'Cat sitting' },
-  { key: 'cat_boarding', label: 'Cat boarding' },
   { key: 'pet_sitting', label: 'Other pet sitting' }
 ];
 
@@ -638,7 +636,6 @@ const ATTRIBUTES = [
   { key: 'has_car', label: 'Own vehicle' },
   { key: 'outdoor_space', label: 'Garden / yard' },
   { key: 'large_dogs_ok', label: 'Large dogs OK' },
-  { key: 'cat_experience', label: 'Cat experience' },
   { key: 'puppy_experience', label: 'Puppy experience' },
   { key: 'senior_pets_ok', label: 'Senior / special needs' },
   { key: 'reactive_dogs_ok', label: 'Reactive dogs OK' },

--- a/review/index.html
+++ b/review/index.html
@@ -176,7 +176,7 @@ const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBh
 
 const SERVICE_LABELS = {
   dog_walking: 'Dog walking', dog_sitting: 'Dog sitting', dog_boarding: 'Dog boarding',
-  cat_sitting: 'Cat sitting', cat_boarding: 'Cat boarding', pet_sitting: 'Other pet sitting'
+  pet_sitting: 'Other pet sitting'
 };
 
 const RATING_LABELS = {

--- a/search/index.html
+++ b/search/index.html
@@ -278,8 +278,6 @@ const SERVICE_LABELS = {
   dog_boarding: 'Dog boarding',
   dog_daycare:  'Dog daycare',
   drop_in:      'Drop-in visit',
-  cat_sitting:  'Cat sitting',
-  cat_boarding: 'Cat boarding',
   pet_sitting:  'Other pet sitting'
 };
 
@@ -289,7 +287,6 @@ const SERVICES = [
   { value: 'dog_sitting',   label: 'Dog sitting',    icon: '🛋️', sub: 'In your home' },
   { value: 'dog_daycare',   label: 'Dog daycare',    icon: '☀️', sub: 'During work hours' },
   { value: 'drop_in',       label: 'Drop-in visit',  icon: '🐾', sub: 'Check on your pet' },
-  { value: 'cat_sitting',   label: 'Cat sitting',    icon: '🐱', sub: 'In your home' },
 ];
 
 const ATTRIBUTE_FILTERS = [
@@ -318,7 +315,6 @@ const ATTR_LABELS = {
   large_dogs_ok:    { label: 'Large dogs OK',    icon: '🐕' },
   puppy_experience: { label: 'Puppies OK',       icon: '🐶' },
   reactive_dogs_ok: { label: 'Anxiety',          icon: '💙' },
-  cat_experience:   { label: 'Cat experience',   icon: '🐱' },
   senior_pets_ok:   { label: 'Seniors',          icon: '🐾' },
   water_confident:  { label: 'Water confident',  icon: '💧' },
 };


### PR DESCRIPTION
## Summary
Removes cat services everywhere so the MVP launches dogs-only (TRU-68).

## Removed (`cat_sitting`, `cat_boarding`, + "Cat experience" attribute)
- **Home + about-us**: search popover service chip, the "Cat sitting · weekend away" suggestion (+ its handler), `SERVICE_META`, and the home services-showcase card
- **Search**: service filter option, `SERVICE_LABELS`, and the `cat_experience` attribute label
- **Provider dashboard**: service catalog rows + label map
- **Register / Login**: provider service + attribute pickers
- **Shared label maps**: book, review, carer, my

## Data
Existing `cat_sitting`/`cat_boarding` rows in `provider_services` are **disabled** (`is_available = false`) rather than deleted — `bookings.service_id` may reference them, so a hard delete would hit the same FK conflict as TRU-49. Search and carer profiles both filter `is_available = true`, so disabled cat services no longer surface.

## Testing
- ✅ Home popover now offers 5 dog-only services; no cat chip/card; popover opens and chips work; no console errors
- ✅ Search + register HTML have zero cat-service references
- ✅ DB: 5 cat service rows now `is_available = false`

## Decisions to confirm
- **`pet_sitting` ("Other pet sitting" — rabbits/birds/fish) was kept.** The ticket says "anything not dog related," which could include this. Say the word and I'll drop it too.
- **Pet-species pickers (dog/cat/other for a customer's pet) left intact** — separate from cat *services*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)