### PR TITLE
TRU-14: Meet & greets — trust gate before a pair's first booking

### DIFF
--- a/book/index.html
+++ b/book/index.html
@@ -226,6 +226,17 @@ const SERVICE_LABELS = {
 
 const MULTI_DAY_SERVICES = ['dog_boarding', 'dog_sitting'];
 
+// --- Meet & greet (TRU-14) ---------------------------------------------------
+// Natural-language service word for the [Service] token in M&G copy.
+const SERVICE_NATURAL = { dog_walking: 'walk', dog_sitting: 'sitting', dog_boarding: 'boarding stay', pet_sitting: 'visit' };
+// Conditional copy blocks each service swaps in (TRU-14 service-variant mapping).
+const MG_VARIANTS = {
+  dog_walking: ['walking'],
+  dog_boarding: ['carers_home', 'overnight'],
+  dog_sitting: ['home_access', 'overnight'],
+  pet_sitting: ['home_access']
+};
+
 const PAW_SVG = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="8" cy="8" rx="1.5" ry="2"/><ellipse cx="16" cy="8" rx="1.5" ry="2"/><ellipse cx="5" cy="13" rx="1.3" ry="1.6"/><ellipse cx="19" cy="13" rx="1.3" ry="1.6"/><path d="M8.5 17.5c0-2.2 1.6-3.5 3.5-3.5s3.5 1.3 3.5 3.5-1.6 3-3.5 3-3.5-.8-3.5-3z"/></svg>';
 const CAT_SVG = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M5 8l1-3 3 2.5M19 8l-1-3-3 2.5"/><path d="M5 8c-.5 2-.5 4 0 6 1 3 4 5 7 5s6-2 7-5c.5-2 .5-4 0-6"/><path d="M10 13h.01M14 13h.01M11 16c.5.4 1.5.4 2 0"/></svg>';
 const SPECIES_ICONS = { dog: PAW_SVG, cat: CAT_SVG, other: PAW_SVG };
@@ -674,6 +685,141 @@ function renderBookingForm() {
   renderPriceEstimate();
 }
 
+// Owner-modal conditional blocks, keyed to MG_VARIANTS. {Dog}/{Carer} are filled in.
+const MG_OWNER_BLOCKS = {
+  walking: "Where they'll wander, how long they'll be out, and how {Carer} handles other dogs and busy roads.",
+  home_access: "Letting them into your home: how you'll sort keys, the alarm, and anywhere that's off limits.",
+  carers_home: "If you can, meet at {Carer}'s place so you can picture where {Dog} will be. Have a look at the yard and say hello to any other pets in the mix.",
+  overnight: "Where {Dog} will sleep, how the evenings go, and how {Carer} settles a pup who's missing home."
+};
+
+function lockedPriceFor(svc, petCount) {
+  const base = svc.price_cents, extra = svc.additional_pet_price_cents || 0;
+  return base != null ? base + Math.max(0, petCount - 1) * extra : null;
+}
+
+// Has this customer already completed a meet & greet with this carer? If so the
+// gate is cleared for good and we book normally (TRU-14: keyed on a completed M&G
+// existing for the pair, not on booking history).
+async function hasCompletedMeetGreet() {
+  const rows = await sbGet('bookings',
+    `customer_id=eq.${customerProfile.id}&provider_id=eq.${providerProfile.id}&is_meet_and_greet=eq.true&status=eq.completed&select=id`,
+    authToken);
+  return rows.length > 0;
+}
+
+let pendingMgIntent = null;
+
+// First booking with a new carer routes here instead of inserting directly: show
+// the owner education modal, then (on confirm) save the series as pending_meet_greet
+// with a free flagged M&G booking. Address is already captured by the caller.
+function enterMeetGreetFlow(intent) {
+  pendingMgIntent = intent;
+  const dog = esc((customerPets.find(p => p.id === intent.petIds[0]) || {}).name || 'your dog');
+  const carer = esc(providerData.first_name || 'your carer');
+  const svc = SERVICE_NATURAL[intent.svcType] || 'visit';
+  const fill = s => s.replace(/{Dog}/g, dog).replace(/{Carer}/g, carer).replace(/{Service}/g, svc);
+  const extras = (MG_VARIANTS[intent.svcType] || []).map(k => `<li>${fill(MG_OWNER_BLOCKS[k])}</li>`).join('');
+
+  const overlay = document.createElement('div');
+  overlay.id = 'mgModal';
+  overlay.style.cssText = 'position:fixed;inset:0;background:rgba(40,30,25,.55);display:flex;align-items:center;justify-content:center;padding:1rem;z-index:1000;';
+  overlay.innerHTML = `
+    <div class="form-card fade-in" style="max-width:520px;max-height:90vh;overflow-y:auto;margin:0;">
+      <h2 style="margin-top:0;">Time for a proper hello</h2>
+      <p>Trusting someone new with ${dog} is a big deal, and it should be. So before your first ${svc}, you'll meet ${carer} in person. It's free, there's no pressure, and your booking is safely saved. You only go ahead once you've met and you're happy.</p>
+      <p>Think of it as a chance to see the two of them together. Ask anything you like, watch how ${dog} takes to them, and go with your gut. You'll know.</p>
+      <p style="font-weight:600;margin-bottom:.4rem;">A few things worth chatting about:</p>
+      <ul style="margin:0 0 1rem;padding-left:1.2rem;line-height:1.6;">
+        <li>How ${carer} handles dogs like ${dog}: their temperament, recall and energy</li>
+        <li>${dog}'s little routines, what they love, and anything that sets them off</li>
+        <li>Health, vet details, and what happens if something ever goes wrong</li>
+        <li>How you'll stay in the loop, including live GPS updates</li>
+        ${extras}
+      </ul>
+      <p style="background:var(--cream,#fbf6ef);border-radius:10px;padding:.75rem .9rem;font-size:.9rem;">Green flags: they're just as curious about ${dog} as you are, they're calm and easy around them, and no question feels like too much.</p>
+      <div id="mgModalMsg" class="msg" style="margin:.5rem 0;"></div>
+      <div style="display:flex;gap:10px;justify-content:flex-end;margin-top:1rem;flex-wrap:wrap;">
+        <button class="btn" id="mgCancelBtn" onclick="closeMgModal()" style="background:none;border:1px solid var(--border);color:var(--text-secondary);">Not now</button>
+        <button class="btn btn-primary" id="mgConfirmBtn" onclick="createMeetGreetSeries()">Set up the meet &amp; greet</button>
+      </div>
+    </div>`;
+  document.body.appendChild(overlay);
+}
+
+function closeMgModal() {
+  const m = document.getElementById('mgModal');
+  if (m) m.remove();
+  pendingMgIntent = null;
+}
+
+// Persist the pending series + the free, short, flagged M&G booking.
+async function createMeetGreetSeries() {
+  const intent = pendingMgIntent;
+  if (!intent) return;
+  const msg = document.getElementById('mgModalMsg');
+  const btn = document.getElementById('mgConfirmBtn');
+  setLoading(btn, true);
+  try {
+    const seriesIns = await sbInsert('booking_series', {
+      customer_id: customerProfile.id,
+      provider_id: providerProfile.id,
+      service_id: intent.serviceId,
+      booking_kind: intent.kind,
+      frequency_type: intent.frequency_type,
+      days_of_week: intent.days_of_week,
+      time_of_day: intent.time_of_day,
+      window_end_time: intent.window_end_time,
+      start_date: intent.start_date,
+      end_date: intent.end_date,
+      status: 'pending_meet_greet',
+      locked_price_cents: intent.lockedPrice
+    }, authToken);
+    const series = Array.isArray(seriesIns) ? seriesIns[0] : seriesIns;
+    await sbInsert('series_pets', intent.petIds.map(pid => ({ series_id: series.id, pet_id: pid })), authToken);
+
+    // Placeholder time — the real timing is arranged in the messages thread.
+    const mgScheduled = new Date(`${intent.start_date}T12:00:00`).toISOString();
+    const mgIns = await sbInsert('bookings', {
+      customer_id: customerProfile.id,
+      provider_id: providerProfile.id,
+      pet_id: intent.petIds[0],
+      service_id: intent.serviceId,
+      status: 'confirmed',
+      scheduled_at: mgScheduled,
+      duration_mins: 30,
+      total_cents: 0,
+      is_meet_and_greet: true,
+      series_id: series.id
+    }, authToken);
+    const mg = Array.isArray(mgIns) ? mgIns[0] : mgIns;
+    if (mg && mg.id) {
+      await sbInsert('booking_pets', intent.petIds.map(pid => ({ booking_id: mg.id, pet_id: pid })), authToken);
+    }
+    closeMgModal();
+    showMeetGreetSuccess(intent);
+  } catch (e) {
+    if (msg) { msg.textContent = e.message; msg.className = 'msg error'; }
+    setLoading(btn, false);
+  }
+}
+
+function showMeetGreetSuccess(intent) {
+  const carer = esc(providerData.first_name || 'your carer');
+  document.getElementById('bookingContent').innerHTML = `
+    <div class="form-card success-card fade-in">
+      <div class="success-icon"><svg width="28" height="28" viewBox="0 0 24 24" fill="none"><path d="M5 13l4 4L19 7" stroke="#5B8C5A" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/></svg></div>
+      <h2>Your booking is saved</h2>
+      <p>Before your first time with ${carer}, you'll have a quick, free meet &amp; greet — no charge and no commitment. Your booking is locked in and waiting; it only goes ahead once you've met and you're happy.</p>
+      <p style="margin-top:0.75rem;font-size:0.82rem;color:var(--text-muted);">Head to your messages to arrange a time that suits you both. You'll mark the meet &amp; greet complete there once you've met.</p>
+      <div style="margin-top:2rem;display:flex;gap:12px;justify-content:center;flex-wrap:wrap;">
+        <a href="/messages/" style="display:inline-block;padding:12px 28px;background:var(--terracotta);color:white;border-radius:10px;font-weight:500;text-decoration:none;font-size:0.9rem;">Arrange the meet &amp; greet</a>
+        <a href="/profile/" style="display:inline-block;padding:12px 28px;border:1px solid var(--border);color:var(--text-secondary);border-radius:10px;font-weight:500;text-decoration:none;font-size:0.9rem;">View my bookings</a>
+      </div>
+    </div>`;
+  clearMsg();
+}
+
 async function submitBooking() {
   if (bookingMode === 'recurring') return submitSeries();
   clearMsg();
@@ -708,6 +854,24 @@ async function submitBooking() {
   try {
     // For at-home services, confirm/capture the address (saved to the profile) first.
     if (!(await captureAddressIfNeeded(selectedSvc?.service_type))) return;
+
+    // First booking with this carer? Route into the meet & greet flow: the intended
+    // booking is wrapped in a pending_meet_greet series and gated on the M&G.
+    if (!(await hasCompletedMeetGreet())) {
+      const lockedPrice = lockedPriceFor(selectedSvc, selectedPetIds.length);
+      const intent = isMultiDay ? {
+        kind: 'multiday', svcType: selectedSvc.service_type, serviceId: selectedServiceId, petIds: selectedPetIds.slice(),
+        frequency_type: 'daily', days_of_week: [], time_of_day: '12:00', window_end_time: null,
+        start_date: date, end_date: document.getElementById('bookDateEnd')?.value, lockedPrice
+      } : {
+        kind: 'oneoff', svcType: selectedSvc.service_type, serviceId: selectedServiceId, petIds: selectedPetIds.slice(),
+        frequency_type: 'daily', days_of_week: [], time_of_day: idxToHHMM(win.start), window_end_time: idxToHHMM(win.end),
+        start_date: date, end_date: null, lockedPrice
+      };
+      setLoading(btn, false);
+      return enterMeetGreetFlow(intent);
+    }
+
     // pet_id keeps the first selected pet as the "primary" for backward compat;
     // every selected pet (including the primary) is recorded in booking_pets.
     const inserted = await sbInsert('bookings', {
@@ -776,6 +940,22 @@ async function submitSeries() {
   try {
     // For at-home services, confirm/capture the address (saved to the profile) first.
     if (!(await captureAddressIfNeeded(selectedSvc?.service_type))) return;
+
+    // First booking with this carer? Route into the meet & greet flow instead of
+    // activating the schedule straight away.
+    if (!(await hasCompletedMeetGreet())) {
+      const intent = {
+        kind: 'recurring', svcType: selectedSvc.service_type, serviceId: selectedServiceId, petIds: selectedPetIds.slice(),
+        frequency_type: recurring.frequency,
+        days_of_week: recurring.frequency === 'specific_days' ? recurring.days.slice().sort((a, b) => a - b) : [],
+        time_of_day: idxToHHMM(win.start), window_end_time: idxToHHMM(win.end),
+        start_date: recurring.startDate, end_date: recurring.endMode === 'until' ? recurring.endDate : null,
+        lockedPrice
+      };
+      setLoading(btn, false);
+      return enterMeetGreetFlow(intent);
+    }
+
     const inserted = await sbInsert('booking_series', {
       customer_id: customerProfile.id,
       provider_id: providerProfile.id,

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -136,6 +136,9 @@
   }
   .status-pending { background: var(--warning-bg); color: var(--warning); }
   .status-confirmed { background: var(--success-bg); color: var(--success); }
+  .mg-chips { display: flex; flex-wrap: wrap; gap: 8px; }
+  .mg-chip { font: inherit; font-size: 0.82rem; padding: 6px 12px; border-radius: 20px; border: 1px solid var(--border); background: #fff; color: var(--text-secondary); cursor: pointer; }
+  .mg-chip-on { background: var(--terracotta); border-color: var(--terracotta); color: #fff; }
 
   /* Empty state */
   .empty { text-align: center; padding: 2.5rem 1rem; color: var(--text-muted); font-size: 0.9rem; }
@@ -295,9 +298,29 @@ const SERVICE_LABELS = {
   dog_walking:'Dog walking', dog_sitting:'Dog sitting', dog_boarding:'Dog boarding',
   pet_sitting:'Other pet sitting'
 };
+// --- Meet & greet (TRU-14) ---
+const SERVICE_NATURAL = { dog_walking:'walk', dog_sitting:'sitting', dog_boarding:'boarding stay', pet_sitting:'visit' };
+const MG_VARIANTS = {
+  dog_walking: ['walking'],
+  dog_boarding: ['carers_home', 'overnight'],
+  dog_sitting: ['home_access', 'overnight'],
+  pet_sitting: ['home_access']
+};
+const MG_CARER_BLOCKS = {
+  walking: "Confirm the route, timing, and how {Dog} does on lead and around other dogs.",
+  home_access: "You'll be coming into {Owner}'s home, so check access, the alarm, and what's yours to use while you're there.",
+  carers_home: "Show {Owner} around so they can see where {Dog} will stay, including the yard and any other pets you'll have that day.",
+  overnight: "Talk through the overnight setup: where {Dog} sleeps, the evening wind-down, and how you'll handle a restless night."
+};
+const MG_CARER_DECLINE_CHIPS = [
+  'Not comfortable with the dog', 'Location or travel', 'Scheduling clash',
+  'Not the right fit for me', 'Something about the owner'
+];
 
 let authToken = null, authUid = null;
 let userData = null, providerProfile = null, providerServices = [], bookings = [], series = [];
+let mgSeriesById = {};       // pending_meet_greet series (provider side), keyed by id
+let mgBowOutSel = {};        // series_id -> Set of selected carer decline chips
 let dashCancelId = null;
 
 const DAY_SHORT = { 1: 'Mon', 2: 'Tue', 3: 'Wed', 4: 'Thu', 5: 'Fri', 6: 'Sat', 7: 'Sun' };
@@ -346,6 +369,15 @@ async function sbInsert(table, row) {
     method: 'POST', headers: { ...headers(authToken), 'Prefer':'return=representation' }, body: JSON.stringify(row)
   });
   if (!r.ok) { const e = await r.json(); throw new Error(e.message); } return await r.json();
+}
+// Insert without reading the row back — for write-only tables (e.g. decline
+// feedback) that intentionally have no SELECT policy, where return=representation
+// would be rejected by RLS.
+async function sbInsertQuiet(table, row) {
+  const r = await fetch(`${SUPABASE_URL}/rest/v1/${table}`, {
+    method: 'POST', headers: { ...headers(authToken), 'Prefer':'return=minimal' }, body: JSON.stringify(row)
+  });
+  if (!r.ok) { const e = await r.json().catch(() => ({})); throw new Error(e.message || 'Insert failed'); }
 }
 
 function esc(s) {
@@ -508,6 +540,32 @@ async function loadSeries() {
   });
 }
 
+// Pending meet & greet series assigned to this carer — drives the M&G cards.
+async function loadMgSeries() {
+  mgSeriesById = {};
+  let rows = [];
+  try {
+    rows = await sbGet('booking_series', `provider_id=eq.${providerProfile.id}&status=eq.pending_meet_greet&select=*&order=created_at.desc`);
+  } catch(e) { return; }
+  if (!rows.length) return;
+  const ids = rows.map(s => s.id);
+  let nameMap = {};
+  try {
+    const names = await sbGet('series_party_names', `series_id=in.(${ids.join(',')})&select=*`);
+    nameMap = Object.fromEntries(names.map(n => [n.series_id, n]));
+  } catch(e) {}
+  const svcIds = [...new Set(rows.map(s => s.service_id).filter(Boolean))];
+  const svcs = svcIds.length ? await sbGet('provider_services', `id=in.(${svcIds.join(',')})&select=id,service_type`) : [];
+  const svcMap = Object.fromEntries(svcs.map(s => [s.id, s.service_type]));
+  rows.forEach(s => {
+    const n = nameMap[s.id] || {};
+    s._customer_name = `${n.customer_first_name || ''} ${n.customer_last_name || ''}`.trim() || 'the owner';
+    s._pet_names = n.pet_names || (n.pet_count ? `${n.pet_count} pet${n.pet_count > 1 ? 's' : ''}` : 'their dog');
+    s._service_type = svcMap[s.service_id];
+    mgSeriesById[s.id] = s;
+  });
+}
+
 async function acceptSeries(id) {
   try {
     await sbPatch('booking_series', 'id', id, { status: 'active' });
@@ -612,11 +670,18 @@ function bookingDetailsHtml(b) {
 }
 
 function renderBookingsTab() {
-  const pending = bookings.filter(b => b.status === 'pending');
-  const confirmed = bookings.filter(b => b.status === 'confirmed');
+  const pending = bookings.filter(b => b.status === 'pending' && !b.is_meet_and_greet);
+  const confirmed = bookings.filter(b => b.status === 'confirmed' && !b.is_meet_and_greet);
+  // M&G bookings whose series is still awaiting the meet & greet.
+  const mgBookings = bookings.filter(b => b.is_meet_and_greet && mgSeriesById[b.series_id]);
   const area = document.getElementById('tab-bookings');
 
   let html = '';
+
+  if (mgBookings.length > 0) {
+    html += `<div class="card-title" style="margin-bottom:0.75rem;">Meet &amp; greets (${mgBookings.length})</div>`;
+    html += mgBookings.map(mgCarerCardHtml).join('');
+  }
 
   if (series.length > 0) {
     html += `<div class="card-title" style="margin-bottom:0.75rem;">Recurring requests (${series.length})</div>`;
@@ -680,12 +745,146 @@ function renderBookingsTab() {
     `).join('');
   }
 
-  if (pending.length === 0 && confirmed.length === 0 && series.length === 0) {
+  if (pending.length === 0 && confirmed.length === 0 && series.length === 0 && mgBookings.length === 0) {
     html = `<div class="empty"><div class="empty-icon"><svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3.5" y="5" width="17" height="15" rx="2"/><path d="M3.5 9.5h17M8 3v4M16 3v4"/></svg></div>No bookings yet. Once customers book you, their requests will appear here.</div>`;
   }
 
   area.innerHTML = html;
+  maybeShowCarerMgModal();
 }
+
+/* ── Meet & greet, carer side (TRU-14) ── */
+function mgFirstName(full) { return (full || '').trim().split(/\s+/)[0] || 'the owner'; }
+function mgProposedText(s) {
+  if (!s) return '';
+  if (s.booking_kind === 'multiday') return `${seriesDateText(s)}`;
+  if (s.booking_kind === 'oneoff') {
+    const d = new Date(s.start_date + 'T00:00:00').toLocaleDateString('en-AU', { weekday: 'long', day: 'numeric', month: 'short' });
+    return `${d} at ${formatTimeOfDay(s.time_of_day)}${s.window_end_time ? '–' + formatTimeOfDay(s.window_end_time) : ''}`;
+  }
+  return `${seriesPatternText(s)} · ${seriesDateText(s)}`;
+}
+function mgCarerCardHtml(b) {
+  const s = mgSeriesById[b.series_id] || {};
+  const owner = esc(mgFirstName(s._customer_name));
+  const dog = esc(s._pet_names || b._pet_label || 'their dog');
+  const serviceLabel = SERVICE_LABELS[s._service_type || b._service_type] || 'Service';
+  const priceLine = s.locked_price_cents != null ? `<div class="bc-time">$${priceToDollars(s.locked_price_cents)} per service · locked</div>` : '';
+
+  let actions;
+  if (mgBowOutSel[b.series_id]) {
+    actions = mgBowOutFormHtml(b.series_id, owner, dog);
+  } else {
+    actions = `
+      <button class="bc-btn message" onclick="window.location.href='/messages/?booking=${b.id}'">Message ${owner} <span class="bc-msg-badge" id="cardbadge-${b.id}" style="display:none;">0</span></button>
+      <button class="bc-btn decline" onclick="carerBowOutStart('${b.series_id}')">This one isn't the right fit for me</button>`;
+  }
+
+  return `
+    <div class="booking-card">
+      <div class="bc-info">
+        <div class="bc-customer">${esc(s._customer_name || b._customer_name || 'Owner')} <span class="recurring-tag">Meet &amp; greet</span></div>
+        <div class="bc-pet">${dog}</div>
+        <span class="bc-service">${serviceLabel}</span>
+        <div class="bc-time">Proposed: ${esc(mgProposedText(s))}</div>
+        ${priceLine}
+        ${bookingDetailsHtml(b)}
+        <p class="bc-notes" style="font-style:normal;">A free, no-commitment hello before the first paid ${esc(SERVICE_NATURAL[s._service_type || b._service_type] || 'visit')}. Arrange a time in your messages — ${owner} marks it complete once you've met.</p>
+      </div>
+      <div class="bc-actions">${actions}</div>
+    </div>`;
+}
+function mgBowOutFormHtml(seriesId, owner, dog) {
+  const sel = mgBowOutSel[seriesId] || new Set();
+  const chips = MG_CARER_DECLINE_CHIPS.map(raw => {
+    const on = sel.has(raw) ? ' mg-chip-on' : '';
+    return `<button type="button" class="mg-chip${on}" onclick="toggleMgBowChip('${seriesId}','${encodeURIComponent(raw)}')">${esc(raw)}</button>`;
+  }).join('');
+  return `
+    <div style="width:100%;">
+      <p style="font-weight:600;margin:0 0 2px;">Quick word, just for us?</p>
+      <p style="font-size:0.84rem;color:var(--text-muted);margin:0 0 10px;">${owner} won't see this. It helps us send better-matched jobs your way.</p>
+      <div class="mg-chips">${chips}</div>
+      <textarea id="mg-bow-note-${seriesId}" rows="2" placeholder="Anything else? (optional)" style="width:100%;margin-top:10px;border:1px solid var(--border);border-radius:8px;padding:8px;font:inherit;font-size:0.86rem;"></textarea>
+      <div class="bc-actions" style="margin-top:10px;">
+        <button class="bc-btn accept" onclick="carerBowOutConfirm('${seriesId}')">Done</button>
+        <button class="bc-btn" onclick="carerBowOutConfirm('${seriesId}', true)" style="background:none;border:1px solid var(--border);">Skip</button>
+      </div>
+    </div>`;
+}
+function carerBowOutStart(seriesId) { mgBowOutSel[seriesId] = new Set(); renderBookingsTab(); }
+function toggleMgBowChip(seriesId, encRaw) {
+  const raw = decodeURIComponent(encRaw);
+  const set = mgBowOutSel[seriesId] || (mgBowOutSel[seriesId] = new Set());
+  if (set.has(raw)) set.delete(raw); else set.add(raw);
+  renderBookingsTab();
+}
+async function carerBowOutConfirm(seriesId, skip) {
+  const note = skip ? '' : (document.getElementById('mg-bow-note-' + seriesId)?.value || '').trim();
+  const reasons = skip ? [] : [...(mgBowOutSel[seriesId] || [])];
+  const s = mgSeriesById[seriesId] || {};
+  const owner = esc(mgFirstName(s._customer_name));
+  try {
+    if (reasons.length || note) {
+      try { await sbInsertQuiet('series_decline_feedback', { series_id: seriesId, declined_by: 'carer', decline_reason: reasons, decline_note: note || null }); } catch(e) {}
+    }
+    await sbPatch('booking_series', 'id', seriesId, { status: 'cancelled' });
+    delete mgBowOutSel[seriesId];
+    // Confirmation first, so the per-series education modal doesn't stomp it.
+    mgOverlay(`
+      <h2 style="margin-top:0;">Thanks for being upfront</h2>
+      <p>Thanks for being upfront, it's the kind thing to do. We've gently let ${owner} know it won't go ahead and cancelled the booking. Nothing more for you to do.</p>
+      <div style="display:flex;justify-content:flex-end;"><button class="bc-btn accept" onclick="closeMgOverlay()">Done</button></div>`);
+    await loadBookings();
+    await loadMgSeries();
+    renderBookingsTab();
+  } catch(e) { showMsg(e.message, 'error'); }
+}
+
+// Carer education modal — shown once per M&G series, on entry to the flow.
+function maybeShowCarerMgModal() {
+  if (document.getElementById('mgOverlay')) return; // don't stomp a confirmation/overlay
+  const ids = Object.keys(mgSeriesById);
+  for (const id of ids) {
+    const key = 'mg_carer_seen_' + id;
+    if (localStorage.getItem(key)) continue;
+    localStorage.setItem(key, '1');
+    showCarerMgModal(mgSeriesById[id]);
+    break;
+  }
+}
+function showCarerMgModal(s) {
+  if (!s) return;
+  const owner = esc(mgFirstName(s._customer_name));
+  const dog = esc(s._pet_names || 'their dog');
+  const svc = SERVICE_NATURAL[s._service_type] || 'visit';
+  const fill = str => str.replace(/{Dog}/g, dog).replace(/{Owner}/g, owner).replace(/{Service}/g, svc);
+  const extras = (MG_VARIANTS[s._service_type] || []).map(k => `<li>${fill(MG_CARER_BLOCKS[k])}</li>`).join('');
+  mgOverlay(`
+    <h2 style="margin-top:0;">Say hello to ${owner} and ${dog}</h2>
+    <p>Before your first paid ${esc(svc)}, you'll meet ${owner} and ${dog} in person. It's free, relaxed, and there's no commitment on either side.</p>
+    <p>This one's for you too. It's your chance to make sure the job feels right and that you and ${dog} click, not just the other way round.</p>
+    <p style="font-weight:600;margin-bottom:.3rem;">Worth covering while you're there:</p>
+    <ul style="margin:0 0 1rem;padding-left:1.2rem;line-height:1.6;">
+      <li>Get to know ${dog}: their temperament, recall, and how they are with new people and other dogs</li>
+      <li>Run through the routine, feeding, handling notes, and any triggers</li>
+      <li>Ask about health, vet details, and what they'd want you to do in an emergency</li>
+      <li>Agree how you'll keep ${owner} posted, including GPS</li>
+      ${extras}
+    </ul>
+    <p style="background:var(--cream,#fbf6ef);border-radius:10px;padding:.75rem .9rem;font-size:.9rem;">The little things that put an owner at ease: turn up on time, make a fuss of ${dog}, and be honest about what you can and can't take on.</p>
+    <div style="display:flex;justify-content:flex-end;margin-top:1rem;"><button class="bc-btn accept" onclick="closeMgOverlay()">Set up the meet &amp; greet</button></div>`);
+}
+
+function mgOverlay(html) {
+  closeMgOverlay();
+  const o = document.createElement('div');
+  o.id = 'mgOverlay';
+  o.style.cssText = 'position:fixed;inset:0;background:rgba(40,30,25,.55);display:flex;align-items:center;justify-content:center;padding:1rem;z-index:1000;';
+  o.innerHTML = `<div class="fade-in" style="max-width:520px;width:100%;max-height:90vh;overflow-y:auto;margin:0;background:#fff;border-radius:14px;padding:1.5rem;">${html}</div>`;
+  document.body.appendChild(o);
+}
+function closeMgOverlay() { const o = document.getElementById('mgOverlay'); if (o) o.remove(); }
 
 function renderDashboard() {
   const initials = ((userData.first_name||'')[0]||'') + ((userData.last_name||'')[0]||'');
@@ -1005,6 +1204,7 @@ async function init() {
     // Load bookings
     await loadBookings();
     await loadSeries();
+    await loadMgSeries();
 
     renderDashboard();
     refreshMsgBadge();

--- a/messages/index.html
+++ b/messages/index.html
@@ -63,6 +63,12 @@
   .thread-ctx{font-size:0.72rem;color:var(--text-muted);margin-top:1px;}
   .thread-link{font-size:0.78rem;color:var(--terracotta);text-decoration:none;white-space:nowrap;flex-shrink:0;}
   .thread-link:hover{text-decoration:underline;}
+  .mg-banner{flex-shrink:0;background:rgba(196,117,91,0.08);border-bottom:1px solid var(--border);padding:12px 16px;}
+  .mg-banner-title{font-size:0.78rem;font-weight:700;color:var(--terracotta);margin-bottom:4px;}
+  .mg-banner-details{font-size:0.8rem;color:var(--text-secondary);margin-bottom:6px;}
+  .mg-banner-copy{font-size:0.84rem;color:var(--text-secondary);margin:0 0 8px;}
+  .mg-banner-copy a{color:var(--terracotta);}
+  .mg-banner-btn{font:inherit;font-size:0.84rem;font-weight:500;padding:8px 16px;border-radius:8px;border:0;background:var(--terracotta);color:#fff;cursor:pointer;}
 
   .thread-body{flex:1;overflow-y:auto;padding:16px;background:var(--cream);display:flex;flex-direction:column;gap:8px;}
   .day-sep{align-self:center;font-size:0.7rem;color:var(--text-muted);background:var(--warm-white);border:1px solid var(--border);padding:2px 10px;border-radius:999px;margin:4px 0;}
@@ -145,8 +151,11 @@ let myProfileId = null;            // customer_profiles.id or provider_profiles.
 // `id` is the real conversations row (null until the first message creates it).
 let conversations = [];            // [{key, id, counterpartyUserId, name, initials, lastMessageAt, bookings:[...], composeBookingId}]
 let msgsByConv = {};               // conversationId -> [messages]
-let bookingMap = {};               // bookingId -> {serviceType, scheduledAt, status}
+let bookingMap = {};               // bookingId -> {serviceType, scheduledAt, status, isMg, seriesId}
+let mgSeriesById = {};             // pending_meet_greet series (TRU-14), keyed by id
 let activeKey = null;
+const SERVICE_NATURAL = { dog_walking:'walk', dog_sitting:'sitting', dog_boarding:'boarding stay', pet_sitting:'visit' };
+const DAY_FULL_MG = { 1:'Mon', 2:'Tue', 3:'Wed', 4:'Thu', 5:'Fri', 6:'Sat', 7:'Sun' };
 let pollTimer = null;
 
 function h(token) {
@@ -167,6 +176,11 @@ async function sbInsert(t, row) {
 async function sbPatchWhere(t, filter, upd) {
   const r = await fetch(`${SUPABASE_URL}/rest/v1/${t}?${filter}`, { method:'PATCH', headers:{ ...h(authToken), 'Prefer':'return=minimal' }, body: JSON.stringify(upd) });
   if (!r.ok) { const e = await r.json().catch(()=>({})); throw new Error(e.message || 'Update failed'); }
+}
+async function sbRpc(fn, args){
+  const r = await fetch(`${SUPABASE_URL}/rest/v1/rpc/${fn}`, { method:'POST', headers:{ ...h(authToken), 'Prefer':'return=representation' }, body: JSON.stringify(args||{}) });
+  if (!r.ok) { const e = await r.json().catch(()=>({})); throw new Error(e.message || 'Request failed'); }
+  return r.json();
 }
 
 function esc(s){ return (s||'').toString().replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
@@ -225,13 +239,29 @@ async function loadConversations(){
     const pp = await sbGet('provider_profiles', `user_id=eq.${authUid}&select=id`);
     if (!pp.length) return [];
     myProfileId = pp[0].id;
-    bookings = await sbGet('bookings', `provider_id=eq.${myProfileId}&select=id,customer_id,provider_id,service_id,scheduled_at,status,created_at`);
+    bookings = await sbGet('bookings', `provider_id=eq.${myProfileId}&select=id,customer_id,provider_id,service_id,scheduled_at,status,created_at,is_meet_and_greet,series_id`);
   } else {
     const cp = await sbGet('customer_profiles', `user_id=eq.${authUid}&select=id`);
     if (!cp.length) return [];
     myProfileId = cp[0].id;
-    bookings = await sbGet('bookings', `customer_id=eq.${myProfileId}&select=id,customer_id,provider_id,service_id,scheduled_at,status,created_at`);
+    bookings = await sbGet('bookings', `customer_id=eq.${myProfileId}&select=id,customer_id,provider_id,service_id,scheduled_at,status,created_at,is_meet_and_greet,series_id`);
   }
+
+  // Pending meet & greet series for this person (TRU-14) — proposed booking details.
+  mgSeriesById = {};
+  try {
+    const col = role === 'provider' ? 'provider_id' : 'customer_id';
+    const srows = await sbGet('booking_series', `${col}=eq.${myProfileId}&status=eq.pending_meet_greet&select=*`);
+    if (srows.length) {
+      const sids = srows.map(s => s.id);
+      let nameMap = {};
+      try {
+        const names = await sbGet('series_party_names', `series_id=in.(${sids.join(',')})&select=*`);
+        nameMap = Object.fromEntries(names.map(n => [n.series_id, n]));
+      } catch(e) {}
+      srows.forEach(s => { s._petNames = (nameMap[s.id] || {}).pet_names || 'your dog'; mgSeriesById[s.id] = s; });
+    }
+  } catch(e) { /* non-fatal */ }
 
   const serviceIds = [...new Set(bookings.map(b => b.service_id).filter(Boolean))];
   const svcMap = {};
@@ -240,7 +270,7 @@ async function loadConversations(){
     svcs.forEach(s => svcMap[s.id] = s.service_type);
   }
   bookingMap = {};
-  bookings.forEach(b => { bookingMap[b.id] = { serviceType: svcMap[b.service_id] || null, scheduledAt: b.scheduled_at, status: b.status }; });
+  bookings.forEach(b => { bookingMap[b.id] = { serviceType: svcMap[b.service_id] || null, scheduledAt: b.scheduled_at, status: b.status, isMg: b.is_meet_and_greet, seriesId: b.series_id }; });
 
   // Per-booking participant pair + counterparty name (booking_party_names bypasses
   // per-table RLS and resolves the other party's name, scoped to my bookings).
@@ -297,8 +327,12 @@ async function loadConversations(){
     const pair = pairByBooking[b.id];
     if (!pair) return;
     const conv = ensureConv(pair.custUser, pair.provUser);
-    conv.bookings.push({ id: b.id, serviceType: bookingMap[b.id].serviceType, scheduledAt: b.scheduled_at, status: b.status, viewHref: role === 'provider' ? '/dashboard/' : `/track/?booking=${b.id}` });
+    conv.bookings.push({ id: b.id, serviceType: bookingMap[b.id].serviceType, scheduledAt: b.scheduled_at, status: b.status, isMg: b.is_meet_and_greet, seriesId: b.series_id, viewHref: role === 'provider' ? '/dashboard/' : `/track/?booking=${b.id}` });
     if ((conv.name === fallback) && pair.name) { conv.name = pair.name; conv.initials = initialsOf(pair.name) || '?'; }
+    // Surface a pending meet & greet on the conversation.
+    if (b.is_meet_and_greet && b.series_id && mgSeriesById[b.series_id]) {
+      conv.mg = { bookingId: b.id, mgStatus: b.status, series: mgSeriesById[b.series_id] };
+    }
   });
 
   const convs = Object.values(byKey);
@@ -411,6 +445,7 @@ function renderThread(preserveInput){
       </div>
       ${viewLink}
     </div>
+    ${mgBannerHtml(c)}
     <div class="thread-body" id="threadBody">${body}</div>
     <form class="composer" id="composer">
       <textarea id="composerInput" rows="1" placeholder="Write a message…" aria-label="Write a message"></textarea>
@@ -431,6 +466,56 @@ function renderThread(preserveInput){
 }
 
 function autosize(t){ t.style.height='auto'; t.style.height=Math.min(t.scrollHeight,120)+'px'; }
+
+/* ── Meet & greet banner (TRU-14) ── */
+function mgSchedSummary(s){
+  if (!s) return '';
+  const fdate = d => new Date(d + 'T00:00:00').toLocaleDateString('en-AU',{weekday:'short',day:'numeric',month:'short'});
+  const ftime = hhmm => { if(!hhmm) return ''; const [h,m]=hhmm.split(':'); const dd=new Date(); dd.setHours(+h,+m,0); return dd.toLocaleTimeString('en-AU',{hour:'numeric',minute:'2-digit',hour12:true}); };
+  if (s.booking_kind === 'multiday') return `${fdate(s.start_date)} → ${s.end_date?fdate(s.end_date):''}`.trim();
+  if (s.booking_kind === 'oneoff') return `${fdate(s.start_date)} · ${ftime(s.time_of_day)}${s.window_end_time?'–'+ftime(s.window_end_time):''}`;
+  let freq = 'every weekday';
+  if (s.frequency_type==='daily') freq='every day';
+  else if (s.frequency_type==='specific_days') freq='every '+(s.days_of_week||[]).slice().sort((a,b)=>a-b).map(n=>DAY_FULL_MG[n]).join(', ');
+  return `${freq} from ${fdate(s.start_date)} · ${ftime(s.time_of_day)}${s.window_end_time?'–'+ftime(s.window_end_time):''}`;
+}
+function mgBannerHtml(c){
+  if (!c || !c.mg) return '';
+  const s = c.mg.series;
+  const svcLabel = SERVICE_LABELS[s.service_type] || SERVICE_LABELS[bookingMap[c.mg.bookingId]?.serviceType] || 'Service';
+  const svcNat = SERVICE_NATURAL[s.service_type] || SERVICE_NATURAL[bookingMap[c.mg.bookingId]?.serviceType] || 'visit';
+  const who = esc((c.name || '').trim().split(/\s+/)[0] || c.name);
+  const pets = esc(s._petNames || 'your dog');
+  const details = `<div class="mg-banner-details"><strong>Proposed ${esc(svcNat)}</strong> · ${esc(svcLabel)} · ${esc(mgSchedSummary(s))} · ${pets}</div>`;
+
+  let action;
+  if (role === 'customer') {
+    if (c.mg.mgStatus !== 'completed') {
+      action = `<p class="mg-banner-copy">All done meeting ${who}? Mark it complete whenever you're ready to decide, no rush at all.</p>
+        <button type="button" class="mg-banner-btn" onclick="markMgCompleteFromThread('${c.mg.bookingId}')">Mark meet &amp; greet complete</button>`;
+    } else {
+      action = `<p class="mg-banner-copy">Meet &amp; greet marked complete. Head to <a href="/profile/">your bookings</a> to go ahead or pass.</p>`;
+    }
+  } else {
+    action = `<p class="mg-banner-copy">${who} would like a quick, free hello before the first paid ${esc(svcNat)}. Arrange a time below — they'll mark it complete once you've met.</p>`;
+  }
+
+  return `<div class="mg-banner">
+    <div class="mg-banner-title">🐾 Meet &amp; greet</div>
+    ${details}
+    ${action}
+  </div>`;
+}
+async function markMgCompleteFromThread(bookingId){
+  try {
+    await sbRpc('mark_meet_greet_complete', { p_booking_id: bookingId });
+    if (bookingMap[bookingId]) bookingMap[bookingId].status = 'completed';
+    const c = convByKey(activeKey);
+    if (c && c.mg && c.mg.bookingId === bookingId) c.mg.mgStatus = 'completed';
+    if (c) { const bk = c.bookings.find(b => b.id === bookingId); if (bk) bk.status = 'completed'; }
+    renderThread(true);
+  } catch(e){ alert(e.message); }
+}
 
 function syncUrl(){
   const c = convByKey(activeKey);

--- a/profile/index.html
+++ b/profile/index.html
@@ -65,6 +65,9 @@
   .bc-time{font-size:0.82rem;color:var(--text-muted);margin-bottom:8px;}
 
   .status-badge{display:inline-flex;align-items:center;gap:5px;font-size:0.72rem;font-weight:600;padding:2px 10px;border-radius:20px;text-transform:uppercase;letter-spacing:0.03em;}
+  .mg-chips{display:flex;flex-wrap:wrap;gap:8px;}
+  .mg-chip{font:inherit;font-size:0.82rem;padding:6px 12px;border-radius:20px;border:1px solid var(--border);background:#fff;color:var(--text-secondary);cursor:pointer;}
+  .mg-chip-on{background:var(--terracotta);border-color:var(--terracotta);color:#fff;}
   .badge-pending{background:var(--warning-bg);color:var(--warning);}
   .badge-confirmed{background:var(--success-bg);color:var(--success);}
   .badge-in-progress{background:var(--success-bg);color:var(--success);}
@@ -225,8 +228,18 @@ const SERVICE_LABELS = {
   dog_walking:'Dog walking', dog_sitting:'Dog sitting', dog_boarding:'Dog boarding',
   pet_sitting:'Other pet sitting'
 };
+// Natural-language service word for meet & greet copy (TRU-14).
+const SERVICE_NATURAL = { dog_walking:'walk', dog_sitting:'sitting', dog_boarding:'boarding stay', pet_sitting:'visit' };
+// Customer decline-feedback chips (private; never shown to the carer).
+const MG_CUSTOMER_DECLINE_CHIPS = [
+  'Didn’t feel like the right match', 'Wasn’t sure about them with {Dog}',
+  'Timing or availability', 'Price', 'Going with someone else', 'My plans changed'
+];
+const DAY_FULL_MG = { 1:'Mon', 2:'Tue', 3:'Wed', 4:'Thu', 5:'Fri', 6:'Sat', 7:'Sun' };
 
 let authToken = null, authUid = null;
+let seriesById = {};          // booking_series.id -> series row (for M&G bookings)
+let mgDeclineSel = {};        // series_id -> Set of selected chip labels (decline feedback)
 let userData = null;          // row from users
 let customerProfile = null;   // customer_profiles row (id, suburb) — customers only
 let profileRow = null;        // role-specific profile row holding suburb
@@ -249,6 +262,17 @@ async function sbGet(t, p) {
   const r = await fetch(`${SUPABASE_URL}/rest/v1/${t}?${p}`, { headers: h(authToken) });
   if (!r.ok) { const e = await r.json(); throw new Error(e.message); }
   return await r.json();
+}
+async function sbRpc(fn, args) {
+  const r = await fetch(`${SUPABASE_URL}/rest/v1/rpc/${fn}`, { method: 'POST', headers: { ...h(authToken), 'Prefer': 'return=representation' }, body: JSON.stringify(args || {}) });
+  if (!r.ok) { const e = await r.json().catch(() => ({})); throw new Error(e.message || 'Request failed'); }
+  return await r.json();
+}
+// Insert without reading the row back — for write-only tables (decline feedback)
+// that have no SELECT policy by design.
+async function sbInsertQuiet(t, row) {
+  const r = await fetch(`${SUPABASE_URL}/rest/v1/${t}`, { method: 'POST', headers: { ...h(authToken), 'Prefer': 'return=minimal' }, body: JSON.stringify(row) });
+  if (!r.ok) { const e = await r.json().catch(() => ({})); throw new Error(e.message || 'Insert failed'); }
 }
 async function sbPatch(t, col, val, upd) {
   const r = await fetch(`${SUPABASE_URL}/rest/v1/${t}?${col}=eq.${val}`, { method: 'PATCH', headers: { ...h(authToken), 'Prefer': 'return=representation' }, body: JSON.stringify(upd) });
@@ -412,7 +436,102 @@ function cancelConfirmHtml(b) {
   }
   return `<div class="cancel-confirm"><span>Are you sure?</span><button class="btn-cancel-yes" onclick="doCancelBooking('${b.id}')">Yes, cancel</button><button class="btn-cancel-keep" onclick="dismissCancel()">Keep booking</button></div>`;
 }
+/* ── Meet & greet (TRU-14) ── */
+// An M&G card stays in the "active" list while it still needs the customer's
+// attention: before completion, and after completion while the series awaits a
+// proceed/decline decision.
+function mgNeedsAction(b) {
+  const s = seriesById[b.series_id];
+  return b.status === 'confirmed' || (b.status === 'completed' && s && s.status === 'pending_meet_greet');
+}
+function firstName(full) { return (full || '').trim().split(/\s+/)[0] || 'your carer'; }
+function mgScheduleSummary(s) {
+  if (!s) return '';
+  const fdate = d => new Date(d + 'T00:00:00').toLocaleDateString('en-AU', { weekday: 'long', day: 'numeric', month: 'long' });
+  const fwin = () => {
+    if (!s.time_of_day) return '';
+    const t = hhmm => { const [h, m] = hhmm.split(':'); const dd = new Date(); dd.setHours(+h, +m, 0); return dd.toLocaleTimeString('en-AU', { hour: 'numeric', minute: '2-digit', hour12: true }); };
+    return s.window_end_time ? ` between ${t(s.time_of_day)}–${t(s.window_end_time)}` : ` at ${t(s.time_of_day)}`;
+  };
+  if (s.booking_kind === 'multiday') return `${fdate(s.start_date)} to ${s.end_date ? fdate(s.end_date) : ''}`.trim();
+  if (s.booking_kind === 'oneoff') return `${fdate(s.start_date)}${fwin()}`;
+  // recurring
+  let freq = 'every weekday';
+  if (s.frequency_type === 'daily') freq = 'every day';
+  else if (s.frequency_type === 'specific_days') freq = 'every ' + (s.days_of_week || []).slice().sort((a, b) => a - b).map(n => DAY_FULL_MG[n]).join(', ');
+  return `${freq} from ${fdate(s.start_date)}${fwin()}`;
+}
+function mgCardHtml(b) {
+  const s = seriesById[b.series_id];
+  const carer = esc(firstName(b._provider_name));
+  const dog = esc(b._pet_name || 'your dog');
+  const svcNat = SERVICE_NATURAL[b._service_type] || 'visit';
+  const serviceLabel = SERVICE_LABELS[b._service_type] || 'Service';
+  const summary = esc(mgScheduleSummary(s));
+
+  let body;
+  if (b.status === 'confirmed') {
+    // Awaiting the meet & greet.
+    body = `
+      <div class="bc-time">Your ${esc(svcNat)} is saved — ${summary || 'ready when you are'}.</div>
+      <div style="margin-bottom:10px;"><span class="status-badge badge-pending">Meet &amp; greet</span></div>
+      <p style="font-size:0.86rem;color:var(--text-secondary);margin:0 0 12px;">Arrange a time with ${carer} in your messages. Once you've met, mark it complete to decide whether to go ahead.</p>
+      <div class="bc-actions">
+        <button class="btn-track" onclick="markMgComplete('${b.id}')">Mark meet &amp; greet complete</button>
+        <a href="/messages/?booking=${b.id}" class="btn-ghost">Message ${carer}</a>
+      </div>`;
+  } else if (b.status === 'completed' && s && s.status === 'pending_meet_greet') {
+    // Met — decide whether to proceed.
+    if (mgDeclineSel[b.series_id]) {
+      body = mgDeclineFormHtml(b, s, dog, carer);
+    } else {
+      body = `
+        <div style="margin-bottom:10px;"><span class="status-badge badge-completed">Met</span></div>
+        <p style="font-weight:600;margin:0 0 2px;">How did you two get on?</p>
+        <p style="font-size:0.86rem;color:var(--text-secondary);margin:0 0 12px;">Whenever you're ready, ${carer} is all set to look after ${dog}.</p>
+        <div class="bc-actions">
+          <button class="btn-track" onclick="proceedMg('${b.series_id}')">Yes, let's go ahead</button>
+          <button class="btn-ghost danger" onclick="declineMgStart('${b.series_id}')">Not quite the right fit</button>
+        </div>`;
+    }
+  } else {
+    // Resolved.
+    const resolved = s && s.status === 'active'
+      ? `Your ${esc(svcNat)} is confirmed.`
+      : `This booking was cancelled.`;
+    body = `
+      <div style="margin-bottom:10px;"><span class="status-badge badge-completed">Meet &amp; greet complete</span></div>
+      <p style="font-size:0.86rem;color:var(--text-secondary);margin:0;">${resolved}</p>`;
+  }
+
+  return `
+    <div class="booking-card">
+      <div class="bc-pet-name">Meet &amp; greet with ${carer} <span class="recurring-tag">Free</span></div>
+      <div class="bc-meta">${dog} · ${serviceLabel}</div>
+      ${body}
+    </div>`;
+}
+function mgDeclineFormHtml(b, s, dog, carer) {
+  const sel = mgDeclineSel[b.series_id] || new Set();
+  const chips = MG_CUSTOMER_DECLINE_CHIPS.map(raw => {
+    const label = raw.replace(/{Dog}/g, dog);
+    const on = sel.has(raw) ? ' mg-chip-on' : '';
+    return `<button type="button" class="mg-chip${on}" onclick="toggleMgChip('${b.series_id}','${encodeURIComponent(raw)}')">${esc(label)}</button>`;
+  }).join('');
+  return `
+    <div style="margin-bottom:10px;"><span class="status-badge badge-completed">Met</span></div>
+    <p style="font-weight:600;margin:0 0 2px;">Mind telling us why?</p>
+    <p style="font-size:0.84rem;color:var(--text-secondary);margin:0 0 10px;">It stays between us, ${carer} won't see a thing. It just helps us look after you and ${dog} better next time.</p>
+    <div class="mg-chips">${chips}</div>
+    <textarea id="mg-note-${b.series_id}" rows="2" placeholder="Anything else you'd like us to know? (optional)" style="width:100%;margin-top:10px;border:1px solid var(--border);border-radius:8px;padding:8px;font:inherit;font-size:0.86rem;"></textarea>
+    <div class="bc-actions" style="margin-top:10px;">
+      <button class="btn-track" onclick="declineMgConfirm('${b.series_id}')">Done</button>
+      <button class="btn-ghost" onclick="declineMgConfirm('${b.series_id}', true)">Skip</button>
+    </div>`;
+}
+
 function bookingCardHtml(b) {
+  if (b.is_meet_and_greet) return mgCardHtml(b);
   const petLabel = esc(b._pet_name || 'Your pet') + (b._pet_breed ? ' · ' + esc(b._pet_breed) : '');
   const serviceLabel = SERVICE_LABELS[b._service_type] || esc(b._service_type) || 'Service';
   const provLabel = esc(b._provider_name || 'Your carer');
@@ -719,12 +838,16 @@ function renderBookingsTab() {
   const area = document.getElementById('tab-bookings');
   if (!area) return;
 
+  const isActive = b => b.is_meet_and_greet
+    ? mgNeedsAction(b)
+    : ['pending', 'confirmed', 'in_progress'].includes(b.status);
+
   const active = bookings
-    .filter(b => ['pending', 'confirmed', 'in_progress'].includes(b.status))
+    .filter(isActive)
     .sort((a, b) => new Date(a.scheduled_at) - new Date(b.scheduled_at));
 
   const past = bookings
-    .filter(b => ['completed', 'cancelled'].includes(b.status))
+    .filter(b => !isActive(b) && ['completed', 'cancelled'].includes(b.status))
     .sort((a, b) => new Date(b.scheduled_at) - new Date(a.scheduled_at))
     .slice(0, 10);
 
@@ -889,6 +1012,90 @@ async function doCancelSeries(seriesId) {
   } catch(e) { showMsg(e.message, 'error'); }
 }
 
+/* ── Meet & greet actions (TRU-14) ── */
+async function markMgComplete(bookingId) {
+  try {
+    await sbRpc('mark_meet_greet_complete', { p_booking_id: bookingId });
+    const b = bookings.find(x => x.id === bookingId);
+    if (b) b.status = 'completed';
+    renderBookingsTab();
+  } catch(e) { showMsg(e.message, 'error'); }
+}
+
+function mgOverlay(html) {
+  closeMgOverlay();
+  const o = document.createElement('div');
+  o.id = 'mgOverlay';
+  o.style.cssText = 'position:fixed;inset:0;background:rgba(40,30,25,.55);display:flex;align-items:center;justify-content:center;padding:1rem;z-index:1000;';
+  o.innerHTML = `<div class="form-card fade-in" style="max-width:460px;width:100%;margin:0;background:#fff;border-radius:14px;padding:1.5rem;">${html}</div>`;
+  document.body.appendChild(o);
+}
+function closeMgOverlay() { const o = document.getElementById('mgOverlay'); if (o) o.remove(); }
+
+// Proceed: stubbed payment-method step (no card stored — Stripe Connect lands later),
+// then activate the series. The DB gate requires a completed M&G to allow this.
+function proceedMg(seriesId) {
+  mgOverlay(`
+    <h2 style="margin-top:0;">Add a payment method</h2>
+    <p style="font-size:0.9rem;">You're only ever charged after a service is finished — never before, and never for the meet &amp; greet.</p>
+    <div style="background:var(--cream,#fbf6ef);border:1px dashed var(--border);border-radius:10px;padding:1rem;margin:1rem 0;font-size:0.84rem;color:var(--text-muted);">Card payments are coming soon. During launch there's nothing to add — just confirm to go ahead.</div>
+    <div id="mgOverlayMsg" class="msg"></div>
+    <div style="display:flex;gap:10px;justify-content:flex-end;flex-wrap:wrap;">
+      <button class="btn-ghost" onclick="closeMgOverlay()">Not now</button>
+      <button class="btn-track" id="mgProceedConfirm" onclick="confirmProceedMg('${seriesId}')">Confirm and go ahead</button>
+    </div>`);
+}
+async function confirmProceedMg(seriesId) {
+  const btn = document.getElementById('mgProceedConfirm');
+  if (btn) { btn.disabled = true; btn.textContent = 'Confirming…'; }
+  try {
+    await sbPatch('booking_series', 'id', seriesId, { status: 'active' });
+    const s = seriesById[seriesId];
+    if (s) s.status = 'active';
+    const carer = esc(firstName((bookings.find(b => b.series_id === seriesId) || {})._provider_name));
+    const dog = esc((bookings.find(b => b.series_id === seriesId) || {})._pet_name || 'your dog');
+    const svcNat = SERVICE_NATURAL[(bookings.find(b => b.series_id === seriesId) || {})._service_type] || 'visit';
+    const startTxt = s && s.start_date ? new Date(s.start_date + 'T00:00:00').toLocaleDateString('en-AU', { weekday: 'long', day: 'numeric', month: 'long' }) : 'soon';
+    mgOverlay(`
+      <h2 style="margin-top:0;">You're all set</h2>
+      <p>Wonderful. ${carer} can't wait to spend time with ${dog}. Your ${esc(svcNat)} starts ${startTxt}, and you're only ever charged once a service is done, never a moment before.</p>
+      <div style="display:flex;justify-content:flex-end;"><button class="btn-track" onclick="closeMgOverlay();reloadBookings()">Done</button></div>`);
+  } catch(e) {
+    const m = document.getElementById('mgOverlayMsg');
+    if (m) { m.textContent = e.message; m.className = 'msg error'; }
+    if (btn) { btn.disabled = false; btn.textContent = 'Confirm and go ahead'; }
+  }
+}
+
+function declineMgStart(seriesId) { mgDeclineSel[seriesId] = new Set(); renderBookingsTab(); }
+function toggleMgChip(seriesId, encRaw) {
+  const raw = decodeURIComponent(encRaw);
+  const set = mgDeclineSel[seriesId] || (mgDeclineSel[seriesId] = new Set());
+  if (set.has(raw)) set.delete(raw); else set.add(raw);
+  renderBookingsTab();
+}
+async function declineMgConfirm(seriesId, skip) {
+  const note = skip ? '' : (document.getElementById('mg-note-' + seriesId)?.value || '').trim();
+  const reasons = skip ? [] : [...(mgDeclineSel[seriesId] || [])];
+  try {
+    // Private feedback (carer never sees it). Best-effort — never blocks the decline.
+    if (reasons.length || note) {
+      try { await sbInsertQuiet('series_decline_feedback', { series_id: seriesId, declined_by: 'customer', decline_reason: reasons, decline_note: note || null }); } catch(e) {}
+    }
+    await sbPatch('booking_series', 'id', seriesId, { status: 'cancelled' });
+    const s = seriesById[seriesId]; if (s) s.status = 'cancelled';
+    delete mgDeclineSel[seriesId];
+    const dog = esc((bookings.find(b => b.series_id === seriesId) || {})._pet_name || 'your dog');
+    mgOverlay(`
+      <h2 style="margin-top:0;">No harm done</h2>
+      <p>That's completely okay. We've cancelled the booking, no harm done. The right carer for ${dog} is out there, so take your time and have another look whenever you feel like it.</p>
+      <div style="display:flex;justify-content:flex-end;gap:10px;"><a href="/search/" class="btn-ghost">Find another carer</a><button class="btn-track" onclick="closeMgOverlay();reloadBookings()">Done</button></div>`);
+  } catch(e) { showMsg(e.message, 'error'); }
+}
+
+// After proceed/decline the generated rows (or cancellation) need a fresh read.
+async function reloadBookings() { location.reload(); }
+
 /* ── Pet management ── */
 function showPetEdit(id) { editingPetId = id; renderAccountTab(); }
 function cancelPetEdit() { editingPetId = null; renderAccountTab(); }
@@ -1036,6 +1243,13 @@ async function init() {
     profileRow = profiles[0];
 
     const rawBookings = await sbGet('bookings', `customer_id=eq.${customerProfile.id}&select=*&order=scheduled_at.desc`);
+
+    // Series this customer owns — used to drive the meet & greet card state.
+    seriesById = {};
+    try {
+      const seriesRows = await sbGet('booking_series', `customer_id=eq.${customerProfile.id}&select=id,status,booking_kind,frequency_type,days_of_week,time_of_day,window_end_time,start_date,end_date,locked_price_cents,service_id`);
+      seriesRows.forEach(s => { seriesById[s.id] = s; });
+    } catch(e) { /* non-fatal */ }
 
     let reviewedBookingIds = new Set();
     try {

--- a/supabase/migrations/20260615_tru14_meet_and_greets.sql
+++ b/supabase/migrations/20260615_tru14_meet_and_greets.sql
@@ -1,0 +1,267 @@
+-- TRU-14 Meet & greets
+-- Before a customer's first booking with a new carer, the pair completes a free
+-- introductory meet & greet (M&G). The M&G is the first booking between the pair
+-- (bookings.is_meet_and_greet = true) and gates activation of the intended series.
+--
+-- Pair key: the gate ("a completed M&G already exists for this pair") is keyed on
+-- (bookings.customer_id, bookings.provider_id) i.e. (customer_profiles.id,
+-- provider_profiles.id) -- the identifiers the bookings tables already use. This
+-- maps 1:1 to a users pair and avoids the provider_services users.id vs
+-- provider_profiles.id mismatch called out in TRU-61.
+--
+-- Applied to the live DB via apply_migration (Supabase branching is broken on this
+-- repo); committed here for version control. The "Supabase Preview" check on this
+-- PR is expected to fail and is non-blocking.
+
+-- 1. New series state: the intended booking is locked in as pending until the M&G
+--    is completed and the customer proceeds.
+ALTER TYPE public.series_status ADD VALUE IF NOT EXISTS 'pending_meet_greet';
+
+-- 2. Private decline feedback. Both parties can SELECT * on booking_series, so the
+--    feedback lives in its own table with INSERT-only RLS and no SELECT policy:
+--    write-only from the client, never exposed to the other party (or to either
+--    party) via the API -- only readable by service_role/SQL for our own analytics.
+CREATE TABLE IF NOT EXISTS public.series_decline_feedback (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  series_id      uuid NOT NULL REFERENCES public.booking_series(id) ON DELETE CASCADE,
+  declined_by    text NOT NULL CHECK (declined_by IN ('customer','carer')),
+  decline_reason text[] NOT NULL DEFAULT '{}',
+  decline_note   text,
+  created_at     timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_series_decline_feedback_series ON public.series_decline_feedback(series_id);
+
+ALTER TABLE public.series_decline_feedback ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS customer_insert_decline_feedback ON public.series_decline_feedback;
+CREATE POLICY customer_insert_decline_feedback ON public.series_decline_feedback
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    declined_by = 'customer'
+    AND EXISTS (
+      SELECT 1 FROM public.booking_series bs
+      JOIN public.customer_profiles cp ON cp.id = bs.customer_id
+      WHERE bs.id = series_decline_feedback.series_id AND cp.user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS carer_insert_decline_feedback ON public.series_decline_feedback;
+CREATE POLICY carer_insert_decline_feedback ON public.series_decline_feedback
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    declined_by = 'carer'
+    AND EXISTS (
+      SELECT 1 FROM public.booking_series bs
+      JOIN public.provider_profiles pp ON pp.id = bs.provider_id
+      WHERE bs.id = series_decline_feedback.series_id AND pp.user_id = auth.uid()
+    )
+  );
+
+-- 3. M&G wraps EVERY first booking in a pending_meet_greet series, including
+--    one-offs and multi-day boarding/sitting. booking_kind tells the generator what
+--    to materialise on activation. Existing series are all recurring.
+ALTER TABLE public.booking_series
+  ADD COLUMN IF NOT EXISTS booking_kind text NOT NULL DEFAULT 'recurring'
+    CHECK (booking_kind IN ('recurring','oneoff','multiday'));
+
+-- Row generator: branch on booking_kind. Never (re)generate an M&G row, and never
+-- materialise twice for the same series.
+CREATE OR REPLACE FUNCTION public.generate_series_bookings(p_series_id uuid, p_weeks_ahead integer DEFAULT 4)
+ RETURNS integer
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  s public.booking_series%ROWTYPE;
+  d date;
+  horizon date;
+  dow int;
+  want boolean;
+  scheduled timestamptz;
+  win_end timestamptz;
+  ends timestamptz;
+  svc_duration int;
+  primary_pet uuid;
+  created_count int := 0;
+  new_booking_id uuid;
+BEGIN
+  SELECT * INTO s FROM public.booking_series WHERE id = p_series_id;
+  IF NOT FOUND OR s.status <> 'active' THEN
+    RETURN 0;
+  END IF;
+
+  SELECT pet_id INTO primary_pet FROM public.series_pets WHERE series_id = p_series_id ORDER BY created_at LIMIT 1;
+  IF primary_pet IS NULL THEN
+    RETURN 0;
+  END IF;
+
+  SELECT duration_mins INTO svc_duration FROM public.provider_services WHERE id = s.service_id;
+
+  -- A non-M&G booking already materialised for this series? nothing to do.
+  IF EXISTS (
+    SELECT 1 FROM public.bookings b
+    WHERE b.series_id = p_series_id AND NOT COALESCE(b.is_meet_and_greet, false)
+  ) THEN
+    RETURN 0;
+  END IF;
+
+  -- One-off (single timed booking) and multi-day (boarding/sitting, single row with
+  -- a date range) intents materialise exactly one booking on activation.
+  IF s.booking_kind = 'multiday' THEN
+    scheduled := (s.start_date::timestamp + time '12:00') AT TIME ZONE 'Australia/Sydney';
+    ends      := (COALESCE(s.end_date, s.start_date)::timestamp + time '12:00') AT TIME ZONE 'Australia/Sydney';
+    INSERT INTO public.bookings (customer_id, provider_id, pet_id, service_id, status, scheduled_at, ends_at, total_cents, series_id)
+    VALUES (s.customer_id, s.provider_id, primary_pet, s.service_id, 'confirmed', scheduled, ends, COALESCE(s.locked_price_cents, 0), p_series_id)
+    RETURNING id INTO new_booking_id;
+    INSERT INTO public.booking_pets (booking_id, pet_id)
+    SELECT new_booking_id, pet_id FROM public.series_pets WHERE series_id = p_series_id;
+    RETURN 1;
+
+  ELSIF s.booking_kind = 'oneoff' THEN
+    scheduled := (s.start_date::timestamp + s.time_of_day) AT TIME ZONE 'Australia/Sydney';
+    win_end   := CASE WHEN s.window_end_time IS NOT NULL
+                      THEN (s.start_date::timestamp + s.window_end_time) AT TIME ZONE 'Australia/Sydney'
+                      ELSE NULL END;
+    INSERT INTO public.bookings (customer_id, provider_id, pet_id, service_id, status, scheduled_at, window_end_at, duration_mins, total_cents, series_id)
+    VALUES (s.customer_id, s.provider_id, primary_pet, s.service_id, 'confirmed', scheduled, win_end, svc_duration, COALESCE(s.locked_price_cents, 0), p_series_id)
+    RETURNING id INTO new_booking_id;
+    INSERT INTO public.booking_pets (booking_id, pet_id)
+    SELECT new_booking_id, pet_id FROM public.series_pets WHERE series_id = p_series_id;
+    RETURN 1;
+  END IF;
+
+  -- Recurring schedule (existing behaviour).
+  horizon := LEAST(
+    COALESCE(s.end_date, (current_date + (p_weeks_ahead * 7))),
+    (current_date + (p_weeks_ahead * 7))
+  );
+  d := GREATEST(s.start_date, current_date);
+
+  WHILE d <= horizon LOOP
+    dow := EXTRACT(isodow FROM d);
+    want := CASE s.frequency_type
+      WHEN 'daily' THEN true
+      WHEN 'weekdays' THEN dow BETWEEN 1 AND 5
+      WHEN 'specific_days' THEN dow = ANY(s.days_of_week)
+      ELSE false
+    END;
+
+    IF want THEN
+      scheduled := (d::timestamp + s.time_of_day) AT TIME ZONE 'Australia/Sydney';
+      win_end := CASE WHEN s.window_end_time IS NOT NULL
+                      THEN (d::timestamp + s.window_end_time) AT TIME ZONE 'Australia/Sydney'
+                      ELSE NULL END;
+      IF NOT EXISTS (
+        SELECT 1 FROM public.bookings b
+        WHERE b.series_id = p_series_id
+          AND NOT COALESCE(b.is_meet_and_greet, false)
+          AND (b.scheduled_at AT TIME ZONE 'Australia/Sydney')::date = d
+      ) THEN
+        INSERT INTO public.bookings (customer_id, provider_id, pet_id, service_id, status, scheduled_at, window_end_at, duration_mins, total_cents, series_id)
+        VALUES (s.customer_id, s.provider_id, primary_pet, s.service_id, 'confirmed', scheduled, win_end, svc_duration, COALESCE(s.locked_price_cents, 0), p_series_id)
+        RETURNING id INTO new_booking_id;
+
+        INSERT INTO public.booking_pets (booking_id, pet_id)
+        SELECT new_booking_id, pet_id FROM public.series_pets WHERE series_id = p_series_id;
+
+        created_count := created_count + 1;
+      END IF;
+    END IF;
+    d := d + 1;
+  END LOOP;
+
+  RETURN created_count;
+END;
+$function$;
+
+-- 4. Cancel trigger: never cancel the M&G booking -- it stays on record (completed)
+--    even when the series is declined/cancelled.
+CREATE OR REPLACE FUNCTION public.trg_series_cancelled()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+BEGIN
+  IF NEW.status = 'cancelled' AND (OLD.status IS DISTINCT FROM 'cancelled') THEN
+    UPDATE public.bookings
+       SET status = 'cancelled', updated_at = now()
+     WHERE series_id = NEW.id
+       AND NOT COALESCE(is_meet_and_greet, false)
+       AND status IN ('pending', 'confirmed')
+       AND scheduled_at > now();
+  END IF;
+  RETURN NEW;
+END;
+$function$;
+
+-- 5. Gate enforcement: a series may only move pending_meet_greet -> active once a
+--    completed M&G booking exists for it. Server-side so a client cannot bypass the
+--    gate by PATCHing status directly.
+CREATE OR REPLACE FUNCTION public.trg_meet_greet_gate()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+BEGIN
+  IF OLD.status = 'pending_meet_greet' AND NEW.status = 'active' THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM public.bookings b
+      WHERE b.series_id = NEW.id
+        AND b.is_meet_and_greet = true
+        AND b.status = 'completed'
+    ) THEN
+      RAISE EXCEPTION 'Cannot activate series % before its meet & greet is completed', NEW.id
+        USING ERRCODE = 'check_violation';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$function$;
+
+DROP TRIGGER IF EXISTS series_meet_greet_gate ON public.booking_series;
+CREATE TRIGGER series_meet_greet_gate
+  BEFORE UPDATE OF status ON public.booking_series
+  FOR EACH ROW EXECUTE FUNCTION public.trg_meet_greet_gate();
+
+-- Trigger function — not meant to be RPC-callable.
+REVOKE ALL ON FUNCTION public.trg_meet_greet_gate() FROM PUBLIC, anon, authenticated;
+
+-- 6. Completion RPC. Customers have no UPDATE policy on bookings, so marking the
+--    (free) M&G complete runs through a definer fn scoped to the booking's customer.
+CREATE OR REPLACE FUNCTION public.mark_meet_greet_complete(p_booking_id uuid)
+ RETURNS public.bookings
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  b public.bookings%ROWTYPE;
+BEGIN
+  SELECT bk.* INTO b FROM public.bookings bk WHERE bk.id = p_booking_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Booking not found';
+  END IF;
+  IF NOT b.is_meet_and_greet THEN
+    RAISE EXCEPTION 'Booking % is not a meet & greet', p_booking_id;
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM public.customer_profiles cp
+    WHERE cp.id = b.customer_id AND cp.user_id = auth.uid()
+  ) THEN
+    RAISE EXCEPTION 'Not authorised to complete this meet & greet';
+  END IF;
+
+  UPDATE public.bookings
+     SET status = 'completed', completed_at = now(), updated_at = now()
+   WHERE id = p_booking_id
+   RETURNING * INTO b;
+  RETURN b;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.mark_meet_greet_complete(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.mark_meet_greet_complete(uuid) TO authenticated;


### PR DESCRIPTION
Implements [TRU-14](https://linear.app/truffl-pets/issue/TRU-14/meet-and-greets). Before a customer's first booking with a new carer, the pair must complete a free introductory meet & greet (M&G). It applies to **every** service type and is the marketplace's trust gate. The gate is keyed on whether a **completed** M&G already exists for the `(customer_profile, provider_profile)` pair — cleared for good once met, regardless of any later decline.

### Scoping decisions (confirmed up front)
- **Payment is stubbed.** There is no Stripe integration in the project yet, so the "add a payment method" step is a clearly-labelled placeholder that collects no card and activates the series directly. Wiring real Stripe Connect (SetupIntent + charge-on-completion) is left to its own ticket.
- **Every first booking is wrapped in a series.** One-offs (single walks) and all boarding/sitting don't normally create a `booking_series`, but the M&G model is series-centric. So a `booking_kind` discriminator (`recurring`/`oneoff`/`multiday`) was added and the generator now materialises the right row(s) on activation.

### Schema (`supabase/migrations/20260615_tru14_meet_and_greets.sql`, applied to live DB via MCP)
- `series_status` += `pending_meet_greet`; `booking_series.booking_kind`.
- `generate_series_bookings` branches on `booking_kind`, never (re)generates the M&G row.
- `trg_series_cancelled` leaves the completed M&G on record.
- `trg_meet_greet_gate` (BEFORE UPDATE) enforces the gate server-side — no `pending_meet_greet → active` without a completed M&G booking (a client can't bypass it).
- `mark_meet_greet_complete(uuid)` SECURITY DEFINER — customers have no UPDATE on `bookings`, so completion runs through a scoped definer fn (EXECUTE limited to `authenticated`).
- `series_decline_feedback` — **private, INSERT-only RLS, no SELECT policy**: decline reasons/notes are write-only and never readable via the API by either party.

### Surfaces
- **book/**: first-pair bookings route into the M&G flow — owner education modal with service-variant copy blocks → pending series + free flagged M&G booking. Returning pairs book normally.
- **profile/** (customer): M&G card → mark complete → proceed (stub payment → series activates, real booking generated) or decline with private feedback chips.
- **dashboard/** (carer): carer education modal on entry, proposed series details, two-way bow-out with its own private feedback.
- **messages/**: proposed-details banner for both parties; mirrored mark-complete prompt for the customer.

### Testing (Preview + DB verification, all test data cleaned up)
- ✅ First booking → owner modal (tokens + walking variant) → pending series + free M&G booking ($0, 30 min, on record).
- ✅ Mark complete → proceed (stub payment) → series active → real booking generated ($25 locked, correct window).
- ✅ Gate **blocks** `pending_meet_greet → active` without a completed M&G (negative test).
- ✅ Customer decline + carer bow-out both cancel the series and persist private feedback; feedback is **unreadable** via the API by a participant (0 rows).
- ✅ Carer dashboard: education modal, proposed details, bow-out. Messages banner both roles + mirrored completion.
- ✅ Gate-cleared: a returning pair skips the M&G flow and books normally.

> [!NOTE]
> The "Supabase Preview" check will fail (red ❌) as agreed — branching is broken on this repo; the migration is applied via MCP and committed for version control. The `security_definer_view` lints are pre-existing/accepted (no new views were added — this reuses `series_party_names`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)