### PR TITLE
TRU-12 (PR 3): recurring walks — cancellations (TRU-37 + TRU-38)

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -35,6 +35,10 @@
   .nav-msg-badge { position: absolute; top: -7px; right: -8px; min-width: 16px; height: 16px; padding: 0 4px; border-radius: 999px; background: var(--terracotta); color: #fff; font-size: 10px; line-height: 16px; text-align: center; font-weight: 600; }
   .bc-msg-badge { min-width: 16px; height: 16px; padding: 0 5px; border-radius: 999px; background: var(--terracotta); color: #fff; font-size: 10px; line-height: 16px; text-align: center; font-weight: 600; }
   .recurring-tag { display: inline-block; margin-left: 6px; font-size: 0.62rem; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; color: var(--sage-dark); background: var(--success-bg); padding: 2px 8px; border-radius: 20px; vertical-align: middle; }
+  .cancel-inline { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+  .cancel-inline span { font-size: 0.82rem; color: var(--text-secondary); }
+  .cancel-inline.series { flex-direction: column; align-items: flex-start; }
+  .cancel-inline-btns { display: flex; gap: 8px; flex-wrap: wrap; }
   .nav-avatar {
     width: 32px; height: 32px; border-radius: 50%; background: var(--blush);
     display: flex; align-items: center; justify-content: center;
@@ -279,6 +283,7 @@ const SERVICE_LABELS = {
 
 let authToken = null, authUid = null;
 let userData = null, providerProfile = null, providerServices = [], bookings = [], series = [];
+let dashCancelId = null;
 
 const DAY_SHORT = { 1: 'Mon', 2: 'Tue', 3: 'Wed', 4: 'Thu', 5: 'Fri', 6: 'Sat', 7: 'Sun' };
 function formatTimeOfDay(t) {
@@ -487,6 +492,50 @@ async function declineSeries(id) {
   } catch(e) { showMsg(e.message, 'error'); }
 }
 
+/* ── Cancelling an upcoming walk (and, for series walks, the whole series) ── */
+function dashShowCancel(id) { dashCancelId = id; renderBookingsTab(); }
+function dashDismissCancel() { dashCancelId = null; renderBookingsTab(); }
+function dashCancelConfirm(b) {
+  if (b.series_id) {
+    return `<div class="cancel-inline series">
+      <span>Recurring walk — cancel what?</span>
+      <div class="cancel-inline-btns">
+        <button class="bc-btn decline" onclick="cancelWalk('${b.id}')">Just this walk</button>
+        <button class="bc-btn decline" onclick="cancelSeriesWalks('${b.series_id}')">All future walks</button>
+        <button class="bc-btn" style="border:1px solid var(--border);color:var(--text-muted);" onclick="dashDismissCancel()">Keep</button>
+      </div>
+    </div>`;
+  }
+  return `<div class="cancel-inline">
+    <span>Cancel this walk?</span>
+    <button class="bc-btn decline" onclick="cancelWalk('${b.id}')">Yes, cancel</button>
+    <button class="bc-btn" style="border:1px solid var(--border);color:var(--text-muted);" onclick="dashDismissCancel()">Keep</button>
+  </div>`;
+}
+async function cancelWalk(id) {
+  try {
+    await sbPatch('bookings', 'id', id, { status: 'cancelled' });
+    const b = bookings.find(x => x.id === id);
+    if (b) b.status = 'cancelled';
+    dashCancelId = null;
+    renderBookingsTab();
+  } catch(e) { showMsg(e.message, 'error'); }
+}
+async function cancelSeriesWalks(seriesId) {
+  try {
+    await sbPatch('booking_series', 'id', seriesId, { status: 'cancelled' });
+    const now = Date.now();
+    bookings.forEach(b => {
+      if (b.series_id === seriesId && (b.status === 'pending' || b.status === 'confirmed') && new Date(b.scheduled_at).getTime() > now) {
+        b.status = 'cancelled';
+      }
+    });
+    dashCancelId = null;
+    renderBookingsTab();
+    showMsg('Recurring schedule cancelled — upcoming walks were cancelled. Past walks are unchanged.', 'success');
+  } catch(e) { showMsg(e.message, 'error'); }
+}
+
 function renderBookingsTab() {
   const pending = bookings.filter(b => b.status === 'pending');
   const confirmed = bookings.filter(b => b.status === 'confirmed');
@@ -539,16 +588,17 @@ function renderBookingsTab() {
     html += confirmed.map(b => `
       <div class="booking-card">
         <div class="bc-info">
-          <div class="bc-customer">${b._customer_name || 'Customer'}</div>
+          <div class="bc-customer">${b._customer_name || 'Customer'}${b.series_id ? ' <span class="recurring-tag">Recurring</span>' : ''}</div>
           <div class="bc-pet">${b._pet_label || 'Pet'}</div>
           <span class="bc-service">${SERVICE_LABELS[b._service_type] || b._service_type || 'Service'}</span>
           <div class="bc-time">${formatDate(b.scheduled_at)}</div>
           ${b.customer_notes ? `<div class="bc-notes">"${b.customer_notes}"</div>` : ''}
         </div>
-        <div class="bc-actions">
+        <div class="bc-actions">${dashCancelId === b.id ? dashCancelConfirm(b) : `
           <button class="bc-btn start-walk" onclick="window.location.href='/walk/?booking=${b.id}'">Start walk</button>
           <button class="bc-btn message" onclick="window.location.href='/messages/?booking=${b.id}'">Message <span class="bc-msg-badge" id="cardbadge-${b.id}" style="display:none;">0</span></button>
-        </div>
+          <button class="bc-btn decline" onclick="dashShowCancel('${b.id}')">Cancel</button>
+        `}</div>
       </div>
     `).join('');
   }

--- a/my/index.html
+++ b/my/index.html
@@ -73,6 +73,9 @@
 
   .cancel-confirm{display:flex;align-items:center;gap:8px;flex-wrap:wrap;}
   .cancel-confirm span{font-size:0.82rem;color:var(--text-secondary);}
+  .cancel-confirm.series{flex-direction:column;align-items:flex-start;}
+  .cancel-confirm-btns{display:flex;gap:8px;flex-wrap:wrap;}
+  .recurring-tag{display:inline-block;font-size:0.6rem;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:var(--sage-dark);background:var(--success-bg);padding:2px 8px;border-radius:20px;vertical-align:middle;}
   .btn-cancel-yes{padding:8px 14px;background:var(--error);color:white;border:none;border-radius:8px;font-size:0.82rem;font-weight:500;cursor:pointer;font-family:'DM Sans',sans-serif;}
   .btn-cancel-yes:hover{opacity:0.9;}
   .btn-cancel-keep{padding:8px 14px;background:transparent;border:1px solid var(--border);color:var(--text-muted);border-radius:8px;font-size:0.82rem;cursor:pointer;font-family:'DM Sans',sans-serif;}
@@ -327,11 +330,11 @@ function actionButtons(b) {
       : `<a href="/track/?booking=${b.id}" class="btn-ghost">View walk</a>`;
   }
   if (b.status === 'confirmed') {
-    if (pendingCancelId === b.id) return cancelConfirmHtml(b.id);
+    if (pendingCancelId === b.id) return cancelConfirmHtml(b);
     return `<a href="/track/?booking=${b.id}" class="btn-ghost">View booking</a><button class="btn-ghost danger" onclick="showCancelConfirm('${b.id}')">Cancel</button>`;
   }
   if (b.status === 'pending') {
-    if (pendingCancelId === b.id) return cancelConfirmHtml(b.id);
+    if (pendingCancelId === b.id) return cancelConfirmHtml(b);
     return `<button class="btn-ghost danger" onclick="showCancelConfirm('${b.id}')">Cancel</button>`;
   }
   if (b.status === 'completed') {
@@ -345,8 +348,18 @@ function actionButtons(b) {
   return '';
 }
 
-function cancelConfirmHtml(id) {
-  return `<div class="cancel-confirm"><span>Are you sure?</span><button class="btn-cancel-yes" onclick="doCancelBooking('${id}')">Yes, cancel</button><button class="btn-cancel-keep" onclick="dismissCancel()">Keep booking</button></div>`;
+function cancelConfirmHtml(b) {
+  if (b.series_id) {
+    return `<div class="cancel-confirm series">
+      <span>This is a recurring walk — what would you like to cancel?</span>
+      <div class="cancel-confirm-btns">
+        <button class="btn-cancel-yes" onclick="doCancelBooking('${b.id}')">Just this walk</button>
+        <button class="btn-cancel-yes" onclick="doCancelSeries('${b.series_id}')">All future walks</button>
+        <button class="btn-cancel-keep" onclick="dismissCancel()">Keep</button>
+      </div>
+    </div>`;
+  }
+  return `<div class="cancel-confirm"><span>Are you sure?</span><button class="btn-cancel-yes" onclick="doCancelBooking('${b.id}')">Yes, cancel</button><button class="btn-cancel-keep" onclick="dismissCancel()">Keep booking</button></div>`;
 }
 
 function bookingCardHtml(b) {
@@ -356,9 +369,10 @@ function bookingCardHtml(b) {
   const dateStr = b.scheduled_at ? formatScheduledAt(b.scheduled_at) : '';
   const actions = actionButtons(b);
   const msgLink = `<a href="/messages/?booking=${b.id}" class="btn-ghost bc-msg-link">Message <span class="bc-msg-badge" id="cardbadge-${b.id}" style="display:none;">0</span></a>`;
+  const recurringTag = b.series_id ? ' <span class="recurring-tag">Recurring</span>' : '';
   return `
     <div class="booking-card">
-      <div class="bc-pet-name">${petLabel}</div>
+      <div class="bc-pet-name">${petLabel}${recurringTag}</div>
       <div class="bc-meta">${serviceLabel} · ${provLabel}</div>
       <div class="bc-time">${esc(dateStr)}</div>
       ${statusBadge(b.status)}
@@ -556,6 +570,21 @@ async function doCancelBooking(id) {
     if (b) b.status = 'cancelled';
     pendingCancelId = null;
     renderBookingsTab();
+  } catch(e) { showMsg(e.message, 'error'); }
+}
+async function doCancelSeries(seriesId) {
+  try {
+    await sbPatch('booking_series', 'id', seriesId, { status: 'cancelled' });
+    // Mirror the DB trigger locally: cancel future pending/confirmed walks.
+    const now = Date.now();
+    bookings.forEach(b => {
+      if (b.series_id === seriesId && (b.status === 'pending' || b.status === 'confirmed') && new Date(b.scheduled_at).getTime() > now) {
+        b.status = 'cancelled';
+      }
+    });
+    pendingCancelId = null;
+    renderBookingsTab();
+    showMsg('Recurring schedule cancelled — upcoming walks were cancelled. Past walks are unchanged.', 'success');
   } catch(e) { showMsg(e.message, 'error'); }
 }
 

--- a/supabase/migrations/20260612_recurring_walks_series_cancel.sql
+++ b/supabase/migrations/20260612_recurring_walks_series_cancel.sql
@@ -1,0 +1,32 @@
+-- TRU-38 — Recurring walks: series-level cancellation cascade.
+--
+-- Applied to Supabase via the Supabase MCP; this file is the
+-- version-controlled record.
+--
+-- When a series is cancelled (by either party via the existing update RLS),
+-- cancel all of its FUTURE pending/confirmed bookings. Past, in-progress and
+-- completed walks are left untouched. The rolling job already skips
+-- non-active series, so nothing regenerates.
+CREATE OR REPLACE FUNCTION public.trg_series_cancelled()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.status = 'cancelled' AND (OLD.status IS DISTINCT FROM 'cancelled') THEN
+    UPDATE public.bookings
+       SET status = 'cancelled', updated_at = now()
+     WHERE series_id = NEW.id
+       AND status IN ('pending', 'confirmed')
+       AND scheduled_at > now();
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS series_cancelled ON public.booking_series;
+CREATE TRIGGER series_cancelled
+  AFTER UPDATE OF status ON public.booking_series
+  FOR EACH ROW
+  EXECUTE FUNCTION public.trg_series_cancelled();


### PR DESCRIPTION
Final PR of the recurring-walks epic — the cancellation flows. Either party can cancel a single walk or end the whole series.

## DB (migration applied + tracked under supabase/migrations/)
- **Trigger on `booking_series`**: when a series is cancelled, it cancels all of its **future** `pending`/`confirmed` bookings (`scheduled_at > now`). Past, in-progress and completed walks are untouched; the rolling job already skips non-active series so nothing regenerates.
- Series-level cancel just flips `booking_series.status` to `cancelled` (allowed for both parties by the existing update RLS); the trigger does the cascade.

## Customer — `my/index.html`
- Series bookings show a **Recurring** tag.
- Cancelling a recurring walk offers a series-aware choice: **"Just this walk"** vs **"All future walks"** (ends the series). One-off bookings keep the simple confirm.

## Provider — `dashboard/index.html`
- Upcoming series walks show a **Recurring** tag and a **Cancel** action with the same two-way choice; one-off confirmed bookings get a plain "Cancel this walk?".

Clients mirror the cascade locally (cancel future walks in the in-memory list) so the UI updates without a refetch.

## Verified end-to-end (both sides)
- **Single walk**: cancels just that booking; others untouched; series stays active.
- **Whole series**: series → `cancelled`, all future walks cancelled, **past/completed walks preserved** (confirmed in DB — e.g. 20 cancelled, 1 already-past walk left as-is).
- No console errors; test data cleaned up.

## Epic complete
With this, TRU-12 is fully built across three PRs: #30 (create → accept → generate), #31 (rolling job), and this one (cancellations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)