### PR TITLE
TRU-69 follow-up: tidy multi-day filter UI

### DIFF
--- a/search/index.html
+++ b/search/index.html
@@ -512,6 +512,17 @@ function isMultiDayService() {
   return MULTI_DAY_SERVICES.includes(state.service);
 }
 
+/* Boarding/sitting are always one-off multi-day stays — hide the
+   One-off/Recurring toggle and force recurring off for those services. */
+function syncWhenSection() {
+  const multi = isMultiDayService();
+  if (multi && state.recurring) state.recurring = false;
+  document.querySelectorAll('.segmented').forEach(el => el.style.display = multi ? 'none' : 'flex');
+  document.querySelectorAll('.segmented button').forEach(b => b.classList.toggle('active', (b.dataset.rec === 'true') === state.recurring));
+  document.querySelectorAll('#whenFields').forEach(el => el.innerHTML = renderWhenFields());
+  wireWhenFields();
+}
+
 function renderWhenFields() {
   if (state.recurring) {
     return `
@@ -529,12 +540,14 @@ function renderWhenFields() {
   if (isMultiDayService()) {
     return `
       <div class="input-row">
-        <input type="date" class="input-base" id="inputDate" value="${esc(state.date)}" aria-label="Check-in date">
-        <input type="date" class="input-base" id="inputDateEnd" value="${esc(state.dateEnd)}" aria-label="Check-out date">
-      </div>
-      <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:2px;">
-        <span style="font-size:0.68rem;letter-spacing:.1em;text-transform:uppercase;color:var(--text-muted);padding-left:2px;">Check-in</span>
-        <span style="font-size:0.68rem;letter-spacing:.1em;text-transform:uppercase;color:var(--text-muted);padding-left:2px;">Check-out</span>
+        <div>
+          <div class="field-label" style="margin-bottom:5px;">Check-in</div>
+          <input type="date" class="input-base" id="inputDate" value="${esc(state.date)}" aria-label="Check-in date">
+        </div>
+        <div>
+          <div class="field-label" style="margin-bottom:5px;">Check-out</div>
+          <input type="date" class="input-base" id="inputDateEnd" value="${esc(state.dateEnd)}" aria-label="Check-out date">
+        </div>
       </div>
     `;
   }
@@ -553,6 +566,7 @@ function mountFilterForm() {
   mobile.innerHTML = renderFilterForm();
   wireFilterForm(desktop);
   wireFilterForm(mobile);
+  syncWhenSection();
 }
 
 function wireFilterForm(root) {
@@ -565,8 +579,7 @@ function wireFilterForm(root) {
       state.service = (state.service === v) ? '' : v;
       document.querySelectorAll('.service-tile').forEach(t => t.classList.toggle('active', t.dataset.svc === state.service));
       // Re-render when fields — multi-day vs single-date depends on service
-      document.querySelectorAll('#whenFields').forEach(el => el.innerHTML = renderWhenFields());
-      wireWhenFields();
+      syncWhenSection();
     });
   });
 


### PR DESCRIPTION
Follow-up tweaks to the TRU-69 date filters (the main change merged in #20). These commits landed on the branch after #20 was already merged, so they need a separate PR.

## Changes
- **Check-in / Check-out labels above the inputs** — matches the sidebar's standard field-label style (previously sat awkwardly below the inputs).
- **Hide the One-off/Recurring toggle for boarding and sitting** — those services are always one-off multi-day stays, so `recurring` is forced off and the segmented control is hidden when either is selected.

## Test plan
- [ ] Search: select Dog boarding or Dog sitting → no One-off/Recurring toggle; Check-in / Check-out labels sit above the date pickers
- [ ] Search: select Dog walking / drop-in → toggle reappears, single date + time
- [ ] Set Recurring on a walk, switch to boarding → recurring resets to off

🤖 Generated with [Claude Code](https://claude.com/claude-code)