### PR TITLE
TRU-7 (PR 2): messaging entry points + unread badges

### DIFF
--- a/book/index.html
+++ b/book/index.html
@@ -27,6 +27,10 @@
   .nav-logo { display: flex; align-items: center; text-decoration: none; }
   .nav-back { font-size: 0.85rem; color: var(--text-secondary); text-decoration: none; display: flex; align-items: center; gap: 6px; transition: color 0.2s; }
   .nav-back:hover { color: var(--terracotta); }
+  .nav-right { display: flex; align-items: center; gap: 18px; }
+  .nav-msg { position: relative; display: inline-flex; align-items: center; color: var(--text-secondary); }
+  .nav-msg:hover { color: var(--terracotta); }
+  .nav-msg-badge { position: absolute; top: -6px; right: -7px; min-width: 16px; height: 16px; padding: 0 4px; border-radius: 999px; background: var(--terracotta); color: #fff; font-size: 0.62rem; line-height: 16px; text-align: center; font-weight: 600; }
 
   .page-wrapper { max-width: 560px; margin: 0 auto; padding: 2.5rem 1.5rem 4rem; }
   .page-header { text-align: center; margin-bottom: 2rem; }
@@ -150,10 +154,16 @@
       <text x="52" y="50" font-family="'DM Sans', sans-serif" font-size="12" font-weight="600" fill="#B0A090" letter-spacing="4">PETS</text>
     </svg>
   </a>
-  <a href="javascript:history.back()" class="nav-back">
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M10 12L6 8L10 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-    Back
-  </a>
+  <div class="nav-right">
+    <a href="/messages/" class="nav-msg" id="navMsg" title="Messages" aria-label="Messages" style="display:none;">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/></svg>
+      <span class="nav-msg-badge" id="navMsgBadge" style="display:none;">0</span>
+    </a>
+    <a href="javascript:history.back()" class="nav-back">
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M10 12L6 8L10 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      Back
+    </a>
+  </div>
 </nav>
 
 <div class="page-wrapper">
@@ -466,6 +476,15 @@ async function submitBooking() {
   } catch(e) { showMsg(e.message, 'error'); } finally { setLoading(btn, false); }
 }
 
+async function refreshMsgBadge() {
+  if (!authToken || !authUid) return;
+  try {
+    const rows = await sbGet('messages', `sender_id=neq.${authUid}&read_at=is.null&select=id`, authToken);
+    const badge = document.getElementById('navMsgBadge');
+    if (badge) { badge.textContent = rows.length > 9 ? '9+' : String(rows.length); badge.style.display = rows.length > 0 ? '' : 'none'; }
+  } catch (e) { /* non-fatal */ }
+}
+
 async function init() {
   const area = document.getElementById('bookingContent');
   const params = new URLSearchParams(window.location.search);
@@ -484,6 +503,13 @@ async function init() {
       authToken = session.access_token;
       authUid = session.user_id;
     } catch(e) {}
+  }
+
+  if (authToken && authUid) {
+    const nm = document.getElementById('navMsg');
+    if (nm) nm.style.display = '';
+    refreshMsgBadge();
+    setInterval(refreshMsgBadge, 10000);
   }
 
   if (!authToken) {

--- a/carer/index.html
+++ b/carer/index.html
@@ -43,6 +43,9 @@
   .nav-right { display: flex; align-items: center; gap: 20px; font-size: 13px; }
   .nav-right a { color: var(--text-secondary); text-decoration: none; transition: color 0.2s; }
   .nav-right a:hover { color: var(--terracotta); }
+  .nav-msg { position: relative; display: inline-flex; align-items: center; color: var(--text-secondary); }
+  .nav-msg:hover { color: var(--terracotta); }
+  .nav-msg-badge { position: absolute; top: -7px; right: -8px; min-width: 16px; height: 16px; padding: 0 4px; border-radius: 999px; background: var(--terracotta); color: #fff; font-size: 10px; line-height: 16px; text-align: center; font-weight: 600; }
   .btn-nav {
     background: var(--terracotta); color: white; padding: 8px 18px;
     border-radius: 8px; font-weight: 500; transition: all 0.2s; text-decoration: none; font-size: 13px;
@@ -262,7 +265,11 @@
     </svg>
   </a>
   <div class="nav-right">
-    <a href="/login/">Sign in</a>
+    <a href="/messages/" class="nav-msg" id="navMsg" title="Messages" aria-label="Messages" style="display:none;">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/></svg>
+      <span class="nav-msg-badge" id="navMsgBadge" style="display:none;">0</span>
+    </a>
+    <a href="/login/" id="navSignIn">Sign in</a>
     <a href="/search/" class="btn-nav">Find a carer</a>
   </div>
 </nav>
@@ -612,6 +619,28 @@ async function loadProfile() {
 }
 
 document.addEventListener('DOMContentLoaded', loadProfile);
+
+/* Messages entry point — shown only to logged-in visitors */
+(function () {
+  let tok = null, uid = null;
+  try { const s = JSON.parse(localStorage.getItem('truffl_session') || 'null'); if (s) { tok = s.access_token; uid = s.user_id; } } catch (e) {}
+  if (!tok || !uid) return;
+  const nm = document.getElementById('navMsg');
+  const si = document.getElementById('navSignIn');
+  if (nm) nm.style.display = '';
+  if (si) si.style.display = 'none';
+  async function refresh() {
+    try {
+      const r = await fetch(`${SUPABASE_URL}/rest/v1/messages?sender_id=neq.${uid}&read_at=is.null&select=id`, { headers: { 'apikey': SUPABASE_ANON_KEY, 'Authorization': `Bearer ${tok}` } });
+      if (!r.ok) return;
+      const rows = await r.json();
+      const badge = document.getElementById('navMsgBadge');
+      if (badge) { badge.textContent = rows.length > 9 ? '9+' : String(rows.length); badge.style.display = rows.length > 0 ? '' : 'none'; }
+    } catch (e) {}
+  }
+  refresh();
+  setInterval(refresh, 10000);
+})();
 </script>
 </body>
 </html>

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -30,6 +30,10 @@
   .nav-right a { color: var(--text-secondary); text-decoration: none; transition: color 0.2s; }
   .nav-right a:hover { color: var(--terracotta); }
   .nav-user { display: flex; align-items: center; gap: 8px; }
+  .nav-msg { position: relative; display: inline-flex; align-items: center; color: var(--text-secondary); }
+  .nav-msg:hover { color: var(--terracotta); }
+  .nav-msg-badge { position: absolute; top: -7px; right: -8px; min-width: 16px; height: 16px; padding: 0 4px; border-radius: 999px; background: var(--terracotta); color: #fff; font-size: 10px; line-height: 16px; text-align: center; font-weight: 600; }
+  .bc-msg-badge { min-width: 16px; height: 16px; padding: 0 5px; border-radius: 999px; background: var(--terracotta); color: #fff; font-size: 10px; line-height: 16px; text-align: center; font-weight: 600; }
   .nav-avatar {
     width: 32px; height: 32px; border-radius: 50%; background: var(--blush);
     display: flex; align-items: center; justify-content: center;
@@ -103,6 +107,8 @@
   .bc-btn.decline:hover { border-color: var(--error); color: var(--error); }
   .bc-btn.start-walk { background: var(--terracotta); color: white; }
   .bc-btn.start-walk:hover { background: var(--terracotta-light); }
+  .bc-btn.message { background: transparent; border: 1px solid var(--border); color: var(--text-secondary); position: relative; display: inline-flex; align-items: center; gap: 6px; }
+  .bc-btn.message:hover { border-color: var(--terracotta); color: var(--terracotta); }
 
   .status-badge {
     display: inline-block; font-size: 0.7rem; font-weight: 600; padding: 3px 10px;
@@ -245,6 +251,10 @@
     </svg>
   </a>
   <div class="nav-right">
+    <a href="/messages/" class="nav-msg" id="navMsg" title="Messages" aria-label="Messages">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/></svg>
+      <span class="nav-msg-badge" id="navMsgBadge" style="display:none;">0</span>
+    </a>
     <div class="nav-user" id="navUser"></div>
     <a href="#" onclick="logout()" style="font-size:0.8rem;color:var(--text-muted);">Sign out</a>
   </div>
@@ -434,6 +444,7 @@ function renderBookingsTab() {
         <div class="bc-actions">
           <button class="bc-btn accept" onclick="acceptBooking('${b.id}')">Accept</button>
           <button class="bc-btn decline" onclick="declineBooking('${b.id}')">Decline</button>
+          <button class="bc-btn message" onclick="window.location.href='/messages/?booking=${b.id}'">Message <span class="bc-msg-badge" id="cardbadge-${b.id}" style="display:none;">0</span></button>
         </div>
       </div>
     `).join('');
@@ -452,6 +463,7 @@ function renderBookingsTab() {
         </div>
         <div class="bc-actions">
           <button class="bc-btn start-walk" onclick="window.location.href='/walk/?booking=${b.id}'">Start walk</button>
+          <button class="bc-btn message" onclick="window.location.href='/messages/?booking=${b.id}'">Message <span class="bc-msg-badge" id="cardbadge-${b.id}" style="display:none;">0</span></button>
         </div>
       </div>
     `).join('');
@@ -514,12 +526,13 @@ function renderDashboard() {
       </div>
     </div>
 
-    <!-- Messages placeholder -->
+    <!-- Messages: lives on its own page now -->
     <div class="tab-content" id="tab-messages">
       <div class="placeholder-card">
-        <div class="ph-icon">💬</div>
-        <h3>Messages coming soon</h3>
-        <p>You'll be able to chat with customers about booking details, gate codes, and anything else before their visit.</p>
+        <div class="ph-icon" style="color:var(--terracotta);"><svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/></svg></div>
+        <h3>Your messages</h3>
+        <p>Chat with customers about booking details, gate codes, and anything else before their visit.</p>
+        <a href="/messages/" class="bc-btn message" style="display:inline-flex;margin-top:14px;text-decoration:none;">Open messages</a>
       </div>
     </div>
 
@@ -782,9 +795,28 @@ async function init() {
     await loadBookings();
 
     renderDashboard();
+    refreshMsgBadge();
+    setInterval(refreshMsgBadge, 10000);
   } catch(e) {
     area.innerHTML = `<div class="login-prompt"><h2>Something went wrong</h2><p>${e.message}</p><a href="/login/">Try signing in again</a></div>`;
   }
+}
+
+async function refreshMsgBadge() {
+  if (!authToken || !authUid) return;
+  try {
+    const rows = await sbGet('messages', `sender_id=neq.${authUid}&read_at=is.null&select=id,booking_id`);
+    const badge = document.getElementById('navMsgBadge');
+    if (badge) { badge.textContent = rows.length > 9 ? '9+' : String(rows.length); badge.style.display = rows.length > 0 ? '' : 'none'; }
+    const byBooking = {};
+    rows.forEach(r => { byBooking[r.booking_id] = (byBooking[r.booking_id] || 0) + 1; });
+    document.querySelectorAll('[id^="cardbadge-"]').forEach(el => {
+      const id = el.id.slice('cardbadge-'.length);
+      const n = byBooking[id] || 0;
+      el.textContent = n > 9 ? '9+' : String(n);
+      el.style.display = n > 0 ? '' : 'none';
+    });
+  } catch (e) { /* non-fatal */ }
 }
 
 document.addEventListener('DOMContentLoaded', init);

--- a/my/index.html
+++ b/my/index.html
@@ -25,6 +25,11 @@
   .nav-right{display:flex;align-items:center;gap:8px;}
   .nav-avatar{width:32px;height:32px;border-radius:50%;background:var(--blush);display:flex;align-items:center;justify-content:center;font-size:0.75rem;font-weight:600;color:var(--brown);}
   .nav-name{font-size:0.85rem;font-weight:500;color:var(--text-primary);}
+  .nav-msg{position:relative;display:inline-flex;align-items:center;color:var(--text-secondary);text-decoration:none;}
+  .nav-msg:hover{color:var(--terracotta);}
+  .nav-msg-badge{position:absolute;top:-6px;right:-7px;min-width:16px;height:16px;padding:0 4px;border-radius:999px;background:var(--terracotta);color:#fff;font-size:0.62rem;line-height:16px;text-align:center;font-weight:600;}
+  .bc-msg-link{display:inline-flex;align-items:center;gap:5px;position:relative;}
+  .bc-msg-badge{min-width:16px;height:16px;padding:0 5px;border-radius:999px;background:var(--terracotta);color:#fff;font-size:0.62rem;line-height:16px;text-align:center;font-weight:600;}
 
   .page-wrapper{max-width:560px;margin:0 auto;padding:1.5rem 1rem 4rem;}
 
@@ -161,7 +166,13 @@
       <text x="52" y="50" font-family="'DM Sans', sans-serif" font-size="12" font-weight="600" fill="#B0A090" letter-spacing="4">PETS</text>
     </svg>
   </a>
-  <div class="nav-right" id="navUser"></div>
+  <div class="nav-right">
+    <a href="/messages/" class="nav-msg" id="navMsg" title="Messages" aria-label="Messages">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/></svg>
+      <span class="nav-msg-badge" id="navMsgBadge" style="display:none;">0</span>
+    </a>
+    <span id="navUser"></span>
+  </div>
 </nav>
 
 <div class="page-wrapper">
@@ -344,13 +355,14 @@ function bookingCardHtml(b) {
   const provLabel = esc(b._provider_name || 'Your carer');
   const dateStr = b.scheduled_at ? formatScheduledAt(b.scheduled_at) : '';
   const actions = actionButtons(b);
+  const msgLink = `<a href="/messages/?booking=${b.id}" class="btn-ghost bc-msg-link">Message <span class="bc-msg-badge" id="cardbadge-${b.id}" style="display:none;">0</span></a>`;
   return `
     <div class="booking-card">
       <div class="bc-pet-name">${petLabel}</div>
       <div class="bc-meta">${serviceLabel} · ${provLabel}</div>
       <div class="bc-time">${esc(dateStr)}</div>
       ${statusBadge(b.status)}
-      ${actions ? `<div class="bc-actions">${actions}</div>` : ''}
+      <div class="bc-actions">${actions}${msgLink}</div>
     </div>
   `;
 }
@@ -668,6 +680,24 @@ function signOut() {
   window.location.href = '/';
 }
 
+/* ── Unread message badges (header + per-booking-card) ── */
+async function refreshMsgBadge() {
+  if (!authToken || !authUid) return;
+  try {
+    const rows = await sbGet('messages', `sender_id=neq.${authUid}&read_at=is.null&select=id,booking_id`);
+    const badge = document.getElementById('navMsgBadge');
+    if (badge) { badge.textContent = rows.length > 9 ? '9+' : String(rows.length); badge.style.display = rows.length > 0 ? '' : 'none'; }
+    const byBooking = {};
+    rows.forEach(r => { byBooking[r.booking_id] = (byBooking[r.booking_id] || 0) + 1; });
+    document.querySelectorAll('[id^="cardbadge-"]').forEach(el => {
+      const id = el.id.slice('cardbadge-'.length);
+      const n = byBooking[id] || 0;
+      el.textContent = n > 9 ? '9+' : String(n);
+      el.style.display = n > 0 ? '' : 'none';
+    });
+  } catch (e) { /* non-fatal */ }
+}
+
 /* ── Init ── */
 async function init() {
   const area = document.getElementById('myContent');
@@ -738,6 +768,8 @@ async function init() {
     pets = await sbGet('pets', `customer_id=eq.${customerProfile.id}&is_active=eq.true&select=*`);
 
     renderDashboard();
+    refreshMsgBadge();
+    setInterval(refreshMsgBadge, 10000);
   } catch(e) {
     area.innerHTML = `<div class="login-prompt"><h2>Something went wrong</h2><p>${esc(e.message)}</p><a href="/login/">Try signing in again</a></div>`;
   }

--- a/track/index.html
+++ b/track/index.html
@@ -23,6 +23,9 @@
   body{font-family:'DM Sans',sans-serif;background:var(--cream);color:var(--text-primary);min-height:100vh;-webkit-font-smoothing:antialiased;}
 
   .nav{position:sticky;top:0;z-index:200;background:var(--warm-white);border-bottom:1px solid var(--border);padding:0 1.25rem;height:56px;display:flex;align-items:center;}
+  .nav-msg{margin-left:auto;position:relative;display:inline-flex;align-items:center;color:var(--text-secondary);text-decoration:none;}
+  .nav-msg:hover{color:var(--terracotta);}
+  .nav-msg-badge{position:absolute;top:-6px;right:-7px;min-width:16px;height:16px;padding:0 4px;border-radius:999px;background:var(--terracotta);color:#fff;font-size:0.62rem;line-height:16px;text-align:center;font-weight:600;}
   .nav-logo{display:flex;align-items:center;text-decoration:none;}
 
   .page-wrapper{max-width:560px;margin:0 auto;padding:1rem 1rem 6rem;}
@@ -95,6 +98,10 @@
       <text x="52" y="30" font-family="'Cormorant Garamond',Georgia,serif" font-size="32" font-style="italic" font-weight="400" fill="#3D2B1F" letter-spacing="-0.5">truffl</text>
       <text x="52" y="50" font-family="'DM Sans',sans-serif" font-size="12" font-weight="600" fill="#B0A090" letter-spacing="4">PETS</text>
     </svg>
+  </a>
+  <a href="/messages/" class="nav-msg" id="navMsg" title="Messages" aria-label="Messages">
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/></svg>
+    <span class="nav-msg-badge" id="navMsgBadge" style="display:none;">0</span>
   </a>
 </nav>
 
@@ -284,6 +291,10 @@ function renderWaitingState() {
       <div style="font-size:0.95rem;font-weight:500;color:var(--text-primary);margin-bottom:2px;">${petName}${petBreed ? ' · ' + petBreed : ''}</div>
       <div style="font-size:0.85rem;color:var(--text-secondary);margin-bottom:6px;">Walker: ${providerName}</div>
       <div style="font-size:0.82rem;color:var(--text-muted);">${scheduledStr}</div>
+      <a href="/messages/?booking=${bookingId}" style="display:inline-flex;align-items:center;gap:7px;margin-top:14px;padding:9px 16px;border:1px solid var(--border);border-radius:10px;color:var(--text-secondary);text-decoration:none;font-size:0.85rem;font-weight:500;">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/></svg>
+        Message your carer
+      </a>
     </div>
 
     <div class="info-notice">
@@ -397,6 +408,15 @@ function renderSummary(allUpdates) {
   }
 }
 
+async function refreshMsgBadge() {
+  if (!authToken || !authUid) return;
+  try {
+    const rows = await sbGet('messages', `sender_id=neq.${authUid}&read_at=is.null&select=id`);
+    const badge = document.getElementById('navMsgBadge');
+    if (badge) { badge.textContent = rows.length > 9 ? '9+' : String(rows.length); badge.style.display = rows.length > 0 ? '' : 'none'; }
+  } catch (e) { /* non-fatal */ }
+}
+
 async function init() {
   const area = document.getElementById('trackContent');
   const stored = localStorage.getItem('truffl_session');
@@ -406,6 +426,9 @@ async function init() {
     area.innerHTML = `<div class="login-prompt"><h2>Sign in required</h2><p>You need to be logged in to track a walk.</p><a href="/login/?redirect=${encodeURIComponent(window.location.pathname + window.location.search)}">Sign in</a></div>`;
     return;
   }
+
+  refreshMsgBadge();
+  setInterval(refreshMsgBadge, 10000);
 
   const params = new URLSearchParams(window.location.search);
   bookingId = params.get('booking');


### PR DESCRIPTION
Second of two PRs for TRU-7. PR 1 (#27, merged) delivered the `/messages/` inbox; this adds the entry points and unread badges across the app.

## Changes
- **Header chat icon** → `/messages/` on `my`, `dashboard`, `track`, `carer`, `book`. On the public-ish `carer`/`book` pages it's revealed only when a session exists (and hides the "Sign in" link on carer).
- **Total-unread badge** on the header icon — count of messages addressed to me (`sender_id != me`, `read_at is null`), refreshed on load and every 10s.
- **"Message" entry points** deep-linking to `/messages/?booking=ID`:
  - Customer booking cards (`my`) and provider booking cards (`dashboard`).
  - "Message your carer" CTA on the `track` booking detail.
- **Per-booking unread badge** on the `my` + `dashboard` booking cards.
- **Dashboard "Messages" tab**: the "coming soon" placeholder now points to the new inbox ("Open messages") and drops a leftover emoji.

## Verified end-to-end (customer + provider)
- Header badge shows the right unread total and clears as messages are read.
- Per-card badges show per-booking unread counts.
- Deep-links open the correct thread.
- Icon is login-gated on carer/book; shown always on my/dashboard/track.
- No console errors. Test data created and cleaned up.

## Note
Provider booking cards still show "Customer"/"Pet" (pre-existing RLS gap). PR 1 added a `booking_party_names` view that could fix this — out of scope here, easy follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)