### PR TITLE
TRU-12 (PR 2): recurring walks — daily rolling job (TRU-34)

### DIFF
--- a/supabase/migrations/20260612_recurring_walks_rolling_job.sql
+++ b/supabase/migrations/20260612_recurring_walks_rolling_job.sql
@@ -1,0 +1,46 @@
+-- TRU-34 — Recurring walks: daily rolling job.
+--
+-- NOTE: DB changes on this project are applied to Supabase via the Supabase
+-- MCP (apply_migration), not by a CLI pipeline. This file is the
+-- version-controlled record of what was applied. Depends on
+-- generate_series_bookings(series_id, weeks_ahead) from the previous
+-- recurring-walks PR.
+
+-- Daily rolling job: keep ~4 weeks of bookings populated for every active
+-- series, and retire series that have passed their end date.
+CREATE OR REPLACE FUNCTION public.roll_all_series_bookings()
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  r record;
+  total int := 0;
+BEGIN
+  -- Retire series whose end date has passed.
+  UPDATE public.booking_series
+     SET status = 'completed', updated_at = now()
+   WHERE status = 'active'
+     AND end_date IS NOT NULL
+     AND end_date < current_date;
+
+  -- Top up upcoming bookings for everything still active.
+  FOR r IN SELECT id FROM public.booking_series WHERE status = 'active' LOOP
+    total := total + public.generate_series_bookings(r.id, 4);
+  END LOOP;
+
+  RETURN total;
+END;
+$$;
+
+-- Schedule it daily at 16:00 UTC (~2am Sydney) via pg_cron.
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+DO $$
+BEGIN
+  PERFORM cron.unschedule('roll-series-bookings')
+  WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'roll-series-bookings');
+END $$;
+
+SELECT cron.schedule('roll-series-bookings', '0 16 * * *', $$SELECT public.roll_all_series_bookings();$$);


### PR DESCRIPTION
Second PR of the recurring-walks epic. Adds the scheduled job that keeps recurring schedules rolling forward. Builds on PR #30 (the generation function + creation/acceptance).

## What it does
- **`roll_all_series_bookings()`** — `SECURITY DEFINER`:
  - Retires series whose `end_date` has passed (`status → completed`).
  - Tops up every still-active series via the existing idempotent `generate_series_bookings(id, 4)`, so there are always ~4 weeks of upcoming bookings.
- **Scheduled daily at 16:00 UTC (~2am Sydney)** via **pg_cron**.

This is what makes an "ongoing" series actually keep going — without it, an open-ended schedule only ever has its first ~4 weeks (as noted on PR #30).

## Repo note
DB changes on this project are applied via the Supabase MCP, not a CLI pipeline. Previously they left no git artifact. This PR is **pure database**, so it also **starts version-controlling the SQL** under `supabase/migrations/` — this file is the record of exactly what was applied. (Earlier recurring-walks DB objects from PR #30 aren't backfilled here; happy to do that separately if you'd like the full history tracked.)

## Verified
- Trimmed an active series down to 6 bookings (simulating time passing) → ran the job → topped back up to 21.
- A series with a past `end_date` → marked `completed`.
- `cron.job` shows `roll-series-bookings` registered, daily, active.
- Idempotent (re-running creates none). Test data cleaned up.

## Next
PR 3 (TRU-37/38): cancel one walk / cancel whole series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)