### PR TITLE
Fix signup flow: one step per screen + inline service checkboxes

### DIFF
--- a/login/index.html
+++ b/login/index.html
@@ -173,7 +173,9 @@
   .success-card p { color: var(--text-secondary); font-size: 0.92rem; line-height: 1.6; max-width: 400px; margin: 0 auto; }
 
   .checkbox-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
-  .checkbox-item {
+  .form-step { display: none; }
+  .form-step.active { display: block; }
+  .checkbox-grid .checkbox-item {
     display: flex; align-items: center; gap: 8px; padding: 10px 12px;
     border: 1px solid var(--border); border-radius: 10px; cursor: pointer;
     transition: all 0.2s; user-select: none;


### PR DESCRIPTION
## Problems (on `/login/` signup)
1. **All steps showed at once** — the multi-step panels rendered stacked on a single long page instead of one step at a time.
2. **Service checkboxes stacked above their labels** on the provider "Your services" step.

## Root causes
1. There was **no CSS for `.form-step`** — `showStep()` toggled an `.active` class, but nothing hid inactive panels. (The `/register/` page already had this rule; `/login/` didn't.)
2. The checkbox items are `<label class="checkbox-item">` inside a `.field`, and `.field label { display: block }` (specificity 0,1,1) overrode `.checkbox-item { display: flex }` (0,1,0) — forcing them to stack.

## Fix (`login/index.html`, CSS only)
- Add `.form-step { display: none }` / `.form-step.active { display: block }`.
- Scope the checkbox rule to `.checkbox-grid .checkbox-item` (0,2,0) so its inline flex layout wins.

## Testing (verified live)
- ✅ On load only step 1 is visible; navigating shows exactly one step (`pStep3` alone)
- ✅ Checkbox computed `display: flex` / `row` — box + label inline (see screenshot-confirmed render)
- ✅ Applies to both customer and provider flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)