### PR TITLE
TRU-78: multi-pet pricing — additional fee per extra pet

### DIFF
--- a/book/index.html
+++ b/book/index.html
@@ -213,6 +213,45 @@ function selectService(el, serviceId) {
   el.classList.add('selected'); selectedServiceId = serviceId;
   const svcType = el.querySelector('input')?.dataset.svcType;
   document.getElementById('dateFields').innerHTML = renderDateFields(MULTI_DAY_SERVICES.includes(svcType));
+  renderPriceEstimate();
+}
+
+function fmtPrice(cents) {
+  const n = cents / 100;
+  return '$' + (Number.isInteger(n) ? n : n.toFixed(2));
+}
+
+/* Informational price estimate (paid directly to the carer). Includes the
+   per-extra-pet fee. Platform charging stays $0 during launch. */
+function renderPriceEstimate() {
+  const el = document.getElementById('priceEstimate');
+  if (!el) return;
+  const svc = providerServices.find(s => s.id === selectedServiceId);
+  const n = selectedPetIds.length || 1;
+  if (!svc || svc.price_cents == null) { el.innerHTML = ''; return; }
+
+  const base = svc.price_cents;
+  const extraFee = svc.additional_pet_price_cents || 0;
+  const extraPets = Math.max(0, n - 1);
+  const total = base + extraPets * extraFee;
+  const unit = svc.service_type === 'dog_walking' ? ' / walk'
+    : (MULTI_DAY_SERVICES.includes(svc.service_type) ? ' / night' : '');
+
+  let breakdown = '';
+  if (extraPets > 0 && extraFee > 0) {
+    breakdown = `<div style="font-size:0.75rem;color:var(--text-muted);margin-top:2px;">${fmtPrice(base)} base + ${fmtPrice(extraFee)} × ${extraPets} extra pet${extraPets > 1 ? 's' : ''}</div>`;
+  } else if (extraPets > 0) {
+    breakdown = `<div style="font-size:0.75rem;color:var(--text-muted);margin-top:2px;">${n} pets · no extra-pet fee</div>`;
+  }
+
+  el.innerHTML = `
+    <div style="display:flex;justify-content:space-between;align-items:center;">
+      <span style="font-size:0.85rem;color:var(--text-secondary);">Estimated price${unit}</span>
+      <span style="font-size:0.95rem;font-weight:600;color:var(--text-primary);">${fmtPrice(total)}</span>
+    </div>
+    ${breakdown}
+    <div style="border-top:1px solid var(--border);margin:10px 0;"></div>
+  `;
 }
 
 function renderDateFields(isMultiDay) {
@@ -281,6 +320,7 @@ function onPetToggle(input) {
   else if (!input.checked && i >= 0) selectedPetIds.splice(i, 1);
   const opt = input.closest('.pet-option');
   if (opt) opt.classList.toggle('selected', input.checked);
+  renderPriceEstimate();
 }
 
 function renderBookingForm() {
@@ -344,6 +384,7 @@ function renderBookingForm() {
       </div>
 
       <div style="background:var(--cream);border-radius:10px;padding:12px 16px;margin-top:0.5rem;">
+        <div id="priceEstimate"></div>
         <div style="display:flex;justify-content:space-between;align-items:center;">
           <span style="font-size:0.85rem;color:var(--text-secondary);">Platform fee</span>
           <span style="font-size:0.85rem;font-weight:500;color:var(--success);">$0 — free during launch</span>
@@ -357,6 +398,8 @@ function renderBookingForm() {
       </div>
     </div>
   `;
+
+  renderPriceEstimate();
 }
 
 async function submitBooking() {
@@ -459,7 +502,7 @@ async function init() {
     const [users, profiles, services] = await Promise.all([
       sbGet('users', `id=eq.${providerId}&select=first_name,last_name`, authToken),
       sbGet('provider_profiles', `user_id=eq.${providerId}&select=*`, authToken),
-      sbGet('provider_services', `provider_id=eq.${providerId}&select=id,service_type,is_available&is_available=eq.true`, authToken)
+      sbGet('provider_services', `provider_id=eq.${providerId}&select=id,service_type,is_available,price_cents,additional_pet_price_cents&is_available=eq.true`, authToken)
     ]);
 
     if (!users.length || !profiles.length) {

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -159,6 +159,9 @@
     background: var(--warm-white); outline: none; text-align: right; transition: border-color 0.15s;
   }
   .svc-price-input:focus { border-color: var(--border-focus); }
+  .svc-extra-wrap { display: flex; align-items: center; gap: 4px; font-size: 0.82rem; color: var(--text-muted); }
+  .svc-extra-wrap .svc-extra-label { white-space: nowrap; font-size: 0.76rem; }
+  .svc-extra-input { width: 60px; }
   .svc-row-status {
     font-size: 0.72rem; color: var(--text-muted); min-width: 56px; text-align: right;
   }
@@ -169,7 +172,8 @@
     .svc-row-label { flex-basis: 100%; order: 2; }
     .svc-toggle { order: 1; }
     .svc-price-wrap { order: 3; }
-    .svc-row-status { order: 4; }
+    .svc-extra-wrap { order: 4; flex-basis: 100%; }
+    .svc-row-status { order: 5; }
   }
 
   /* Profile preview */
@@ -580,6 +584,7 @@ function serviceRowHtml(service_type, duration_mins, label, unitHint) {
   const existing = findService(service_type, duration_mins);
   const on = !!(existing && existing.is_available);
   const price = existing ? priceToDollars(existing.price_cents) : '';
+  const extra = existing ? priceToDollars(existing.additional_pet_price_cents) : '';
   const slotId = `${service_type}__${duration_mins == null ? 'na' : duration_mins}`;
   const durArg = duration_mins == null ? 'null' : duration_mins;
   const unit = unitHint ? `<span class="svc-row-unit">· ${esc(unitHint)}</span>` : '';
@@ -589,10 +594,18 @@ function serviceRowHtml(service_type, duration_mins, label, unitHint) {
       <div class="svc-row-label">${esc(label)}${unit}</div>
       <div class="svc-price-wrap">
         <span class="dollar">$</span>
-        <input class="svc-price-input" type="text" inputmode="decimal" placeholder="0"
+        <input class="svc-price-input" type="text" inputmode="decimal" placeholder="0" aria-label="Base price for ${esc(label)}"
                value="${esc(price)}"
                oninput="markRowDirty('${slotId}')"
                onblur="saveServicePrice('${service_type}', ${durArg}, this.value)">
+      </div>
+      <div class="svc-extra-wrap" title="Optional extra charge per additional pet on the same booking">
+        <span class="svc-extra-label">+ per extra pet</span>
+        <span class="dollar">$</span>
+        <input class="svc-price-input svc-extra-input" type="text" inputmode="decimal" placeholder="0" aria-label="Extra fee per additional pet for ${esc(label)}"
+               value="${esc(extra)}"
+               oninput="markRowDirty('${slotId}')"
+               onblur="saveExtraPetPrice('${service_type}', ${durArg}, this.value)">
       </div>
       <div class="svc-row-status" id="status-${slotId}"></div>
     </div>
@@ -683,6 +696,46 @@ async function saveServicePrice(service_type, duration_mins, raw) {
       providerServices.push(Array.isArray(res) ? res[0] : res);
     }
     refreshRowVisuals(service_type, duration_mins);
+    setRowStatus(slotId, 'Saved', 'saved');
+  } catch (e) {
+    setRowStatus(slotId, 'Error', 'error');
+    showMsg(e.message, 'error');
+  }
+}
+
+async function saveExtraPetPrice(service_type, duration_mins, raw) {
+  const slotId = `${service_type}__${duration_mins == null ? 'na' : duration_mins}`;
+  const trimmed = (raw || '').toString().trim();
+  const existing = findService(service_type, duration_mins);
+
+  // Empty input clears the extra-pet fee.
+  if (trimmed === '') {
+    if (!existing || existing.additional_pet_price_cents == null) { setRowStatus(slotId, '', ''); return; }
+    setRowStatus(slotId, 'Saving…', '');
+    try {
+      const res = await sbPatch('provider_services', 'id', existing.id, { additional_pet_price_cents: null });
+      Object.assign(existing, Array.isArray(res) ? res[0] : res);
+      setRowStatus(slotId, 'Saved', 'saved');
+    } catch (e) { setRowStatus(slotId, 'Error', 'error'); showMsg(e.message, 'error'); }
+    return;
+  }
+
+  const cents = dollarsToCents(trimmed);
+  if (cents == null) { setRowStatus(slotId, 'Invalid', 'error'); return; }
+  if (existing && existing.additional_pet_price_cents === cents) { setRowStatus(slotId, '', ''); return; }
+
+  setRowStatus(slotId, 'Saving…', '');
+  try {
+    if (existing) {
+      const res = await sbPatch('provider_services', 'id', existing.id, { additional_pet_price_cents: cents });
+      Object.assign(existing, Array.isArray(res) ? res[0] : res);
+    } else {
+      // No base row yet — create one carrying the extra-pet fee so it isn't lost.
+      const row = { provider_id: authUid, service_type, duration_mins, additional_pet_price_cents: cents, is_available: true };
+      const res = await sbInsert('provider_services', row);
+      providerServices.push(Array.isArray(res) ? res[0] : res);
+      refreshRowVisuals(service_type, duration_mins);
+    }
     setRowStatus(slotId, 'Saved', 'saved');
   } catch (e) {
     setRowStatus(slotId, 'Error', 'error');


### PR DESCRIPTION
Lets providers charge an optional flat fee per additional pet on a booking. Builds on TRU-75 (multi-pet bookings).

## Product decisions (confirmed)
- **Flat fee per extra pet**, set per service.
- **Capture the fee + show an informational estimate**, but keep platform charging at **$0 "free during launch"** — `total_cents` stays 0, no real charging switched on.
- Applies to **all paid services**.

## Changes
- **Schema**: `provider_services.additional_pet_price_cents integer` (nullable). Migration applied to Supabase.
- **Dashboard service editor** (`dashboard/index.html`): each service row gains a "+ per extra pet $__" input beside the base price, saved via `saveExtraPetPrice` (mirrors the base-price save; empty input clears it; creates the row if none exists).
- **Booking flow** (`book/index.html`): now loads `price_cents` + `additional_pet_price_cents` and shows an **Estimated price** (paid directly to the carer) = base + (n−1) × extra-pet fee, with a breakdown line. Updates live as service/pets change. The "$0 — free during launch" platform-fee line is unchanged.

## Verified end-to-end
- Dashboard: setting "+ per extra pet $10" on the 30-min walk persisted (`additional_pet_price_cents = 1000`); renders cleanly desktop + mobile.
- Booking: a 2-dog walk shows **"$55 — $45 base + $10 × 1 extra pet"**; single pet shows just the base; a service with no fee shows "N pets · no extra-pet fee"; a service with no base price shows no estimate.
- No console errors. All test fees reverted (Isla's data restored).

## Note
The booking form still collapses each service *type* to a single row (e.g. all dog-walk durations → one "Dog walking" option), so the estimate uses whichever duration row is first. That's a pre-existing simplification, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)