### PR TITLE
TRU-69: per-service date filters (boarding/sitting get start+end dates)

### DIFF
--- a/book/index.html
+++ b/book/index.html
@@ -172,6 +172,8 @@ const SERVICE_LABELS = {
   pet_sitting: 'Other pet sitting'
 };
 
+const MULTI_DAY_SERVICES = ['dog_boarding', 'dog_sitting'];
+
 const SPECIES_ICONS = { dog: '🐕', cat: '🐈', other: '🐾' };
 
 let authToken = null, authUid = null;
@@ -209,6 +211,67 @@ function setLoading(btn, on) {
 function selectService(el, serviceId) {
   document.querySelectorAll('.service-option').forEach(s => s.classList.remove('selected'));
   el.classList.add('selected'); selectedServiceId = serviceId;
+  const svcType = el.querySelector('input')?.dataset.svcType;
+  document.getElementById('dateFields').innerHTML = renderDateFields(MULTI_DAY_SERVICES.includes(svcType));
+}
+
+function renderDateFields(isMultiDay) {
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const defaultDate = tomorrow.toISOString().split('T')[0];
+  if (isMultiDay) {
+    const dayAfter = new Date();
+    dayAfter.setDate(dayAfter.getDate() + 2);
+    const defaultEnd = dayAfter.toISOString().split('T')[0];
+    return `
+      <div class="field-row">
+        <div class="field">
+          <label>Check-in date</label>
+          <input type="date" id="bookDate" value="${defaultDate}" min="${defaultDate}">
+        </div>
+        <div class="field">
+          <label>Check-out date</label>
+          <input type="date" id="bookDateEnd" value="${defaultEnd}" min="${defaultDate}">
+        </div>
+      </div>
+    `;
+  }
+  return `
+    <div class="field-row">
+      <div class="field">
+        <label>Date</label>
+        <input type="date" id="bookDate" value="${defaultDate}" min="${defaultDate}">
+      </div>
+      <div class="field">
+        <label>Time</label>
+        <select id="bookTime">
+          <option value="07:00">7:00 AM</option>
+          <option value="07:30">7:30 AM</option>
+          <option value="08:00" selected>8:00 AM</option>
+          <option value="08:30">8:30 AM</option>
+          <option value="09:00">9:00 AM</option>
+          <option value="09:30">9:30 AM</option>
+          <option value="10:00">10:00 AM</option>
+          <option value="10:30">10:30 AM</option>
+          <option value="11:00">11:00 AM</option>
+          <option value="11:30">11:30 AM</option>
+          <option value="12:00">12:00 PM</option>
+          <option value="12:30">12:30 PM</option>
+          <option value="13:00">1:00 PM</option>
+          <option value="13:30">1:30 PM</option>
+          <option value="14:00">2:00 PM</option>
+          <option value="14:30">2:30 PM</option>
+          <option value="15:00">3:00 PM</option>
+          <option value="15:30">3:30 PM</option>
+          <option value="16:00">4:00 PM</option>
+          <option value="16:30">4:30 PM</option>
+          <option value="17:00">5:00 PM</option>
+          <option value="17:30">5:30 PM</option>
+          <option value="18:00">6:00 PM</option>
+        </select>
+      </div>
+    </div>
+  `;
 }
 
 function selectPet(el, petId) {
@@ -225,9 +288,9 @@ function renderBookingForm() {
     (s, i, arr) => arr.findIndex(x => x.service_type === s.service_type) === i
   );
 
-  const servicesHtml = uniqueServices.map(s => `
-    <label class="service-option" onclick="selectService(this, '${s.id}')">
-      <input type="radio" name="service" value="${s.id}">
+  const servicesHtml = uniqueServices.map((s, i) => `
+    <label class="service-option${i === 0 ? ' selected' : ''}" onclick="selectService(this, '${s.id}')">
+      <input type="radio" name="service" value="${s.id}" data-svc-type="${s.service_type}" ${i === 0 ? 'checked' : ''}>
       <div class="svc-name">${SERVICE_LABELS[s.service_type] || s.service_type.replace(/_/g, ' ')}</div>
     </label>
   `).join('');
@@ -240,13 +303,12 @@ function renderBookingForm() {
     </label>
   `).join('');
 
-  // Auto-select first pet
   if (customerPets.length > 0) selectedPetId = customerPets[0].id;
 
-  // Default date to tomorrow
-  const tomorrow = new Date();
-  tomorrow.setDate(tomorrow.getDate() + 1);
-  const defaultDate = tomorrow.toISOString().split('T')[0];
+  // Determine if first service is multi-day to set initial date fields
+  const firstSvcIsMultiDay = uniqueServices.length > 0 && MULTI_DAY_SERVICES.includes(uniqueServices[0].service_type);
+  // Auto-select first service
+  if (uniqueServices.length > 0) selectedServiceId = uniqueServices[0].id;
 
   area.innerHTML = `
     <div class="page-header">
@@ -268,40 +330,7 @@ function renderBookingForm() {
         <div class="service-grid">${servicesHtml}</div>
       </div>
 
-      <div class="field-row">
-        <div class="field">
-          <label>Date</label>
-          <input type="date" id="bookDate" value="${defaultDate}" min="${defaultDate}">
-        </div>
-        <div class="field">
-          <label>Time</label>
-          <select id="bookTime">
-            <option value="07:00">7:00 AM</option>
-            <option value="07:30">7:30 AM</option>
-            <option value="08:00" selected>8:00 AM</option>
-            <option value="08:30">8:30 AM</option>
-            <option value="09:00">9:00 AM</option>
-            <option value="09:30">9:30 AM</option>
-            <option value="10:00">10:00 AM</option>
-            <option value="10:30">10:30 AM</option>
-            <option value="11:00">11:00 AM</option>
-            <option value="11:30">11:30 AM</option>
-            <option value="12:00">12:00 PM</option>
-            <option value="12:30">12:30 PM</option>
-            <option value="13:00">1:00 PM</option>
-            <option value="13:30">1:30 PM</option>
-            <option value="14:00">2:00 PM</option>
-            <option value="14:30">2:30 PM</option>
-            <option value="15:00">3:00 PM</option>
-            <option value="15:30">3:30 PM</option>
-            <option value="16:00">4:00 PM</option>
-            <option value="16:30">4:30 PM</option>
-            <option value="17:00">5:00 PM</option>
-            <option value="17:30">5:30 PM</option>
-            <option value="18:00">6:00 PM</option>
-          </select>
-        </div>
-      </div>
+      <div id="dateFields">${renderDateFields(firstSvcIsMultiDay)}</div>
 
       ${customerPets.length > 1 ? `<div class="field"><label>Which pet?</label><div class="pet-grid">${petsHtml}</div></div>` : ''}
 
@@ -333,12 +362,23 @@ async function submitBooking() {
   if (!selectedPetId) return showMsg('No pet found on your account. Please add a pet first.', 'error');
 
   const date = document.getElementById('bookDate').value;
-  const time = document.getElementById('bookTime').value;
   const notes = document.getElementById('bookNotes').value.trim();
 
-  if (!date || !time) return showMsg('Please select a date and time.', 'error');
+  const selectedSvc = providerServices.find(s => s.id === selectedServiceId);
+  const isMultiDay = MULTI_DAY_SERVICES.includes(selectedSvc?.service_type);
 
-  const scheduledAt = new Date(`${date}T${time}:00`).toISOString();
+  let scheduledAt, endsAt = null;
+  if (isMultiDay) {
+    const dateEnd = document.getElementById('bookDateEnd')?.value;
+    if (!date || !dateEnd) return showMsg('Please select both a check-in and check-out date.', 'error');
+    if (dateEnd <= date) return showMsg('Check-out date must be after check-in date.', 'error');
+    scheduledAt = new Date(`${date}T12:00:00`).toISOString();
+    endsAt = new Date(`${dateEnd}T12:00:00`).toISOString();
+  } else {
+    const time = document.getElementById('bookTime')?.value;
+    if (!date || !time) return showMsg('Please select a date and time.', 'error');
+    scheduledAt = new Date(`${date}T${time}:00`).toISOString();
+  }
 
   const btn = document.querySelector('.btn-primary');
   setLoading(btn, true);
@@ -351,6 +391,7 @@ async function submitBooking() {
       service_id: selectedServiceId,
       status: 'pending',
       scheduled_at: scheduledAt,
+      ends_at: endsAt,
       total_cents: 0,
       customer_notes: notes || null
     }, authToken);

--- a/search/index.html
+++ b/search/index.html
@@ -337,9 +337,11 @@ let myPets = [];
 let isLoading = false;
 
 const state = {
-  suburb: '', service: '', recurring: false, date: '', time: '',
+  suburb: '', service: '', recurring: false, date: '', dateEnd: '', time: '',
   days: [], size: '', puppy: false, petId: '', attributes: [], sort: 'best',
 };
+
+const MULTI_DAY_SERVICES = ['dog_boarding', 'dog_sitting'];
 
 /* ── FIX 1: Public REST helper — always uses anon key, never authToken ── */
 /* Used for all provider search queries so unauthenticated users can browse */
@@ -393,6 +395,7 @@ function readUrlParams() {
   state.suburb    = p.get('suburb')  || '';
   state.recurring = p.get('recurring') === 'true';
   state.date      = p.get('date') || '';
+  state.dateEnd   = p.get('date_end') || '';
   state.time      = p.get('time') || '';
   state.size      = p.get('size') || '';
   state.puppy     = p.get('puppy') === 'true';
@@ -410,6 +413,7 @@ function writeUrlParams() {
   set('suburb',  state.suburb);
   set('recurring', state.recurring ? 'true' : '');
   set('date', state.date);
+  set('date_end', state.dateEnd);
   set('time', state.time);
   set('size', state.size);
   set('puppy', state.puppy ? 'true' : '');
@@ -504,6 +508,10 @@ function renderFilterForm() {
   return html;
 }
 
+function isMultiDayService() {
+  return MULTI_DAY_SERVICES.includes(state.service);
+}
+
 function renderWhenFields() {
   if (state.recurring) {
     return `
@@ -515,6 +523,18 @@ function renderWhenFields() {
       <div class="input-row">
         <input type="date" class="input-base" id="inputDate" value="${esc(state.date)}" aria-label="Start date">
         <select class="input-base" id="inputTime" aria-label="Time">${timeOptions()}</select>
+      </div>
+    `;
+  }
+  if (isMultiDayService()) {
+    return `
+      <div class="input-row">
+        <input type="date" class="input-base" id="inputDate" value="${esc(state.date)}" aria-label="Check-in date">
+        <input type="date" class="input-base" id="inputDateEnd" value="${esc(state.dateEnd)}" aria-label="Check-out date">
+      </div>
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:2px;">
+        <span style="font-size:0.68rem;letter-spacing:.1em;text-transform:uppercase;color:var(--text-muted);padding-left:2px;">Check-in</span>
+        <span style="font-size:0.68rem;letter-spacing:.1em;text-transform:uppercase;color:var(--text-muted);padding-left:2px;">Check-out</span>
       </div>
     `;
   }
@@ -544,6 +564,9 @@ function wireFilterForm(root) {
       const v = tile.dataset.svc;
       state.service = (state.service === v) ? '' : v;
       document.querySelectorAll('.service-tile').forEach(t => t.classList.toggle('active', t.dataset.svc === state.service));
+      // Re-render when fields — multi-day vs single-date depends on service
+      document.querySelectorAll('#whenFields').forEach(el => el.innerHTML = renderWhenFields());
+      wireWhenFields();
     });
   });
 
@@ -601,6 +624,9 @@ function wireWhenFields(root) {
   scope.querySelectorAll('#inputDate').forEach(input => {
     input.addEventListener('change', e => { state.date = e.target.value; });
   });
+  scope.querySelectorAll('#inputDateEnd').forEach(input => {
+    input.addEventListener('change', e => { state.dateEnd = e.target.value; });
+  });
   scope.querySelectorAll('#inputTime').forEach(input => {
     input.addEventListener('change', e => { state.time = e.target.value; });
   });
@@ -641,7 +667,8 @@ function renderMobileSummary() {
   const sec = [];
   if (state.recurring && state.days.length) sec.push(state.days.map(d => DAY_FULL[d]).join('/'));
   else if (state.recurring) sec.push('Recurring');
-  if (state.date) sec.push(state.date);
+  if (state.date && state.dateEnd) sec.push(state.date + ' → ' + state.dateEnd);
+  else if (state.date) sec.push(state.date);
   if (state.time) sec.push(state.time);
   if (state.size) sec.push(state.size + ' dog');
   document.getElementById('msSecondary').textContent = sec.join(' · ') || 'Tap to refine';
@@ -926,7 +953,7 @@ async function runSearch() {
 }
 
 function clearFilters() {
-  state.suburb = ''; state.service = ''; state.recurring = false; state.date = '';
+  state.suburb = ''; state.service = ''; state.recurring = false; state.date = ''; state.dateEnd = '';
   state.time = ''; state.days = []; state.size = ''; state.puppy = false;
   state.petId = ''; state.attributes = []; state.sort = 'best';
   mountFilterForm();


### PR DESCRIPTION
## Summary
- Dog boarding and dog sitting now show **check-in + check-out** date pickers in the search filter and booking form
- Dog walking, daycare, and drop-in keep the original single date + time inputs
- Adds `ends_at` column to `bookings` table (migration applied); stored on submit for multi-day services
- Search filter re-renders when fields when service tile is toggled
- URL params updated to include `date_end` for sharable/bookmarkable multi-day searches

## Test plan
- [ ] Search: select Dog boarding → When section shows two date fields (Check-in / Check-out)
- [ ] Search: select Dog sitting → same two-date layout
- [ ] Search: select Dog walking → reverts to single date + time picker
- [ ] Search: clear service → reverts to single date + time
- [ ] Book page: provider with boarding service → booking form shows Check-in / Check-out
- [ ] Book page: submit with check-out ≤ check-in → validation error shown
- [ ] Book page: valid multi-day booking submits; `ends_at` populated in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)