### PR TITLE
TRU-16: provider booking detail enrichment (+ address capture)

### DIFF
--- a/book/index.html
+++ b/book/index.html
@@ -269,6 +269,41 @@ async function sbInsert(table, row, token) {
   return await r.json();
 }
 
+async function sbPatch(table, params, row, token) {
+  const r = await fetch(`${SUPABASE_URL}/rest/v1/${table}?${params}`, {
+    method: 'PATCH', headers: { ...headers(token), 'Prefer': 'return=minimal' }, body: JSON.stringify(row)
+  });
+  if (!r.ok) { const e = await r.json().catch(() => ({})); throw new Error(e.message || 'Update failed'); }
+}
+
+function esc(s) { return (s || '').toString().replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
+
+// Services performed at the customer's home — we need their address for the carer.
+const AT_HOME_SERVICES = ['dog_walking', 'dog_sitting', 'pet_sitting'];
+
+// Toggle + validate/save the address block for at-home services.
+function updateAddressSection() {
+  const sec = document.getElementById('addressSection');
+  if (sec) sec.style.display = AT_HOME_SERVICES.includes(selectedSvcType) ? 'block' : 'none';
+}
+
+// Collects the address fields for an at-home service, validates them, and persists them to
+// the customer's profile so the carer can see them. Returns false if validation failed.
+async function captureAddressIfNeeded(svcType) {
+  if (!AT_HOME_SERVICES.includes(svcType)) return true;
+  const addr = (document.getElementById('bookAddress')?.value || '').trim();
+  const sub = (document.getElementById('bookSuburb')?.value || '').trim();
+  const pc = (document.getElementById('bookPostcode')?.value || '').trim();
+  if (!addr) { showMsg('Please add the address where the carer should come.', 'error'); return false; }
+  if (!sub) { showMsg('Please add your suburb.', 'error'); return false; }
+  const changed = addr !== (customerProfile.address || '') || sub !== (customerProfile.suburb || '') || pc !== (customerProfile.postcode || '');
+  if (changed) {
+    await sbPatch('customer_profiles', `user_id=eq.${authUid}`, { address: addr, suburb: sub, postcode: pc || null }, authToken);
+    customerProfile.address = addr; customerProfile.suburb = sub; customerProfile.postcode = pc || null;
+  }
+  return true;
+}
+
 function showMsg(t, type) { const el = document.getElementById('formMsg'); el.textContent = t; el.className = `msg ${type}`; }
 function clearMsg() { document.getElementById('formMsg').className = 'msg'; }
 function setLoading(btn, on) {
@@ -286,6 +321,7 @@ function selectService(el, serviceId) {
   if (!recurringAllowed(selectedSvcType)) bookingMode = 'oneoff'; // boarding/sitting are one-off multi-day
   document.getElementById('whenSection').innerHTML = renderWhenSection(selectedSvcType);
   updateWindowUI();
+  updateAddressSection();
   const sb = document.getElementById('submitBtn');
   if (sb) sb.textContent = (bookingMode === 'recurring') ? 'Request recurring schedule' : 'Send booking request';
   if (bookingMode === 'recurring') renderPreview();
@@ -594,6 +630,16 @@ function renderBookingForm() {
 
       ${customerPets.length > 1 ? `<div class="field"><label>Which pets? <span class="optional">(select one or more)</span></label><div class="pet-grid">${petsHtml}</div></div>` : ''}
 
+      <div class="field" id="addressSection" style="display:${AT_HOME_SERVICES.includes(selectedSvcType) ? 'block' : 'none'};">
+        <label>Your address <span class="optional">(so your carer can reach you)</span></label>
+        <input type="text" id="bookAddress" placeholder="Street address" value="${esc(customerProfile && customerProfile.address || '')}">
+        <div style="display:flex;gap:10px;margin-top:8px;">
+          <input type="text" id="bookSuburb" placeholder="Suburb" value="${esc(customerProfile && customerProfile.suburb || '')}" style="flex:1;">
+          <input type="text" id="bookPostcode" placeholder="Postcode" value="${esc(customerProfile && customerProfile.postcode || '')}" style="width:120px;">
+        </div>
+        <div style="font-size:0.75rem;color:var(--text-muted);margin-top:6px;">${customerProfile && customerProfile.address ? 'We\'ve pre-filled your saved address — check it\'s right for this booking.' : 'Your carer comes to you, so we need your address. We\'ll save it to your account.'}</div>
+      </div>
+
       <div class="field">
         <label>Notes for the carer <span class="optional">(optional)</span></label>
         <textarea id="bookNotes" placeholder="Gate code, special instructions, anything they should know..."></textarea>
@@ -651,6 +697,8 @@ async function submitBooking() {
   setLoading(btn, true);
 
   try {
+    // For at-home services, confirm/capture the address (saved to the profile) first.
+    if (!(await captureAddressIfNeeded(selectedSvc?.service_type))) return;
     // pet_id keeps the first selected pet as the "primary" for backward compat;
     // every selected pet (including the primary) is recorded in booking_pets.
     const inserted = await sbInsert('bookings', {
@@ -717,6 +765,8 @@ async function submitSeries() {
   const btn = document.querySelector('.btn-primary');
   setLoading(btn, true);
   try {
+    // For at-home services, confirm/capture the address (saved to the profile) first.
+    if (!(await captureAddressIfNeeded(selectedSvc?.service_type))) return;
     const inserted = await sbInsert('booking_series', {
       customer_id: customerProfile.id,
       provider_id: providerProfile.id,

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -101,6 +101,12 @@
   }
   .bc-time { font-size: 0.82rem; color: var(--text-secondary); }
   .bc-notes { font-size: 0.8rem; color: var(--text-muted); margin-top: 6px; font-style: italic; }
+  .bc-detail { margin-top: 8px; padding-top: 8px; border-top: 1px dashed var(--border); display: flex; flex-direction: column; gap: 4px; }
+  .bc-detail-row { font-size: 0.8rem; color: var(--text-secondary); display: flex; align-items: flex-start; gap: 6px; line-height: 1.4; }
+  .bc-detail-row svg { flex-shrink: 0; color: var(--text-muted); margin-top: 2px; }
+  .bc-detail-row a { color: var(--terracotta); text-decoration: none; }
+  .bc-detail-row a:hover { text-decoration: underline; }
+  .bc-detail-label { color: var(--text-muted); }
   .bc-actions { display: flex; gap: 8px; flex-shrink: 0; }
   .bc-btn {
     padding: 8px 16px; border-radius: 8px; font-size: 0.8rem; font-weight: 500;
@@ -432,35 +438,45 @@ async function loadBookings() {
   bookings = await sbGet('bookings', `provider_id=eq.${providerProfile.id}&select=*&order=scheduled_at.asc`);
   if (!bookings.length) return;
 
-  // Customer names via the booking_party_names view — providers can't read a
-  // customer's users/customer_profiles row directly under per-table RLS.
-  const nameByBooking = {};
+  const ids = bookings.map(b => b.id);
+
+  // Providers can't read a customer's users/customer_profiles/pets rows directly under
+  // per-table RLS, so customer name, contact/location and pet care details all come from
+  // definer views scoped to the provider's own bookings.
+  const nameByBooking = {}, contactByBooking = {}, petsByBooking = {};
   try {
-    const ids = bookings.map(b => b.id);
     const parties = await sbGet('booking_party_names', `booking_id=in.(${ids.join(',')})&select=booking_id,customer_first_name,customer_last_name`);
     parties.forEach(p => { nameByBooking[p.booking_id] = `${p.customer_first_name || ''} ${p.customer_last_name || ''}`.trim(); });
   } catch(e) { /* names fall back to 'Customer' */ }
+  try {
+    const rows = await sbGet('booking_contact_details', `booking_id=in.(${ids.join(',')})&select=*`);
+    rows.forEach(r => { contactByBooking[r.booking_id] = r; });
+  } catch(e) { /* contact details optional */ }
+  try {
+    const rows = await sbGet('booking_pet_care', `booking_id=in.(${ids.join(',')})&select=*`);
+    rows.forEach(r => { (petsByBooking[r.booking_id] = petsByBooking[r.booking_id] || []).push(r); });
+  } catch(e) { /* pet details optional */ }
 
-  // Load pet + service info for each booking
-  for (const b of bookings) {
+  const svcIds = [...new Set(bookings.map(b => b.service_id).filter(Boolean))];
+  const svcMap = {};
+  if (svcIds.length) {
     try {
-      b._customer_name = nameByBooking[b.id] || null;
-      let pets = [];
-      try {
-        const bp = await sbGet('booking_pets', `booking_id=eq.${b.id}&select=pet_id`);
-        const ids = bp.map(r => r.pet_id).filter(Boolean);
-        if (ids.length) pets = await sbGet('pets', `id=in.(${ids.join(',')})&select=name,breed,species`);
-      } catch(e) {}
-      if (!pets.length && b.pet_id) pets = await sbGet('pets', `id=eq.${b.pet_id}&select=name,breed,species`);
-      b._pet = pets[0] || null;
-      b._pet_label = pets.length
-        ? (pets.length === 1 ? pets[0].name + (pets[0].breed ? ' · ' + pets[0].breed : '') : pets.map(p => p.name).filter(Boolean).join(' + '))
-        : 'Pet';
-
-      const svcs = await sbGet('provider_services', `id=eq.${b.service_id}&select=service_type`);
-      if (svcs.length) b._service_type = svcs[0].service_type;
+      const svcs = await sbGet('provider_services', `id=in.(${svcIds.join(',')})&select=id,service_type`);
+      svcs.forEach(s => svcMap[s.id] = s.service_type);
     } catch(e) {}
   }
+
+  bookings.forEach(b => {
+    b._customer_name = nameByBooking[b.id] || null;
+    b._contact = contactByBooking[b.id] || null;
+    b._petcare = petsByBooking[b.id] || [];
+    const petNames = b._petcare.map(p => p.name).filter(Boolean);
+    b._pet = b._petcare[0] || null;
+    b._pet_label = petNames.length
+      ? (petNames.length === 1 ? petNames[0] + (b._petcare[0].breed ? ' · ' + b._petcare[0].breed : '') : petNames.join(' + '))
+      : 'Pet';
+    b._service_type = svcMap[b.service_id];
+  });
 }
 
 async function loadSeries() {
@@ -545,6 +561,47 @@ async function cancelSeriesWalks(seriesId) {
   } catch(e) { showMsg(e.message, 'error'); }
 }
 
+// Services performed at the customer's home — the provider needs the address.
+const AT_HOME_SERVICES = ['dog_walking', 'dog_sitting', 'pet_sitting'];
+const PIN_SVG = `<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>`;
+const PHONE_SVG = `<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72c.13.96.36 1.9.7 2.81a2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45c.91.34 1.85.57 2.81.7A2 2 0 0 1 22 16.92z"/></svg>`;
+
+function petCareHtml(petcare) {
+  return (petcare || []).map(p => {
+    const bits = [];
+    if (p.vet_name || p.vet_phone) bits.push(`Vet: ${esc([p.vet_name, p.vet_phone].filter(Boolean).join(' · '))}`);
+    if (p.behaviour_notes) bits.push(`Behaviour: ${esc(p.behaviour_notes)}`);
+    if (p.medical_notes) bits.push(`Medical: ${esc(p.medical_notes)}`);
+    if (!bits.length) return '';
+    return `<div class="bc-detail-row"><span><span class="bc-detail-label">${esc(p.name)} —</span> ${bits.join(' · ')}</span></div>`;
+  }).filter(Boolean).join('');
+}
+
+// Booking detail block for the provider. Pre-accept (pending) shows the suburb only so they
+// can judge the area; once accepted the full address + contact number are shown.
+function bookingDetailsHtml(b) {
+  const c = b._contact || {};
+  const isAtHome = AT_HOME_SERVICES.includes(b._service_type);
+  const accepted = ['confirmed', 'in_progress', 'completed'].includes(b.status);
+  const rows = [];
+  if (accepted && isAtHome && c.address) {
+    const loc = [c.address, c.suburb, c.postcode].filter(Boolean).join(', ');
+    rows.push(`<div class="bc-detail-row">${PIN_SVG}<span>${esc(loc)}</span></div>`);
+  } else if (c.suburb) {
+    const hint = (!accepted && isAtHome) ? ` <span class="bc-detail-label">(address shown once you accept)</span>` : '';
+    rows.push(`<div class="bc-detail-row">${PIN_SVG}<span>${esc(c.suburb)}${hint}</span></div>`);
+  }
+  if (accepted && c.customer_phone) {
+    rows.push(`<div class="bc-detail-row">${PHONE_SVG}<a href="tel:${esc(c.customer_phone)}">${esc(c.customer_phone)}</a></div>`);
+  }
+  if (accepted && c.emergency_phone) {
+    rows.push(`<div class="bc-detail-row"><span><span class="bc-detail-label">Emergency:</span> ${esc([c.emergency_contact, c.emergency_phone].filter(Boolean).join(' · '))}</span></div>`);
+  }
+  const care = petCareHtml(b._petcare);
+  if (care) rows.push(care);
+  return rows.length ? `<div class="bc-detail">${rows.join('')}</div>` : '';
+}
+
 function renderBookingsTab() {
   const pending = bookings.filter(b => b.status === 'pending');
   const confirmed = bookings.filter(b => b.status === 'confirmed');
@@ -581,7 +638,8 @@ function renderBookingsTab() {
           <div class="bc-pet">${b._pet_label || 'Pet'}</div>
           <span class="bc-service">${SERVICE_LABELS[b._service_type] || b._service_type || 'Service'}</span>
           <div class="bc-time">${bookingTimeLine(b)}</div>
-          ${b.customer_notes ? `<div class="bc-notes">"${b.customer_notes}"</div>` : ''}
+          ${b.customer_notes ? `<div class="bc-notes">"${esc(b.customer_notes)}"</div>` : ''}
+          ${bookingDetailsHtml(b)}
         </div>
         <div class="bc-actions">
           <button class="bc-btn accept" onclick="acceptBooking('${b.id}')">Accept</button>
@@ -601,7 +659,8 @@ function renderBookingsTab() {
           <div class="bc-pet">${b._pet_label || 'Pet'}</div>
           <span class="bc-service">${SERVICE_LABELS[b._service_type] || b._service_type || 'Service'}</span>
           <div class="bc-time">${bookingTimeLine(b)}</div>
-          ${b.customer_notes ? `<div class="bc-notes">"${b.customer_notes}"</div>` : ''}
+          ${b.customer_notes ? `<div class="bc-notes">"${esc(b.customer_notes)}"</div>` : ''}
+          ${bookingDetailsHtml(b)}
         </div>
         <div class="bc-actions">${dashCancelId === b.id ? dashCancelConfirm(b) : `
           <button class="bc-btn start-walk" onclick="window.location.href='/walk/?booking=${b.id}'">Start walk</button>

--- a/supabase/migrations/20260615_tru16_provider_booking_detail_views.sql
+++ b/supabase/migrations/20260615_tru16_provider_booking_detail_views.sql
@@ -1,0 +1,47 @@
+-- TRU-16: surface the info a provider needs to do the job. Providers can't read
+-- customer_profiles / users / pets directly under RLS, so expose just what's needed via
+-- definer views scoped to the caller's bookings (same pattern as booking_party_names).
+
+-- Contact + location, one row per booking. Suburb is always visible to the provider so
+-- they can judge the service area; the full street address + contact numbers are withheld
+-- until the booking is accepted (the customer always sees their own).
+create view public.booking_contact_details as
+select
+  b.id as booking_id,
+  b.status,
+  cp.suburb,
+  case when cp.user_id = auth.uid() or b.status in ('confirmed','in_progress','completed') then cp.address end as address,
+  case when cp.user_id = auth.uid() or b.status in ('confirmed','in_progress','completed') then cp.postcode end as postcode,
+  case when cp.user_id = auth.uid() or b.status in ('confirmed','in_progress','completed') then cu.phone end as customer_phone,
+  case when cp.user_id = auth.uid() or b.status in ('confirmed','in_progress','completed') then cp.emergency_contact end as emergency_contact,
+  case when cp.user_id = auth.uid() or b.status in ('confirmed','in_progress','completed') then cp.emergency_phone end as emergency_phone
+from public.bookings b
+join public.customer_profiles cp on cp.id = b.customer_id
+join public.users cu on cu.id = cp.user_id
+join public.provider_profiles pp on pp.id = b.provider_id
+where cp.user_id = auth.uid() or pp.user_id = auth.uid();
+
+grant select on public.booking_contact_details to anon, authenticated, service_role;
+
+-- Pet care details, one row per pet on the booking (covers multi-pet booking_pets, with a
+-- fallback to the legacy single bookings.pet_id). Always visible to the booking's parties.
+create view public.booking_pet_care as
+select b.id as booking_id, p.id as pet_id, p.name, p.breed, p.species, p.sex, p.age_years, p.weight_kg,
+       p.vet_name, p.vet_phone, p.medical_notes, p.behaviour_notes
+from public.bookings b
+join public.booking_pets bpx on bpx.booking_id = b.id
+join public.pets p on p.id = bpx.pet_id
+join public.customer_profiles cp on cp.id = b.customer_id
+join public.provider_profiles pp on pp.id = b.provider_id
+where cp.user_id = auth.uid() or pp.user_id = auth.uid()
+union
+select b.id, p.id, p.name, p.breed, p.species, p.sex, p.age_years, p.weight_kg,
+       p.vet_name, p.vet_phone, p.medical_notes, p.behaviour_notes
+from public.bookings b
+join public.pets p on p.id = b.pet_id
+join public.customer_profiles cp on cp.id = b.customer_id
+join public.provider_profiles pp on pp.id = b.provider_id
+where (cp.user_id = auth.uid() or pp.user_id = auth.uid())
+  and not exists (select 1 from public.booking_pets bpx where bpx.booking_id = b.id);
+
+grant select on public.booking_pet_care to anon, authenticated, service_role;

--- a/walk/index.html
+++ b/walk/index.html
@@ -175,6 +175,8 @@ let gpsPoints=[], watchId=null, timerInterval=null, wakeLock=null;
 let hasComment=false, hasPhoto=false;
 let updates=[];
 let customerName='', petName='', petBreed='';
+let custContact=null, petCare=[];
+function esc(s){return (s||'').toString().replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');}
 
 function h(token){const hd={'Content-Type':'application/json','apikey':SUPABASE_ANON_KEY,'Authorization':`Bearer ${SUPABASE_ANON_KEY}`};if(token)hd['Authorization']=`Bearer ${token}`;return hd;}
 async function sbGet(t,p){const r=await fetch(`${SUPABASE_URL}/rest/v1/${t}?${p}`,{headers:h(authToken)});if(!r.ok){const e=await r.json();throw new Error(e.message);}return await r.json();}
@@ -402,16 +404,31 @@ async function endWalk(){
   }catch(e){showMsg(e.message,'error');}
 }
 
+function walkPetCareHtml(){
+  return (petCare||[]).map(p=>{
+    const bits=[];
+    if(p.vet_name||p.vet_phone) bits.push(`Vet: ${esc([p.vet_name,p.vet_phone].filter(Boolean).join(' · '))}`);
+    if(p.behaviour_notes) bits.push(`Behaviour: ${esc(p.behaviour_notes)}`);
+    if(p.medical_notes) bits.push(`Medical: ${esc(p.medical_notes)}`);
+    if(!bits.length) return '';
+    return `<div style="font-size:0.8rem;color:var(--text-secondary);margin-top:6px;"><strong style="font-weight:500;">${esc(p.name)}</strong> — ${bits.join(' · ')}</div>`;
+  }).filter(Boolean).join('');
+}
+
 function renderPreWalk(){
   const area=document.getElementById('walkContent');
+  const loc = custContact ? [custContact.address, custContact.suburb, custContact.postcode].filter(Boolean).join(', ') : '';
   area.innerHTML=`
     <div class="status-bar idle"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M10 9l5 3-5 3z"/></svg> Ready to start</div>
 
     <div style="background:var(--warm-white);border:1px solid var(--border);border-radius:14px;padding:1.25rem;margin-bottom:1rem;">
       <div style="font-size:0.78rem;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.08em;margin-bottom:8px;">Booking details</div>
-      <div style="font-size:0.95rem;font-weight:500;color:var(--text-primary);">${customerName}</div>
-      <div style="font-size:0.85rem;color:var(--text-muted);">${petName}${petBreed?' · '+petBreed:''}</div>
-      ${booking.customer_notes?`<div style="font-size:0.82rem;color:var(--text-secondary);margin-top:8px;font-style:italic;">"${booking.customer_notes}"</div>`:''}
+      <div style="font-size:0.95rem;font-weight:500;color:var(--text-primary);">${esc(customerName)}</div>
+      <div style="font-size:0.85rem;color:var(--text-muted);">${esc(petName)}${petBreed?' · '+esc(petBreed):''}</div>
+      ${loc?`<div style="font-size:0.85rem;color:var(--text-secondary);margin-top:8px;display:flex;gap:6px;align-items:flex-start;"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink:0;margin-top:2px;color:var(--text-muted);"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg><span>${esc(loc)}</span></div>`:''}
+      ${custContact&&custContact.customer_phone?`<div style="font-size:0.85rem;margin-top:4px;"><a href="tel:${esc(custContact.customer_phone)}" style="color:var(--terracotta);text-decoration:none;">${esc(custContact.customer_phone)}</a></div>`:''}
+      ${walkPetCareHtml()}
+      ${booking.customer_notes?`<div style="font-size:0.82rem;color:var(--text-secondary);margin-top:8px;font-style:italic;">"${esc(booking.customer_notes)}"</div>`:''}
     </div>
 
     <div class="gps-notice">
@@ -558,12 +575,23 @@ async function init(){
     if(!bookings.length){area.innerHTML=`<div class="login-prompt"><h2>Booking not found</h2><p><a href="/dashboard/" style="color:var(--terracotta);">Back to dashboard</a></p></div>`;return;}
     booking=bookings[0];
 
-    // Get customer and pet names
+    // Customer name, contact/address and pet care details come from definer views —
+    // providers can't read the customer's users/customer_profiles/pets rows directly.
     try{
-      const custs=await sbGet('customer_profiles',`id=eq.${booking.customer_id}&select=user_id`);
-      if(custs.length){const users=await sbGet('users',`id=eq.${custs[0].user_id}&select=first_name,last_name`);if(users.length)customerName=`${users[0].first_name} ${users[0].last_name}`;}
-      const pets=await sbGet('pets',`id=eq.${booking.pet_id}&select=name,breed`);
-      if(pets.length){petName=pets[0].name;petBreed=pets[0].breed||'';}
+      const parties=await sbGet('booking_party_names',`booking_id=eq.${bookingId}&select=customer_first_name,customer_last_name`);
+      if(parties.length) customerName=`${parties[0].customer_first_name||''} ${parties[0].customer_last_name||''}`.trim();
+    }catch(e){}
+    try{
+      const c=await sbGet('booking_contact_details',`booking_id=eq.${bookingId}&select=*`);
+      if(c.length) custContact=c[0];
+    }catch(e){}
+    try{
+      petCare=await sbGet('booking_pet_care',`booking_id=eq.${bookingId}&select=*`);
+      if(petCare.length){
+        const names=petCare.map(p=>p.name).filter(Boolean);
+        petName=names.join(' + ');
+        petBreed=petCare.length===1?(petCare[0].breed||''):'';
+      }
     }catch(e){}
 
     // Check if walk already started


### PR DESCRIPTION
## What & why

The booking detail providers see lacked the info they need to do the job — **customer address, contact phone, pet vet details, behavioural/medical notes** — and the dashboard couldn't even show pet names. Root cause: providers can't read `customer_profiles` / `users` / `pets` directly under RLS. This surfaces what's needed via scoped definer views, and closes the gap that the address was often never captured.

## Schema (`supabase/migrations/`)
- **`booking_contact_details`** (per booking): `suburb` is always visible to the provider so they can judge the service area; full **street address + contact/emergency phone are withheld until the booking is accepted** (`confirmed`/`in_progress`/`completed`). The customer always sees their own.
- **`booking_pet_care`** (per pet on the booking, multi-pet + legacy `pet_id` fallback): name, breed, vet, behaviour, medical notes — scoped to the booking's parties.
- Same definer-view pattern as the existing `booking_party_names`.

## Provider surfaces
- **Dashboard cards:** pending → suburb + "(address shown once you accept)"; accepted → full address + phone + emergency + pet care notes. Also **fixes the long-standing "Pet" placeholder** (names now resolve via the view) and batches the old per-booking N+1 reads.
- **Walk page:** shows customer name, address, phone, pet care notes (previously blank for providers — the direct reads were RLS-blocked).

## Address capture (`book/index.html`)
- For at-home services (`dog_walking` / `dog_sitting` / `pet_sitting`), the booking flow now shows an address block — **prefilled from the saved address to confirm, or captured if missing** — required before sending, and **saved back to the customer's profile**. Boarding (at the provider's place) is unaffected. Signup already captures address optionally; this fills the gap when it wasn't.

## Decisions (per product owner)
- Address visibility: **suburb pre-accept, full address post-accept** (provider needs to know the area to decide, but the home address is only shared once committed).
- Capture: optional at signup (already there) **+ confirm/capture in the booking flow**.

## Testing (Preview, provider + customer, seeded then cleaned up)
- Provider dashboard: pending shows suburb only; confirmed shows full address + phone; pet names resolve. Verified the view returns `address=null` on pending and the real address on confirmed.
- Booking flow: address block prefilled from profile; empty address blocked; a changed address persisted to `customer_profiles` and the booking was created.
- Walk page: customer/address/phone/pet now render for the provider.
- No console errors. All seed data removed; profile/address restored.

## Notes
- Adds files under `supabase/migrations/` → the known **non-blocking** Supabase Preview ❌ check will fire (schema applied to the live project via MCP; committed for version control). The new views trip the same `security_definer_view` advisor lint as the existing `booking_party_names`/`series_party_names` — intentional and scoped by `auth.uid()`.
- Limitation: the provider sees the customer's *current* profile address (no per-booking snapshot), which is the right behaviour for walks; a snapshot column could be added later if bookings ever need a fixed historical address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)