### PR TITLE
TRU-50: show walker photos in the customer live tracking feed

### DIFF
--- a/track/index.html
+++ b/track/index.html
@@ -57,7 +57,7 @@
   .update-icon.photo{background:rgba(139,158,126,0.1);color:var(--sage-dark);}
   .update-text{color:var(--text-secondary);line-height:1.4;}
   .update-time{font-size:0.7rem;color:var(--text-muted);margin-top:2px;}
-  .update-photo{width:100%;max-width:200px;border-radius:8px;margin-top:6px;}
+  .update-photo{width:100%;max-width:240px;border-radius:10px;margin-top:8px;display:block;}
 
   .booking-card{background:var(--warm-white);border:1px solid var(--border);border-radius:14px;padding:1.25rem;margin-bottom:1rem;}
 
@@ -206,7 +206,7 @@ function addUpdateToFeed(update) {
   if (emptyState) emptyState.remove();
   const iconClass = update.update_type === 'mood' ? 'mood' : update.update_type === 'photo' ? 'photo' : 'comment';
   const iconSymbol = update.update_type === 'mood' ? UPDATE_ICONS.mood : update.update_type === 'photo' ? UPDATE_ICONS.photo : UPDATE_ICONS.comment;
-  const photoHtml = update.photo_url ? `<img src="${update.photo_url}" class="update-photo" alt="Walk photo">` : '';
+  const photoHtml = update.photo_url ? `<img src="${update.photo_url}" class="update-photo" alt="Walk photo" loading="lazy" onerror="this.style.display='none'">` : '';
   const item = document.createElement('div');
   item.className = 'update-item fade-in';
   item.innerHTML = `
@@ -256,7 +256,7 @@ async function poll() {
     }
 
     const updateQuery = lastUpdateTime
-      ? `walk_session_id=eq.${walkSession.id}&created_at=gt.${lastUpdateTime}&order=created_at.asc&select=*`
+      ? `walk_session_id=eq.${walkSession.id}&created_at=gt.${encodeURIComponent(lastUpdateTime)}&order=created_at.asc&select=*`
       : `walk_session_id=eq.${walkSession.id}&order=created_at.asc&select=*`;
     const newUpdates = await sbGet('walk_updates', updateQuery);
     if (newUpdates.length) {


### PR DESCRIPTION
## What & why

When a walker uploads a photo during a walk, the customer's `/track/` feed showed only the text "Photo update" — no image. Now the actual photo renders inline below the text.

## Changes (`track/index.html` only)
- The feed `<img>` for photo updates gets `loading="lazy"` and `onerror="this.style.display='none'"` (a broken URL hides cleanly instead of showing an icon). `.update-photo` bumped to `max-width:240px; border-radius:10px; display:block` per the spec. Null/empty `photo_url` still renders no image.
- **Bug fix that unblocks the "live polling" criterion:** the incremental `walk_updates` poll interpolated the last-seen timestamp — which ends in a `+00:00` offset — directly into the query string. The `+` was decoded as a space, so PostgREST rejected it (`invalid input syntax for type timestamp with time zone: "...326321 00:00"`) and **every poll during an active walk silently failed** (the error was swallowed by the poll's try/catch). No live update — photo *or* comment — appeared until a full page refresh. Fixed by `encodeURIComponent`-ing the timestamp.

## Testing (Preview, seeded in-progress walk, then cleaned up)
- Photo renders inline, below the text, capped at 240px / rounded, lazy + onerror present, and the image actually loads (`naturalWidth > 0`).
- A comment update (null `photo_url`) renders no image.
- **Live:** with the page open, inserting a new photo update server-side made it appear within one poll cycle (~10s) **without refresh** — and after the encoding fix the poll runs with no console errors.
- All seed data removed; DB back to its prior state.

## Notes
- No schema or storage changes, so the Supabase Preview check won't fire on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)