### PR TITLE
TRU-75: multi-pet bookings

### DIFF
--- a/book/index.html
+++ b/book/index.html
@@ -179,7 +179,7 @@ const SPECIES_ICONS = { dog: '🐕', cat: '🐈', other: '🐾' };
 let authToken = null, authUid = null;
 let providerData = null, providerProfile = null, providerServices = [];
 let customerProfile = null, customerPets = [];
-let selectedServiceId = null, selectedPetId = null;
+let selectedServiceId = null, selectedPetIds = [];
 
 function headers(token) {
   const h = { 'Content-Type': 'application/json', 'apikey': SUPABASE_ANON_KEY, 'Authorization': `Bearer ${SUPABASE_ANON_KEY}` };
@@ -274,9 +274,13 @@ function renderDateFields(isMultiDay) {
   `;
 }
 
-function selectPet(el, petId) {
-  document.querySelectorAll('.pet-option').forEach(p => p.classList.remove('selected'));
-  el.classList.add('selected'); selectedPetId = petId;
+function onPetToggle(input) {
+  const petId = input.value;
+  const i = selectedPetIds.indexOf(petId);
+  if (input.checked && i < 0) selectedPetIds.push(petId);
+  else if (!input.checked && i >= 0) selectedPetIds.splice(i, 1);
+  const opt = input.closest('.pet-option');
+  if (opt) opt.classList.toggle('selected', input.checked);
 }
 
 function renderBookingForm() {
@@ -296,14 +300,14 @@ function renderBookingForm() {
   `).join('');
 
   const petsHtml = customerPets.map((p, i) => `
-    <label class="pet-option ${i === 0 ? 'selected' : ''}" onclick="selectPet(this, '${p.id}')">
-      <input type="radio" name="pet" value="${p.id}" ${i === 0 ? 'checked' : ''}>
+    <label class="pet-option ${i === 0 ? 'selected' : ''}">
+      <input type="checkbox" name="pet" value="${p.id}" ${i === 0 ? 'checked' : ''} onchange="onPetToggle(this)">
       <span class="pet-icon">${SPECIES_ICONS[p.species] || '🐾'}</span>
       <div><div class="pet-name">${p.name}</div>${p.breed ? `<div class="pet-breed">${p.breed}</div>` : ''}</div>
     </label>
   `).join('');
 
-  if (customerPets.length > 0) selectedPetId = customerPets[0].id;
+  if (customerPets.length > 0) selectedPetIds = [customerPets[0].id];
 
   // Determine if first service is multi-day to set initial date fields
   const firstSvcIsMultiDay = uniqueServices.length > 0 && MULTI_DAY_SERVICES.includes(uniqueServices[0].service_type);
@@ -332,7 +336,7 @@ function renderBookingForm() {
 
       <div id="dateFields">${renderDateFields(firstSvcIsMultiDay)}</div>
 
-      ${customerPets.length > 1 ? `<div class="field"><label>Which pet?</label><div class="pet-grid">${petsHtml}</div></div>` : ''}
+      ${customerPets.length > 1 ? `<div class="field"><label>Which pets? <span class="optional">(select one or more)</span></label><div class="pet-grid">${petsHtml}</div></div>` : ''}
 
       <div class="field">
         <label>Notes for the carer <span class="optional">(optional)</span></label>
@@ -358,8 +362,8 @@ function renderBookingForm() {
 async function submitBooking() {
   clearMsg();
   if (!selectedServiceId) return showMsg('Please select a service.', 'error');
-  if (!selectedPetId && customerPets.length > 0) selectedPetId = customerPets[0].id;
-  if (!selectedPetId) return showMsg('No pet found on your account. Please add a pet first.', 'error');
+  if (!selectedPetIds.length && customerPets.length > 0) selectedPetIds = [customerPets[0].id];
+  if (!selectedPetIds.length) return showMsg('Please select at least one pet.', 'error');
 
   const date = document.getElementById('bookDate').value;
   const notes = document.getElementById('bookNotes').value.trim();
@@ -384,10 +388,12 @@ async function submitBooking() {
   setLoading(btn, true);
 
   try {
-    await sbInsert('bookings', {
+    // pet_id keeps the first selected pet as the "primary" for backward compat;
+    // every selected pet (including the primary) is recorded in booking_pets.
+    const inserted = await sbInsert('bookings', {
       customer_id: customerProfile.id,
       provider_id: providerProfile.id,
-      pet_id: selectedPetId,
+      pet_id: selectedPetIds[0],
       service_id: selectedServiceId,
       status: 'pending',
       scheduled_at: scheduledAt,
@@ -395,6 +401,11 @@ async function submitBooking() {
       total_cents: 0,
       customer_notes: notes || null
     }, authToken);
+
+    const booking = Array.isArray(inserted) ? inserted[0] : inserted;
+    if (booking && booking.id) {
+      await sbInsert('booking_pets', selectedPetIds.map(pid => ({ booking_id: booking.id, pet_id: pid })), authToken);
+    }
 
     document.getElementById('bookingContent').innerHTML = `
       <div class="form-card success-card fade-in">

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -391,8 +391,17 @@ async function loadBookings() {
         const users = await sbGet('users', `id=eq.${custs[0].user_id}&select=first_name,last_name`);
         if (users.length) b._customer_name = `${users[0].first_name} ${users[0].last_name}`;
       }
-      const pets = await sbGet('pets', `id=eq.${b.pet_id}&select=name,breed,species`);
-      if (pets.length) b._pet = pets[0];
+      let pets = [];
+      try {
+        const bp = await sbGet('booking_pets', `booking_id=eq.${b.id}&select=pet_id`);
+        const ids = bp.map(r => r.pet_id).filter(Boolean);
+        if (ids.length) pets = await sbGet('pets', `id=in.(${ids.join(',')})&select=name,breed,species`);
+      } catch(e) {}
+      if (!pets.length && b.pet_id) pets = await sbGet('pets', `id=eq.${b.pet_id}&select=name,breed,species`);
+      b._pet = pets[0] || null;
+      b._pet_label = pets.length
+        ? (pets.length === 1 ? pets[0].name + (pets[0].breed ? ' · ' + pets[0].breed : '') : pets.map(p => p.name).filter(Boolean).join(' + '))
+        : 'Pet';
 
       const svcs = await sbGet('provider_services', `id=eq.${b.service_id}&select=service_type`);
       if (svcs.length) b._service_type = svcs[0].service_type;
@@ -413,7 +422,7 @@ function renderBookingsTab() {
       <div class="booking-card">
         <div class="bc-info">
           <div class="bc-customer">${b._customer_name || 'Customer'}</div>
-          <div class="bc-pet">${b._pet ? `${b._pet.name}${b._pet.breed ? ' · ' + b._pet.breed : ''}` : 'Pet'}</div>
+          <div class="bc-pet">${b._pet_label || 'Pet'}</div>
           <span class="bc-service">${SERVICE_LABELS[b._service_type] || b._service_type || 'Service'}</span>
           <div class="bc-time">${formatDate(b.scheduled_at)}</div>
           ${b.customer_notes ? `<div class="bc-notes">"${b.customer_notes}"</div>` : ''}
@@ -432,7 +441,7 @@ function renderBookingsTab() {
       <div class="booking-card">
         <div class="bc-info">
           <div class="bc-customer">${b._customer_name || 'Customer'}</div>
-          <div class="bc-pet">${b._pet ? `${b._pet.name}${b._pet.breed ? ' · ' + b._pet.breed : ''}` : 'Pet'}</div>
+          <div class="bc-pet">${b._pet_label || 'Pet'}</div>
           <span class="bc-service">${SERVICE_LABELS[b._service_type] || b._service_type || 'Service'}</span>
           <div class="bc-time">${formatDate(b.scheduled_at)}</div>
           ${b.customer_notes ? `<div class="bc-notes">"${b.customer_notes}"</div>` : ''}

--- a/my/index.html
+++ b/my/index.html
@@ -713,8 +713,17 @@ async function init() {
           const pUsers = await sbGet('users', `id=eq.${provProfiles[0].user_id}&select=first_name,last_name`);
           if (pUsers.length) b._provider_name = `${pUsers[0].first_name} ${pUsers[0].last_name}`;
         }
-        const petRows = await sbGet('pets', `id=eq.${b.pet_id}&select=name,breed`);
-        if (petRows.length) { b._pet_name = petRows[0].name; b._pet_breed = petRows[0].breed; }
+        let petRows = [];
+        try {
+          const bp = await sbGet('booking_pets', `booking_id=eq.${b.id}&select=pet_id`);
+          const ids = bp.map(r => r.pet_id).filter(Boolean);
+          if (ids.length) petRows = await sbGet('pets', `id=in.(${ids.join(',')})&select=name,breed`);
+        } catch(e) {}
+        if (!petRows.length && b.pet_id) petRows = await sbGet('pets', `id=eq.${b.pet_id}&select=name,breed`);
+        if (petRows.length) {
+          b._pet_name = petRows.map(p => p.name).filter(Boolean).join(' + ');
+          b._pet_breed = petRows.length === 1 ? petRows[0].breed : null;
+        }
         const svcs = await sbGet('provider_services', `id=eq.${b.service_id}&select=service_type`);
         if (svcs.length) b._service_type = svcs[0].service_type;
         if (b.status === 'in_progress') {

--- a/track/index.html
+++ b/track/index.html
@@ -444,8 +444,17 @@ async function init() {
     } catch (e) {}
 
     try {
-      const pets = await sbGet('pets', `id=eq.${booking.pet_id}&select=name,breed`);
-      if (pets.length) { petName = pets[0].name; petBreed = pets[0].breed || ''; }
+      let pets = [];
+      try {
+        const bp = await sbGet('booking_pets', `booking_id=eq.${bookingId}&select=pet_id`);
+        const ids = bp.map(r => r.pet_id).filter(Boolean);
+        if (ids.length) pets = await sbGet('pets', `id=in.(${ids.join(',')})&select=name,breed`);
+      } catch (e) {}
+      if (!pets.length && booking.pet_id) pets = await sbGet('pets', `id=eq.${booking.pet_id}&select=name,breed`);
+      if (pets.length) {
+        petName = pets.map(p => p.name).filter(Boolean).join(' + ');
+        petBreed = pets.length === 1 ? (pets[0].breed || '') : '';
+      }
     } catch (e) {}
 
     const sessions = await sbGet('walk_sessions', `booking_id=eq.${bookingId}&select=*&order=created_at.desc&limit=1`);


### PR DESCRIPTION
Lets customers add multiple pets to a single booking (e.g. walking two dogs together). The `booking_pets` join table + RLS already existed from earlier; this wires it into the booking flow and display surfaces.

## Data model (option 1 — low risk)
- `bookings.pet_id` is kept as the **primary** pet (first selected) for backward compatibility — no migration of existing bookings needed.
- Every selected pet (including the primary) is written to `booking_pets`.
- Display reads `booking_pets`, falling back to `pet_id`.

## Changes
- **`book/index.html`**: the *Which pets?* picker is now a multi-select (checkboxes, label-wrapped, driven by `onchange` so toggling is reliable/idempotent). Defaults to the first pet; requires ≥1. On submit, inserts one `booking_pets` row per pet.
- **Display surfaces** now render all of a booking's pets, joined as `Cooper + Luna` (breed shown only when a single pet):
  - `my/index.html` (customer booking cards + the welcome line)
  - `dashboard/index.html` (provider — new `_pet_label`)
  - `track/index.html` (walk header)

## Verified end-to-end (as a 2-pet customer)
- Selecting both pets writes `pet_id` = primary + **two** `booking_pets` rows
- `my` page renders "Cooper + Luna"
- Single-pet path unchanged (selector hidden, auto-selected, one `booking_pets` row)
- Provider-read RLS on `booking_pets` already in place
- All test bookings cleaned up

## Follow-on
TRU-78 (additional fee per extra pet) builds on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)