### PR TITLE
TRU-69: fix date-range inputs overflowing the search sidebar

### DIFF
--- a/search/index.html
+++ b/search/index.html
@@ -79,6 +79,9 @@
 
   /* Date / time inputs */
   .input-row { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+  /* Grid items default to min-width:auto; date inputs have a large intrinsic
+     min-width and would otherwise blow out of the 300px sidebar track. */
+  .input-row > * { min-width: 0; }
   .input-base { width: 100%; padding: 9px 11px; border: 1px solid var(--border); border-radius: 10px; font-family: 'DM Sans', sans-serif; font-size: 0.85rem; color: var(--text-primary); background: var(--warm-white); outline: none; transition: border-color 0.2s, box-shadow 0.2s; }
   .input-base:focus { border-color: var(--border-focus); box-shadow: 0 0 0 3px rgba(196,117,91,0.10); }
 


### PR DESCRIPTION
Follow-up bug fix for the TRU-69 date filters. With Dog boarding / Dog sitting selected, the two side-by-side date inputs overflowed the 300px sidebar — check-out spilled past the right edge and the left-hand field labels (WHEN, CHECK-IN, PET SIZE…) clipped.

## Cause
CSS grid items default to `min-width: auto`, and `<input type="date">` has a large intrinsic minimum width. The two inputs refused to shrink below it and blew out of the `1fr 1fr` track.

## Fix
Add `.input-row > * { min-width: 0; }` so the grid children can shrink to their track.

## Verified
Boarding selected → card `scrollWidth` (298) ≤ card width (300), no overflow, check-out input stays within the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)