### PR TITLE
TRU-79: remove remaining emojis site-wide

### DIFF
--- a/book/index.html
+++ b/book/index.html
@@ -123,7 +123,8 @@
   }
   .pet-option:hover { border-color: var(--sage-light); }
   .pet-option.selected { border-color: var(--terracotta); background: rgba(196,117,91,0.05); }
-  .pet-option .pet-icon { font-size: 1.4rem; }
+  .pet-option .pet-icon { display: inline-flex; color: var(--terracotta); }
+  .pet-option .pet-icon svg { width: 22px; height: 22px; display: block; }
   .pet-option .pet-name { font-size: 0.88rem; font-weight: 500; color: var(--text-primary); }
   .pet-option .pet-breed { font-size: 0.75rem; color: var(--text-muted); }
   .pet-option input { display: none; }
@@ -201,7 +202,9 @@ const SERVICE_LABELS = {
 
 const MULTI_DAY_SERVICES = ['dog_boarding', 'dog_sitting'];
 
-const SPECIES_ICONS = { dog: '🐕', cat: '🐈', other: '🐾' };
+const PAW_SVG = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="8" cy="8" rx="1.5" ry="2"/><ellipse cx="16" cy="8" rx="1.5" ry="2"/><ellipse cx="5" cy="13" rx="1.3" ry="1.6"/><ellipse cx="19" cy="13" rx="1.3" ry="1.6"/><path d="M8.5 17.5c0-2.2 1.6-3.5 3.5-3.5s3.5 1.3 3.5 3.5-1.6 3-3.5 3-3.5-.8-3.5-3z"/></svg>';
+const CAT_SVG = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M5 8l1-3 3 2.5M19 8l-1-3-3 2.5"/><path d="M5 8c-.5 2-.5 4 0 6 1 3 4 5 7 5s6-2 7-5c.5-2 .5-4 0-6"/><path d="M10 13h.01M14 13h.01M11 16c.5.4 1.5.4 2 0"/></svg>';
+const SPECIES_ICONS = { dog: PAW_SVG, cat: CAT_SVG, other: PAW_SVG };
 
 let authToken = null, authUid = null;
 let providerData = null, providerProfile = null, providerServices = [];
@@ -481,7 +484,7 @@ function renderBookingForm() {
   const petsHtml = customerPets.map((p, i) => `
     <label class="pet-option ${i === 0 ? 'selected' : ''}">
       <input type="checkbox" name="pet" value="${p.id}" ${i === 0 ? 'checked' : ''} onchange="onPetToggle(this)">
-      <span class="pet-icon">${SPECIES_ICONS[p.species] || '🐾'}</span>
+      <span class="pet-icon">${SPECIES_ICONS[p.species] || PAW_SVG}</span>
       <div><div class="pet-name">${p.name}</div>${p.breed ? `<div class="pet-breed">${p.breed}</div>` : ''}</div>
     </label>
   `).join('');

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -604,7 +604,7 @@ function renderBookingsTab() {
   }
 
   if (pending.length === 0 && confirmed.length === 0 && series.length === 0) {
-    html = `<div class="empty"><div class="empty-icon">📋</div>No bookings yet. Once customers book you, their requests will appear here.</div>`;
+    html = `<div class="empty"><div class="empty-icon"><svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3.5" y="5" width="17" height="15" rx="2"/><path d="M3.5 9.5h17M8 3v4M16 3v4"/></svg></div>No bookings yet. Once customers book you, their requests will appear here.</div>`;
   }
 
   area.innerHTML = html;
@@ -673,7 +673,7 @@ function renderDashboard() {
     <!-- Earnings placeholder -->
     <div class="tab-content" id="tab-earnings">
       <div class="placeholder-card">
-        <div class="ph-icon">📊</div>
+        <div class="ph-icon"><svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 20h18M6 20v-6M11 20V8M16 20v-9"/></svg></div>
         <h3>Earnings tracker coming soon</h3>
         <p>Track your completed bookings and total earnings here. During our launch period, Truffl is free — $0 commission on all bookings.</p>
       </div>

--- a/login/index.html
+++ b/login/index.html
@@ -142,7 +142,9 @@
     text-decoration: none; color: inherit;
   }
   .signup-option:hover { border-color: var(--terracotta); background: rgba(196,117,91,0.03); }
-  .signup-option .opt-icon { font-size: 1.6rem; margin-bottom: 8px; display: block; line-height: 1; }
+  .signup-option .opt-icon { color: var(--terracotta); margin-bottom: 8px; display: block; line-height: 1; }
+  .signup-option .opt-icon svg { width: 26px; height: 26px; }
+  .species-card .species-icon svg { width: 26px; height: 26px; }
   .signup-option .opt-title { font-size: 0.88rem; font-weight: 500; color: var(--text-primary); margin-bottom: 4px; }
   .signup-option .opt-desc { font-size: 0.75rem; color: var(--text-muted); line-height: 1.4; }
 
@@ -200,7 +202,7 @@
   }
   .species-card:hover { border-color: var(--sage-light); background: rgba(139,158,126,0.04); }
   .species-card.selected { border-color: var(--terracotta); background: rgba(196,117,91,0.06); }
-  .species-card .species-icon { font-size: 1.8rem; line-height: 1; }
+  .species-card .species-icon { display: flex; line-height: 1; color: var(--terracotta); }
   .species-card .species-name { font-size: 0.82rem; font-weight: 500; color: var(--text-primary); }
   .species-card input { display: none; }
 
@@ -285,12 +287,12 @@
     <div class="divider">Don't have an account?</div>
     <div class="signup-options">
       <div class="signup-option" onclick="showView('customerSignup')">
-        <span class="opt-icon">🔍</span>
+        <span class="opt-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="6.5"/><path d="M16 16l4 4"/></svg></span>
         <div class="opt-title">Find a carer</div>
         <div class="opt-desc">I'm a dog owner looking for trusted care</div>
       </div>
       <div class="signup-option" onclick="showView('providerSignup')">
-        <span class="opt-icon">🐕</span>
+        <span class="opt-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="8" cy="8" rx="1.5" ry="2"/><ellipse cx="16" cy="8" rx="1.5" ry="2"/><ellipse cx="5" cy="13" rx="1.3" ry="1.6"/><ellipse cx="19" cy="13" rx="1.3" ry="1.6"/><path d="M8.5 17.5c0-2.2 1.6-3.5 3.5-3.5s3.5 1.3 3.5 3.5-1.6 3-3.5 3-3.5-.8-3.5-3z"/></svg></span>
         <div class="opt-title">Become a carer</div>
         <div class="opt-desc">I want to offer professional dog care</div>
       </div>
@@ -356,14 +358,14 @@
     <!-- Customer Step 3: Pet -->
     <div class="form-step" id="cStep3">
       <div class="form-card">
-        <div style="text-align:center;margin-bottom:1.2rem;"><span style="font-size:2.4rem;">🐕</span></div>
+        <div style="text-align:center;margin-bottom:1.2rem;color:var(--terracotta);"><svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="8" cy="8" rx="1.5" ry="2"/><ellipse cx="16" cy="8" rx="1.5" ry="2"/><ellipse cx="5" cy="13" rx="1.3" ry="1.6"/><ellipse cx="19" cy="13" rx="1.3" ry="1.6"/><path d="M8.5 17.5c0-2.2 1.6-3.5 3.5-3.5s3.5 1.3 3.5 3.5-1.6 3-3.5 3-3.5-.8-3.5-3z"/></svg></div>
         <h2 style="text-align:center;">Tell us about your dog</h2>
         <p style="text-align:center;">The more we know, the better we can match you.</p>
         <div class="field"><label>What kind of pet?</label>
           <div class="species-grid">
-            <label class="species-card selected" onclick="selectSpecies(this,'dog')"><input type="radio" name="species" value="dog" checked><span class="species-icon">🐕</span><span class="species-name">Dog</span></label>
-            <label class="species-card" onclick="selectSpecies(this,'cat')"><input type="radio" name="species" value="cat"><span class="species-icon">🐈</span><span class="species-name">Cat</span></label>
-            <label class="species-card" onclick="selectSpecies(this,'other')"><input type="radio" name="species" value="other"><span class="species-icon">🐾</span><span class="species-name">Other</span></label>
+            <label class="species-card selected" onclick="selectSpecies(this,'dog')"><input type="radio" name="species" value="dog" checked><span class="species-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="8" cy="8" rx="1.5" ry="2"/><ellipse cx="16" cy="8" rx="1.5" ry="2"/><ellipse cx="5" cy="13" rx="1.3" ry="1.6"/><ellipse cx="19" cy="13" rx="1.3" ry="1.6"/><path d="M8.5 17.5c0-2.2 1.6-3.5 3.5-3.5s3.5 1.3 3.5 3.5-1.6 3-3.5 3-3.5-.8-3.5-3z"/></svg></span><span class="species-name">Dog</span></label>
+            <label class="species-card" onclick="selectSpecies(this,'cat')"><input type="radio" name="species" value="cat"><span class="species-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M5 8l1-3 3 2.5M19 8l-1-3-3 2.5"/><path d="M5 8c-.5 2-.5 4 0 6 1 3 4 5 7 5s6-2 7-5c.5-2 .5-4 0-6"/><path d="M10 13h.01M14 13h.01M11 16c.5.4 1.5.4 2 0"/></svg></span><span class="species-name">Cat</span></label>
+            <label class="species-card" onclick="selectSpecies(this,'other')"><input type="radio" name="species" value="other"><span class="species-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="8" cy="8" rx="1.5" ry="2"/><ellipse cx="16" cy="8" rx="1.5" ry="2"/><ellipse cx="5" cy="13" rx="1.3" ry="1.6"/><ellipse cx="19" cy="13" rx="1.3" ry="1.6"/><path d="M8.5 17.5c0-2.2 1.6-3.5 3.5-3.5s3.5 1.3 3.5 3.5-1.6 3-3.5 3-3.5-.8-3.5-3z"/></svg></span><span class="species-name">Other</span></label>
           </div>
         </div>
         <div class="field"><label>Pet's name</label><input type="text" id="cPetName" placeholder="e.g. Flick"></div>

--- a/my/index.html
+++ b/my/index.html
@@ -402,7 +402,7 @@ function renderBookingsTab() {
   if (bookings.length === 0) {
     area.innerHTML = `
       <div class="empty">
-        <div class="empty-emoji">🐾</div>
+        <div class="empty-emoji"><svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="8" cy="8" rx="1.5" ry="2"/><ellipse cx="16" cy="8" rx="1.5" ry="2"/><ellipse cx="5" cy="13" rx="1.3" ry="1.6"/><ellipse cx="19" cy="13" rx="1.3" ry="1.6"/><path d="M8.5 17.5c0-2.2 1.6-3.5 3.5-3.5s3.5 1.3 3.5 3.5-1.6 3-3.5 3-3.5-.8-3.5-3z"/></svg></div>
         <h3>No bookings yet</h3>
         <p>Find a trusted carer and book your first walk.</p>
         <a href="/search/" class="btn-primary">Find a carer</a>

--- a/profile/index.html
+++ b/profile/index.html
@@ -191,7 +191,9 @@ function renderAvatar() {
   if (userData.avatar_url) {
     el.innerHTML = `<img src="${esc(userData.avatar_url)}" alt="Your profile photo">`;
   } else {
-    el.textContent = initials(userData.first_name, userData.last_name) || '🐾';
+    const ini = initials(userData.first_name, userData.last_name);
+    if (ini) el.textContent = ini;
+    else el.innerHTML = `<svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="8" cy="8" rx="1.5" ry="2"/><ellipse cx="16" cy="8" rx="1.5" ry="2"/><ellipse cx="5" cy="13" rx="1.3" ry="1.6"/><ellipse cx="19" cy="13" rx="1.3" ry="1.6"/><path d="M8.5 17.5c0-2.2 1.6-3.5 3.5-3.5s3.5 1.3 3.5 3.5-1.6 3-3.5 3-3.5-.8-3.5-3z"/></svg>`;
   }
 }
 function renderNav() {

--- a/track/index.html
+++ b/track/index.html
@@ -51,6 +51,7 @@
   .update-feed{display:flex;flex-direction:column;gap:8px;margin-top:1rem;}
   .update-item{display:flex;gap:10px;padding:10px 12px;background:var(--warm-white);border:1px solid var(--border);border-radius:10px;font-size:0.82rem;}
   .update-icon{width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;flex-shrink:0;font-size:0.75rem;}
+  .update-icon svg{width:15px;height:15px;}
   .update-icon.mood{background:var(--success-bg);color:var(--success);}
   .update-icon.comment{background:rgba(196,117,91,0.1);color:var(--terracotta);}
   .update-icon.photo{background:rgba(139,158,126,0.1);color:var(--sage-dark);}
@@ -114,6 +115,12 @@
 <script>
 const SUPABASE_URL = 'https://gadflsntbnbnnxbpiral.supabase.co';
 const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdhZGZsc250Ym5ibm54YnBpcmFsIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzUwNjcwNTcsImV4cCI6MjA5MDY0MzA1N30.g5ZrqeAX9U5l7oDZEbQFrU5j10828dUF0QuJ0ZlHXK8';
+
+const UPDATE_ICONS = {
+  mood: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><path d="M9 9.5h.01M15 9.5h.01"/></svg>',
+  photo: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M3 8.5A1.5 1.5 0 0 1 4.5 7H7l1-2h8l1 2h2.5A1.5 1.5 0 0 1 21 8.5V18a1.5 1.5 0 0 1-1.5 1.5h-15A1.5 1.5 0 0 1 3 18z"/><circle cx="12" cy="13" r="3.2"/></svg>',
+  comment: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/></svg>'
+};
 
 let authToken = null, authUid = null;
 let booking = null, walkSession = null, bookingId = null;
@@ -198,7 +205,7 @@ function addUpdateToFeed(update) {
   const emptyState = feed.querySelector('.empty-state');
   if (emptyState) emptyState.remove();
   const iconClass = update.update_type === 'mood' ? 'mood' : update.update_type === 'photo' ? 'photo' : 'comment';
-  const iconSymbol = update.update_type === 'mood' ? '😊' : update.update_type === 'photo' ? '📷' : '💬';
+  const iconSymbol = update.update_type === 'mood' ? UPDATE_ICONS.mood : update.update_type === 'photo' ? UPDATE_ICONS.photo : UPDATE_ICONS.comment;
   const photoHtml = update.photo_url ? `<img src="${update.photo_url}" class="update-photo" alt="Walk photo">` : '';
   const item = document.createElement('div');
   item.className = 'update-item fade-in';
@@ -355,7 +362,7 @@ function renderSummary(allUpdates) {
 
   area.innerHTML = `
     <div class="summary-card fade-in">
-      <div style="font-size:2.4rem;margin-bottom:0.5rem;">🎉</div>
+      <div style="margin-bottom:0.5rem;color:var(--success);display:flex;justify-content:center;"><svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M8 12.5l2.5 2.5L16 9"/></svg></div>
       <h2>Walk complete!</h2>
       <p style="color:var(--text-secondary);font-size:0.9rem;">Here's how ${petName}'s walk went.</p>
 

--- a/walk/index.html
+++ b/walk/index.html
@@ -65,7 +65,9 @@
 
   /* Mood chips */
   .mood-chips{display:flex;flex-wrap:wrap;gap:6px;margin-bottom:1rem;}
-  .mood-chip{padding:8px 14px;border:1px solid var(--border);border-radius:20px;font-size:0.8rem;color:var(--text-secondary);cursor:pointer;transition:all 0.2s;background:var(--warm-white);}
+  .mood-chip{display:inline-flex;align-items:center;gap:7px;padding:8px 14px;border:1px solid var(--border);border-radius:20px;font-size:0.8rem;color:var(--text-secondary);cursor:pointer;transition:all 0.2s;background:var(--warm-white);}
+  .mood-chip svg{width:16px;height:16px;flex-shrink:0;}
+  .status-bar svg{vertical-align:-3px;margin-right:2px;}
   .mood-chip:hover{border-color:var(--sage);}
   .mood-chip.sent{border-color:var(--success);background:var(--success-bg);color:var(--success);cursor:default;}
 
@@ -88,6 +90,7 @@
   .update-feed{display:flex;flex-direction:column;gap:8px;margin-top:1rem;}
   .update-item{display:flex;gap:10px;padding:10px 12px;background:var(--warm-white);border:1px solid var(--border);border-radius:10px;font-size:0.82rem;}
   .update-icon{width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;flex-shrink:0;font-size:0.75rem;}
+  .update-icon svg{width:15px;height:15px;}
   .update-icon.mood{background:var(--success-bg);color:var(--success);}
   .update-icon.comment{background:rgba(196,117,91,0.1);color:var(--terracotta);}
   .update-icon.photo{background:rgba(139,158,126,0.1);color:var(--sage-dark);}
@@ -159,6 +162,12 @@
 <script>
 const SUPABASE_URL='https://gadflsntbnbnnxbpiral.supabase.co';
 const SUPABASE_ANON_KEY='eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdhZGZsc250Ym5ibm54YnBpcmFsIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzUwNjcwNTcsImV4cCI6MjA5MDY0MzA1N30.g5ZrqeAX9U5l7oDZEbQFrU5j10828dUF0QuJ0ZlHXK8';
+
+const UPDATE_ICONS = {
+  mood: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><path d="M9 9.5h.01M15 9.5h.01"/></svg>',
+  photo: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M3 8.5A1.5 1.5 0 0 1 4.5 7H7l1-2h8l1 2h2.5A1.5 1.5 0 0 1 21 8.5V18a1.5 1.5 0 0 1-1.5 1.5h-15A1.5 1.5 0 0 1 3 18z"/><circle cx="12" cy="13" r="3.2"/></svg>',
+  comment: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/></svg>'
+};
 
 let authToken=null, authUid=null;
 let booking=null, walkSession=null, map=null, polyline=null;
@@ -234,7 +243,7 @@ function addUpdateToFeed(type, message, photoUrl){
   const feed=document.getElementById('updateFeed');
   if(!feed) return;
   const iconClass=type==='mood'?'mood':type==='photo'?'photo':'comment';
-  const iconSymbol=type==='mood'?'😊':type==='photo'?'📷':'💬';
+  const iconSymbol=type==='mood'?UPDATE_ICONS.mood:type==='photo'?UPDATE_ICONS.photo:UPDATE_ICONS.comment;
   let photoHtml=photoUrl?`<img src="${photoUrl}" class="update-photo" alt="Walk photo">` :'';
   feed.innerHTML=`
     <div class="update-item fade-in">
@@ -396,7 +405,7 @@ async function endWalk(){
 function renderPreWalk(){
   const area=document.getElementById('walkContent');
   area.innerHTML=`
-    <div class="status-bar idle"><span>📋</span> Ready to start</div>
+    <div class="status-bar idle"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M10 9l5 3-5 3z"/></svg> Ready to start</div>
 
     <div style="background:var(--warm-white);border:1px solid var(--border);border-radius:14px;padding:1.25rem;margin-bottom:1rem;">
       <div style="font-size:0.78rem;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.08em;margin-bottom:8px;">Booking details</div>
@@ -437,11 +446,11 @@ function renderActiveWalk(){
 
     <div class="section-title">Send an update</div>
     <div class="mood-chips">
-      <span class="mood-chip" onclick="sendMood(this,'Happy and energetic')">😊 Happy and energetic</span>
-      <span class="mood-chip" onclick="sendMood(this,'Calm and relaxed')">😌 Calm and relaxed</span>
-      <span class="mood-chip" onclick="sendMood(this,'Playful and social')">🐕 Playful and social</span>
-      <span class="mood-chip" onclick="sendMood(this,'A bit anxious today')">😟 A bit anxious</span>
-      <span class="mood-chip" onclick="sendMood(this,'Tired but happy')">😴 Tired but happy</span>
+      <span class="mood-chip" onclick="sendMood(this,'Happy and energetic')"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><path d="M9 9.5h.01M15 9.5h.01"/></svg> Happy and energetic</span>
+      <span class="mood-chip" onclick="sendMood(this,'Calm and relaxed')"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M8.5 14.5c1 .8 6 .8 7 0"/><path d="M8.5 10c.5-.6 1.5-.6 2 0M13.5 10c.5-.6 1.5-.6 2 0"/></svg> Calm and relaxed</span>
+      <span class="mood-chip" onclick="sendMood(this,'Playful and social')"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="8" cy="8" rx="1.5" ry="2"/><ellipse cx="16" cy="8" rx="1.5" ry="2"/><ellipse cx="5" cy="13" rx="1.3" ry="1.6"/><ellipse cx="19" cy="13" rx="1.3" ry="1.6"/><path d="M8.5 17.5c0-2.2 1.6-3.5 3.5-3.5s3.5 1.3 3.5 3.5-1.6 3-3.5 3-3.5-.8-3.5-3z"/></svg> Playful and social</span>
+      <span class="mood-chip" onclick="sendMood(this,'A bit anxious today')"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M8.5 15.5c1-1.2 6-1.2 7 0"/><path d="M9 9.5h.01M15 9.5h.01"/></svg> A bit anxious</span>
+      <span class="mood-chip" onclick="sendMood(this,'Tired but happy')"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M8 10h2M14 10h2M9 15h6"/></svg> Tired but happy</span>
     </div>
 
     <div class="comment-box">
@@ -496,7 +505,7 @@ function renderSummary(){
 
   area.innerHTML=`
     <div class="summary-card fade-in">
-      <div style="font-size:2.4rem;margin-bottom:0.5rem;">🎉</div>
+      <div style="margin-bottom:0.5rem;color:var(--success);display:flex;justify-content:center;"><svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M8 12.5l2.5 2.5L16 9"/></svg></div>
       <h2>Walk complete!</h2>
       <p style="color:var(--text-secondary);font-size:0.9rem;">Great job. ${customerName} has been notified.</p>
 


### PR DESCRIPTION
Completes the emoji → line-icon migration started in #24 (which covered search/home/about). This sweeps the remaining pages so the rendered UI is emoji-free.

## Replacements (inline SVG, `stroke="currentColor"`)
- **book** — pet species `🐕🐈🐾` → paw / cat icons (paw is the dogs-only default).
- **my**, **profile** — empty-state and avatar-fallback `🐾` → paw.
- **dashboard** — `📋` empty-bookings → calendar; `📊` earnings placeholder → bar chart.
- **track** + **walk** — walk-update icons `😊📷💬` → smiley / camera / chat; `🎉` walk-complete → check-circle; walk `📋` "ready to start" → play; mood chips `😊😌🐕😟😴` → happy / calm / paw / anxious / tired line faces.
- **login** — `🔍` → search; onboarding/species `🐕🐈🐾` → paw / cat.

## Kept as-is
Typographic `★` rating stars and `✓` checkmarks (not pictographic emoji), consistent with #24.

## Verified
- Inventory: no pictographic emoji remain in any page's rendered UI.
- Rendered all the custom glyphs (mood faces, camera, chart, check-circle) — they read clearly and match the line-icon style.
- Login signup icons (search / paw) verified in-page. No console errors.

Closes the site-wide emoji cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)