### PR TITLE
TRU-15: Trust & safety hub + one-way Truffl message channel

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -430,6 +430,7 @@
         <a href="/">Home</a>
         <a href="/about-us/" class="active">About</a>
         <a href="/#services">Services</a>
+        <a href="/trust-and-safety/">Trust &amp; safety</a>
         <a href="/#how">How it works</a>
       </div>
     </div>
@@ -710,6 +711,7 @@
     <div class="footer-links">
       <a href="/register/">For carers</a>
       <a href="/about-us/">About</a>
+      <a href="/trust-and-safety/">Trust &amp; safety</a>
       <a href="#">Contact</a>
       <a href="#">Privacy</a>
     </div>

--- a/book/index.html
+++ b/book/index.html
@@ -815,8 +815,11 @@ async function refreshMsgBadge() {
   if (!authToken || !authUid) return;
   try {
     const rows = await sbGet('messages', `sender_id=neq.${authUid}&read_at=is.null&select=id`, authToken);
+    let sysUnread = 0;
+    try { const sm = await sbGet('system_messages', `recipient_user_id=eq.${authUid}&read_at=is.null&select=id`, authToken); sysUnread = sm.length; } catch (e) {}
+    const total = rows.length + sysUnread;
     const badge = document.getElementById('navMsgBadge');
-    if (badge) { badge.textContent = rows.length > 9 ? '9+' : String(rows.length); badge.style.display = rows.length > 0 ? '' : 'none'; }
+    if (badge) { badge.textContent = total > 9 ? '9+' : String(total); badge.style.display = total > 0 ? '' : 'none'; }
   } catch (e) { /* non-fatal */ }
 }
 

--- a/index.html
+++ b/index.html
@@ -316,6 +316,7 @@
         <a href="/about-us/">About</a>
         <a href="#why">Our carers</a>
         <a href="#how">How it works</a>
+        <a href="/trust-and-safety/">Trust &amp; safety</a>
       </div>
     </div>
 
@@ -865,6 +866,7 @@
     <div class="footer-links">
       <a href="/register/">For carers</a>
       <a href="/about-us/">About</a>
+      <a href="/trust-and-safety/">Trust &amp; safety</a>
       <a href="#">Contact</a>
       <a href="#">Privacy</a>
     </div>

--- a/messages/index.html
+++ b/messages/index.html
@@ -46,6 +46,13 @@
   .conv:hover{background:var(--cream);}
   .conv.active{background:var(--cream);}
   .conv-avatar{width:38px;height:38px;border-radius:50%;background:var(--blush);display:flex;align-items:center;justify-content:center;font-family:'Cormorant Garamond',serif;font-weight:600;font-size:0.95rem;color:var(--brown);flex-shrink:0;}
+  .conv-avatar-system{background:var(--terracotta);color:#fff;}
+  .conv-verified{display:inline-flex;align-items:center;justify-content:center;width:15px;height:15px;border-radius:50%;background:var(--terracotta);color:#fff;font-size:0.62rem;font-weight:700;vertical-align:middle;}
+  .sys-cta{display:inline-block;margin-top:8px;padding:8px 16px;border-radius:8px;background:var(--terracotta);color:#fff;font-size:0.84rem;font-weight:500;text-decoration:none;}
+  .sys-cta:hover{background:var(--terracotta-light);}
+  .composer-disabled{display:flex;align-items:center;gap:8px;padding:14px 16px;border-top:1px solid var(--border);flex-shrink:0;font-size:0.8rem;color:var(--text-muted);background:var(--cream);line-height:1.4;}
+  .composer-disabled svg{flex-shrink:0;color:var(--sage-dark);}
+  .composer-disabled a{color:var(--terracotta);}
   .conv-main{min-width:0;flex:1;}
   .conv-top{display:flex;justify-content:space-between;gap:6px;align-items:baseline;}
   .conv-name{font-size:0.9rem;font-weight:500;color:var(--text-primary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
@@ -148,6 +155,24 @@ let msgsByConv = {};               // conversationId -> [messages]
 let bookingMap = {};               // bookingId -> {serviceType, scheduledAt, status}
 let activeKey = null;
 let pollTimer = null;
+// One-way "Truffl" channel (TRU-15): system notifications rendered as a pinned,
+// reply-disabled conversation. Not a real conversations row.
+let systemConv = null;
+const SYSTEM_KEY = '__truffl__';
+const SYS_AVATAR = `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M9 12l2 2 4-4"/></svg>`;
+
+async function loadSystemConversation(){
+  let rows = [];
+  try { rows = await sbGet('system_messages', `recipient_user_id=eq.${authUid}&select=*&order=created_at.asc`); }
+  catch(e){ return null; }
+  if (!rows.length) return null;
+  return {
+    key: SYSTEM_KEY, id: SYSTEM_KEY, isSystem: true,
+    name: 'Truffl', initials: 'T', counterpartyUserId: null,
+    lastMessageAt: rows[rows.length - 1].created_at, bookings: [], composeBookingId: null,
+    sysMsgs: rows
+  };
+}
 
 function h(token) {
   const hd = { 'Content-Type':'application/json', 'apikey':SUPABASE_ANON_KEY, 'Authorization':`Bearer ${SUPABASE_ANON_KEY}` };
@@ -204,8 +229,8 @@ function dayLabel(iso){
 }
 
 function convByKey(key){ return conversations.find(c => c.key === key) || null; }
-function convMsgs(conv){ return (conv && conv.id) ? (msgsByConv[conv.id] || []) : []; }
-function unreadForConv(conv){ return convMsgs(conv).filter(m => m.sender_id !== authUid && !m.read_at).length; }
+function convMsgs(conv){ if (conv && conv.isSystem) return conv.sysMsgs || []; return (conv && conv.id) ? (msgsByConv[conv.id] || []) : []; }
+function unreadForConv(conv){ if (conv && conv.isSystem) return (conv.sysMsgs || []).filter(m => !m.read_at).length; return convMsgs(conv).filter(m => m.sender_id !== authUid && !m.read_at).length; }
 function lastMsgForConv(conv){ const a = convMsgs(conv); return a.length ? a[a.length-1] : null; }
 
 /* Compose target: the most relevant booking to attach a new message to —
@@ -325,9 +350,15 @@ function convSortTime(c){
   return new Date(0);
 }
 function sortedConversations(){
-  return [...conversations].sort((a,b) => convSortTime(b) - convSortTime(a));
+  // Truffl's one-way channel is always pinned to the top.
+  return [...conversations].sort((a,b) => {
+    if (a.isSystem) return -1;
+    if (b.isSystem) return 1;
+    return convSortTime(b) - convSortTime(a);
+  });
 }
 function convSubLine(c){
+  if (c.isSystem) return 'Help & safety';
   const n = c.bookings.length;
   if (c.composeBookingId) {
     const lbl = bookingLabel(c.composeBookingId);
@@ -347,11 +378,15 @@ function renderList(){
     const last = lastMsgForConv(c);
     const unread = unreadForConv(c);
     const snippet = last ? (last.sender_id === authUid ? 'You: ' : '') + last.body : 'No messages yet';
+    const avatar = c.isSystem
+      ? `<div class="conv-avatar conv-avatar-system">${SYS_AVATAR}</div>`
+      : `<div class="conv-avatar">${esc(c.initials)}</div>`;
+    const nameHtml = c.isSystem ? `${esc(c.name)} <span class="conv-verified" title="Official Truffl channel">✓</span>` : esc(c.name);
     return `
       <button class="conv ${c.key===activeKey?'active':''} ${unread>0?'unread':''}" data-key="${esc(c.key)}">
-        <div class="conv-avatar">${esc(c.initials)}</div>
+        ${avatar}
         <div class="conv-main">
-          <div class="conv-top"><span class="conv-name">${esc(c.name)}</span><span class="conv-time">${last?fmtListTime(last.created_at):''}</span></div>
+          <div class="conv-top"><span class="conv-name">${nameHtml}</span><span class="conv-time">${last?fmtListTime(last.created_at):''}</span></div>
           <div class="conv-sub">${esc(convSubLine(c))}</div>
           <div class="conv-snippet">${esc(snippet)}</div>
         </div>
@@ -374,6 +409,7 @@ function renderThread(preserveInput){
     </div>`;
     return;
   }
+  if (c.isSystem) { renderSystemThread(c); return; }
   const prevInput = preserveInput ? (document.getElementById('composerInput')||{}).value : '';
   const msgs = convMsgs(c);
   let body = '';
@@ -430,6 +466,43 @@ function renderThread(preserveInput){
   tb.scrollTop = tb.scrollHeight;
 }
 
+// The one-way Truffl channel: incoming-only bubbles (each can carry a CTA link),
+// and a disabled composer making clear the customer can't reply.
+function renderSystemThread(c){
+  const el = document.getElementById('thread');
+  const msgs = convMsgs(c);
+  let lastDay = null;
+  const body = msgs.map(m => {
+    let pre = '';
+    const dk = dayKey(m.created_at);
+    if (dk !== lastDay){ pre += `<div class="day-sep">${dayLabel(m.created_at)}</div>`; lastDay = dk; }
+    const cta = m.link_url ? `<a class="sys-cta" href="${esc(m.link_url)}">${esc(m.link_label || 'Open')}</a>` : '';
+    return `${pre}<div class="bubble theirs"><div class="bubble-body">${esc(m.body)}</div>${cta}<div class="bubble-meta">${fmtMsgTime(m.created_at)}</div></div>`;
+  }).join('');
+
+  el.innerHTML = `
+    <div class="thread-head">
+      <div style="display:flex;align-items:center;min-width:0;gap:10px;">
+        <button class="thread-back" id="threadBack" aria-label="Back to conversations"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg></button>
+        <div class="conv-avatar conv-avatar-system" style="width:34px;height:34px;">${SYS_AVATAR}</div>
+        <div style="min-width:0;">
+          <div class="thread-title">Truffl <span class="conv-verified" title="Official Truffl channel">✓</span></div>
+          <div class="thread-ctx">Help &amp; safety · official updates</div>
+        </div>
+      </div>
+    </div>
+    <div class="thread-body" id="threadBody">${body}</div>
+    <div class="composer-disabled" aria-disabled="true">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+      <span>This is a one-way channel from Truffl — you can't reply here. Need a hand? <a href="/trust-and-safety/reporting-a-concern/">Get in touch</a>.</span>
+    </div>`;
+
+  const back = document.getElementById('threadBack');
+  if (back) back.addEventListener('click', closeThread);
+  const tb = document.getElementById('threadBody');
+  tb.scrollTop = tb.scrollHeight;
+}
+
 function autosize(t){ t.style.height='auto'; t.style.height=Math.min(t.scrollHeight,120)+'px'; }
 
 function syncUrl(){
@@ -470,7 +543,19 @@ function closeThread(){
 }
 
 async function markRead(conv){
-  if (!conv || !conv.id) return;
+  if (!conv) return;
+  if (conv.isSystem){
+    const unread = (conv.sysMsgs || []).filter(m => !m.read_at);
+    if (!unread.length) return;
+    try {
+      await sbPatchWhere('system_messages', `recipient_user_id=eq.${authUid}&read_at=is.null`, { read_at: new Date().toISOString() });
+      const now = new Date().toISOString();
+      unread.forEach(m => m.read_at = now);
+      renderList();
+    } catch(e){ /* non-fatal */ }
+    return;
+  }
+  if (!conv.id) return;
   const unread = convMsgs(conv).filter(m => m.sender_id !== authUid && !m.read_at);
   if (!unread.length) return;
   try {
@@ -485,7 +570,7 @@ async function onSend(e){
   const input = document.getElementById('composerInput');
   const text = (input.value||'').trim();
   const c = convByKey(activeKey);
-  if (!text || !c) return;
+  if (!text || !c || c.isSystem) return;
   // Need somewhere to attach: an existing conversation, or a booking (the trigger
   // creates the conversation from booking_id on the first message).
   if (!c.id && !c.composeBookingId) { alert('No booking to message about yet.'); return; }
@@ -515,7 +600,7 @@ async function poll(){
   try {
     const active = convByKey(activeKey);
     const before = active ? convMsgs(active).length : 0;
-    await loadMessages(conversations.map(c => c.id).filter(Boolean));
+    await loadMessages(conversations.map(c => c.id).filter(id => id && id !== SYSTEM_KEY));
     renderList();
     if (active){
       const after = convMsgs(active).length;
@@ -551,6 +636,8 @@ async function init(){
 
   try {
     conversations = await loadConversations();
+    systemConv = await loadSystemConversation();
+    if (systemConv) conversations.unshift(systemConv);
     renderList();
     const params = new URLSearchParams(window.location.search);
     const wantConv = params.get('c');

--- a/profile/index.html
+++ b/profile/index.html
@@ -987,8 +987,12 @@ async function refreshMsgBadge() {
   if (!authToken || !authUid) return;
   try {
     const rows = await sbGet('messages', `sender_id=neq.${authUid}&read_at=is.null&select=id,booking_id`);
+    // Unread one-way Truffl notifications count towards the message-centre badge too.
+    let sysUnread = 0;
+    try { const sm = await sbGet('system_messages', `recipient_user_id=eq.${authUid}&read_at=is.null&select=id`); sysUnread = sm.length; } catch(e) {}
+    const total = rows.length + sysUnread;
     const badge = document.getElementById('navMsgBadge');
-    if (badge) { badge.textContent = rows.length > 9 ? '9+' : String(rows.length); badge.style.display = rows.length > 0 ? '' : 'none'; }
+    if (badge) { badge.textContent = total > 9 ? '9+' : String(total); badge.style.display = total > 0 ? '' : 'none'; }
     const byBooking = {};
     rows.forEach(r => { byBooking[r.booking_id] = (byBooking[r.booking_id] || 0) + 1; });
     document.querySelectorAll('[id^="cardbadge-"]').forEach(el => {

--- a/supabase/migrations/20260616_tru15_system_messages.sql
+++ b/supabase/migrations/20260616_tru15_system_messages.sql
@@ -1,0 +1,110 @@
+-- TRU-15: one-way "Truffl" channel in the message centre.
+-- Truffl posts notifications to a customer (welcome + safety on signup, and a
+-- safety nudge on their first booking). Modelled as recipient-keyed rows rather
+-- than shoehorning a system user into the customer<->provider conversations table.
+-- The customer can read and mark-read their own; they cannot post (no INSERT
+-- policy) — the UI renders this as a reply-disabled "Truffl" thread.
+--
+-- Applied to the live DB via apply_migration; committed here for version control.
+
+CREATE TABLE IF NOT EXISTS public.system_messages (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  recipient_user_id uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  body              text NOT NULL,
+  link_url          text,
+  link_label        text,
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  read_at           timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS idx_system_messages_recipient ON public.system_messages(recipient_user_id, created_at);
+
+ALTER TABLE public.system_messages ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS system_messages_read_own ON public.system_messages;
+CREATE POLICY system_messages_read_own ON public.system_messages
+  FOR SELECT TO authenticated
+  USING (recipient_user_id = auth.uid());
+
+DROP POLICY IF EXISTS system_messages_mark_read ON public.system_messages;
+CREATE POLICY system_messages_mark_read ON public.system_messages
+  FOR UPDATE TO authenticated
+  USING (recipient_user_id = auth.uid())
+  WITH CHECK (recipient_user_id = auth.uid());
+
+-- No INSERT/DELETE policy: clients can't create or remove notifications. Only the
+-- SECURITY DEFINER triggers below (owned by postgres) write them. UPDATE is limited
+-- to the read_at column so recipients can mark-read but not edit the body.
+REVOKE INSERT, DELETE ON public.system_messages FROM anon, authenticated;
+REVOKE UPDATE ON public.system_messages FROM anon, authenticated;
+GRANT UPDATE (read_at) ON public.system_messages TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.post_system_message(p_recipient uuid, p_body text, p_link_url text, p_link_label text)
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+BEGIN
+  INSERT INTO public.system_messages (recipient_user_id, body, link_url, link_label)
+  VALUES (p_recipient, p_body, p_link_url, p_link_label);
+END;
+$function$;
+REVOKE ALL ON FUNCTION public.post_system_message(uuid, text, text, text) FROM PUBLIC, anon, authenticated;
+
+-- Welcome + safety nudge when a customer completes signup (customer_profiles row).
+CREATE OR REPLACE FUNCTION public.trg_system_welcome_customer()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+BEGIN
+  PERFORM public.post_system_message(
+    NEW.user_id,
+    'Welcome to Truffl! Your dog is family, and keeping them safe is everything to us. We vet every carer, but a few simple habits of your own make all the difference — have a look at our Help & Safety section whenever you have a moment.',
+    '/trust-and-safety/',
+    'Open Help & Safety'
+  );
+  RETURN NEW;
+END;
+$function$;
+REVOKE ALL ON FUNCTION public.trg_system_welcome_customer() FROM PUBLIC, anon, authenticated;
+
+DROP TRIGGER IF EXISTS system_welcome_customer ON public.customer_profiles;
+CREATE TRIGGER system_welcome_customer
+  AFTER INSERT ON public.customer_profiles
+  FOR EACH ROW EXECUTE FUNCTION public.trg_system_welcome_customer();
+
+-- Safety nudge on a customer's first booking.
+CREATE OR REPLACE FUNCTION public.trg_system_first_booking()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_recipient uuid;
+  v_count int;
+BEGIN
+  SELECT count(*) INTO v_count FROM public.bookings WHERE customer_id = NEW.customer_id;
+  IF v_count = 1 THEN
+    SELECT user_id INTO v_recipient FROM public.customer_profiles WHERE id = NEW.customer_id;
+    IF v_recipient IS NOT NULL THEN
+      PERFORM public.post_system_message(
+        v_recipient,
+        'Exciting — your first booking is in! Before your dog''s first time with a new carer, it''s worth two minutes in our Help & Safety section: what to cover at the meet & greet, sorting access, and following along on GPS.',
+        '/trust-and-safety/',
+        'Open Help & Safety'
+      );
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$function$;
+REVOKE ALL ON FUNCTION public.trg_system_first_booking() FROM PUBLIC, anon, authenticated;
+
+DROP TRIGGER IF EXISTS system_first_booking ON public.bookings;
+CREATE TRIGGER system_first_booking
+  AFTER INSERT ON public.bookings
+  FOR EACH ROW EXECUTE FUNCTION public.trg_system_first_booking();

--- a/trust-and-safety/choosing-your-carer/index.html
+++ b/trust-and-safety/choosing-your-carer/index.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-T2CPSDBJ1L"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-T2CPSDBJ1L');
+</script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Choosing your carer — Trust &amp; safety — Truffl Pets</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --cream: #F7F3EE; --warm: #EDE7DC; --sage: #C8D5C0; --sage-dark: #8A9E82;
+      --blush: #E8D5CC; --terracotta: #C4866A; --terracotta-dark: #B8795C;
+      --brown: #5C4033; --brown-deep: #3A2E28; --text: #3A2E28; --text-mid: #7A6860;
+      --text-light: #A8978E; --border: rgba(92,64,51,0.12);
+    }
+    html { font-size: 16px; scroll-behavior: smooth; }
+    body { font-family: 'DM Sans', sans-serif; background: var(--cream); color: var(--text); line-height: 1.65; -webkit-font-smoothing: antialiased; }
+    a { text-decoration: none; color: inherit; }
+
+    nav { background: var(--cream); padding: 0 56px; height: 82px; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid var(--border); position: sticky; top: 0; z-index: 100; gap: 24px; flex-wrap: wrap; }
+    .nav-left { display: flex; align-items: center; gap: 32px; }
+    .nav-links { display: flex; gap: 28px; font-size: 13px; color: var(--text-mid); }
+    .nav-links a:hover, .nav-links a.active { color: var(--text); }
+    .nav-links a.active { font-weight: 500; }
+    .nav-actions { display: flex; gap: 24px; align-items: center; font-size: 13px; color: var(--text-mid); }
+    .nav-actions a:hover { color: var(--text); }
+    .btn-primary { background: var(--terracotta); color: #fff; padding: 11px 22px; border-radius: 999px; font-size: 13px; font-weight: 500; transition: background 0.2s, transform 0.2s; }
+    .btn-primary:hover { background: var(--terracotta-dark); transform: translateY(-1px); }
+
+    .article { max-width: 720px; margin: 0 auto; padding: 40px 24px 24px; }
+    .crumb { font-size: 13px; color: var(--text-mid); margin-bottom: 26px; display: inline-flex; align-items: center; gap: 7px; }
+    .crumb:hover { color: var(--terracotta); }
+    .article h1 { font-family: 'Cormorant Garamond', serif; font-weight: 500; font-size: 2.5rem; line-height: 1.12; color: var(--brown); margin-bottom: 18px; }
+    .lead { font-size: 1.08rem; color: var(--text-mid); margin-bottom: 30px; }
+    .article h2 { font-family: 'Cormorant Garamond', serif; font-weight: 500; font-size: 1.6rem; color: var(--brown); margin: 34px 0 12px; }
+    .article h3 { font-size: 1rem; font-weight: 600; color: var(--text); margin: 22px 0 8px; }
+    .article p { margin-bottom: 14px; color: var(--text); }
+    .article ul { list-style: none; margin: 0 0 16px; padding: 0; }
+    .article li { position: relative; padding-left: 26px; margin-bottom: 10px; color: var(--text); }
+    .article li::before { content: ''; position: absolute; left: 6px; top: 11px; width: 7px; height: 7px; border-radius: 50%; background: var(--terracotta); }
+    .article a.inline { color: var(--terracotta); font-weight: 500; border-bottom: 1px solid rgba(196,134,106,0.4); }
+    .article a.inline:hover { border-bottom-color: var(--terracotta); }
+    .note { background: #fff; border: 1px solid var(--border); border-left: 3px solid var(--sage-dark); border-radius: 12px; padding: 18px 20px; margin: 22px 0; }
+    .note p:last-child { margin-bottom: 0; }
+    .cta-row { margin: 30px 0 10px; }
+    .footer-nav { display: flex; justify-content: space-between; gap: 12px; margin-top: 40px; padding-top: 22px; border-top: 1px solid var(--border); font-size: 0.9rem; flex-wrap: wrap; }
+    .footer-nav a { color: var(--terracotta); font-weight: 500; }
+
+    footer { background: var(--brown-deep); color: var(--text-light); padding: 40px 56px; display: flex; align-items: center; justify-content: space-between; gap: 20px; flex-wrap: wrap; margin-top: 48px; }
+    .footer-links { display: flex; gap: 24px; font-size: 13px; color: var(--text-light); flex-wrap: wrap; }
+    .footer-links a:hover { color: #fff; }
+    .footer-copy { font-size: 12px; color: var(--text-light); opacity: 0.7; }
+    @media (max-width: 860px) { nav { padding: 0 20px; } .nav-links { display: none; } .article h1 { font-size: 2rem; } footer { padding: 32px 20px; } }
+  </style>
+</head>
+<body>
+  <nav>
+    <div class="nav-left">
+      <a href="/" class="nav-logo" aria-label="Truffl Pets home">
+        <svg width="150" height="48" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <circle cx="20" cy="33" r="20" fill="#C4866A"/>
+          <text x="20" y="38" font-family="'Cormorant Garamond', Georgia, serif" font-size="14" font-style="italic" fill="#F7F3EE" text-anchor="middle">truffl</text>
+          <text x="52" y="30" font-family="'Cormorant Garamond', Georgia, serif" font-size="32" font-style="italic" fill="#5C4033" letter-spacing="-0.5">truffl</text>
+          <text x="52" y="50" font-family="'DM Sans', sans-serif" font-size="12" font-weight="600" fill="#B0A090" letter-spacing="4">PETS</text>
+        </svg>
+      </a>
+      <div class="nav-links">
+        <a href="/">Home</a>
+        <a href="/about-us/">About</a>
+        <a href="/trust-and-safety/" class="active">Trust &amp; safety</a>
+        <a href="/#how">How it works</a>
+      </div>
+    </div>
+    <div class="nav-actions">
+      <a href="/login/">Sign in</a>
+      <a href="/search/" class="btn-primary">Book a carer</a>
+    </div>
+  </nav>
+
+  <article class="article">
+    <a class="crumb" href="/trust-and-safety/"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg> Trust &amp; safety</a>
+    <h1>Choosing your carer</h1>
+    <p class="lead">Vetting gets a carer through the door. The meet &amp; greet is where you decide if they're right for your dog.</p>
+
+    <p>Before any carer can join Truffl, we check three things:</p>
+    <ul>
+      <li>Their ID, so we know they are who they say they are</li>
+      <li>Them in person, including a hands-on pet care demo</li>
+      <li>Their profile, so the address and experience they list are verified, not just claimed</li>
+    </ul>
+
+    <h2>The meet &amp; greet</h2>
+    <p>Every first booking with a new carer starts with a free meet &amp; greet. You'll get the full checklist <a class="inline" href="/search/">when you book</a>, but the short version:</p>
+    <ul>
+      <li>Watch how they are with your dog, and how your dog is with them</li>
+      <li>Ask about their experience with dogs like yours</li>
+      <li>Talk through routine, quirks, and anything that sets your dog off</li>
+      <li>Make sure they answer everything happily, and ask about your dog too</li>
+    </ul>
+
+    <div class="note">
+      <p>Trust your gut. If it doesn't feel right, you never have to go ahead.</p>
+    </div>
+
+    <div class="cta-row"><a href="/search/" class="btn-primary">Find a carer</a></div>
+
+    <div class="footer-nav">
+      <a href="/trust-and-safety/">← All topics</a>
+      <a href="/trust-and-safety/getting-ready/">Getting ready →</a>
+    </div>
+  </article>
+
+  <footer>
+    <a href="/" aria-label="Truffl Pets home">
+      <svg width="130" height="40" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="20" cy="33" r="20" fill="#C4866A" opacity="0.6"/>
+        <text x="20" y="38" font-family="'Cormorant Garamond', Georgia, serif" font-size="14" font-style="italic" fill="#F7F3EE" text-anchor="middle">truffl</text>
+        <text x="52" y="30" font-family="'Cormorant Garamond', Georgia, serif" font-size="32" font-style="italic" fill="#A8978E" letter-spacing="-0.5">truffl</text>
+      </svg>
+    </a>
+    <div class="footer-links">
+      <a href="/register/">For carers</a>
+      <a href="/about-us/">About</a>
+      <a href="/trust-and-safety/">Trust &amp; safety</a>
+      <a href="#">Contact</a>
+      <a href="#">Privacy</a>
+    </div>
+    <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>
+  </footer>
+</body>
+</html>

--- a/trust-and-safety/following-along-with-gps/index.html
+++ b/trust-and-safety/following-along-with-gps/index.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-T2CPSDBJ1L"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-T2CPSDBJ1L');
+</script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Following along with GPS — Trust &amp; safety — Truffl Pets</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --cream: #F7F3EE; --warm: #EDE7DC; --sage: #C8D5C0; --sage-dark: #8A9E82;
+      --blush: #E8D5CC; --terracotta: #C4866A; --terracotta-dark: #B8795C;
+      --brown: #5C4033; --brown-deep: #3A2E28; --text: #3A2E28; --text-mid: #7A6860;
+      --text-light: #A8978E; --border: rgba(92,64,51,0.12);
+    }
+    html { font-size: 16px; scroll-behavior: smooth; }
+    body { font-family: 'DM Sans', sans-serif; background: var(--cream); color: var(--text); line-height: 1.65; -webkit-font-smoothing: antialiased; }
+    a { text-decoration: none; color: inherit; }
+    nav { background: var(--cream); padding: 0 56px; height: 82px; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid var(--border); position: sticky; top: 0; z-index: 100; gap: 24px; flex-wrap: wrap; }
+    .nav-left { display: flex; align-items: center; gap: 32px; }
+    .nav-links { display: flex; gap: 28px; font-size: 13px; color: var(--text-mid); }
+    .nav-links a:hover, .nav-links a.active { color: var(--text); }
+    .nav-links a.active { font-weight: 500; }
+    .nav-actions { display: flex; gap: 24px; align-items: center; font-size: 13px; color: var(--text-mid); }
+    .nav-actions a:hover { color: var(--text); }
+    .btn-primary { background: var(--terracotta); color: #fff; padding: 11px 22px; border-radius: 999px; font-size: 13px; font-weight: 500; transition: background 0.2s, transform 0.2s; }
+    .btn-primary:hover { background: var(--terracotta-dark); transform: translateY(-1px); }
+    .article { max-width: 720px; margin: 0 auto; padding: 40px 24px 24px; }
+    .crumb { font-size: 13px; color: var(--text-mid); margin-bottom: 26px; display: inline-flex; align-items: center; gap: 7px; }
+    .crumb:hover { color: var(--terracotta); }
+    .article h1 { font-family: 'Cormorant Garamond', serif; font-weight: 500; font-size: 2.5rem; line-height: 1.12; color: var(--brown); margin-bottom: 18px; }
+    .lead { font-size: 1.08rem; color: var(--text-mid); margin-bottom: 30px; }
+    .article h2 { font-family: 'Cormorant Garamond', serif; font-weight: 500; font-size: 1.6rem; color: var(--brown); margin: 34px 0 12px; }
+    .article p { margin-bottom: 14px; color: var(--text); }
+    .article ul { list-style: none; margin: 0 0 16px; padding: 0; }
+    .article li { position: relative; padding-left: 26px; margin-bottom: 10px; color: var(--text); }
+    .article li::before { content: ''; position: absolute; left: 6px; top: 11px; width: 7px; height: 7px; border-radius: 50%; background: var(--terracotta); }
+    .note { background: #fff; border: 1px solid var(--border); border-left: 3px solid var(--sage-dark); border-radius: 12px; padding: 18px 20px; margin: 22px 0; }
+    .note p:last-child { margin-bottom: 0; }
+    .footer-nav { display: flex; justify-content: space-between; gap: 12px; margin-top: 40px; padding-top: 22px; border-top: 1px solid var(--border); font-size: 0.9rem; flex-wrap: wrap; }
+    .footer-nav a { color: var(--terracotta); font-weight: 500; }
+    footer { background: var(--brown-deep); color: var(--text-light); padding: 40px 56px; display: flex; align-items: center; justify-content: space-between; gap: 20px; flex-wrap: wrap; margin-top: 48px; }
+    .footer-links { display: flex; gap: 24px; font-size: 13px; color: var(--text-light); flex-wrap: wrap; }
+    .footer-links a:hover { color: #fff; }
+    .footer-copy { font-size: 12px; color: var(--text-light); opacity: 0.7; }
+    @media (max-width: 860px) { nav { padding: 0 20px; } .nav-links { display: none; } .article h1 { font-size: 2rem; } footer { padding: 32px 20px; } }
+  </style>
+</head>
+<body>
+  <nav>
+    <div class="nav-left">
+      <a href="/" class="nav-logo" aria-label="Truffl Pets home">
+        <svg width="150" height="48" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <circle cx="20" cy="33" r="20" fill="#C4866A"/>
+          <text x="20" y="38" font-family="'Cormorant Garamond', Georgia, serif" font-size="14" font-style="italic" fill="#F7F3EE" text-anchor="middle">truffl</text>
+          <text x="52" y="30" font-family="'Cormorant Garamond', Georgia, serif" font-size="32" font-style="italic" fill="#5C4033" letter-spacing="-0.5">truffl</text>
+          <text x="52" y="50" font-family="'DM Sans', sans-serif" font-size="12" font-weight="600" fill="#B0A090" letter-spacing="4">PETS</text>
+        </svg>
+      </a>
+      <div class="nav-links">
+        <a href="/">Home</a>
+        <a href="/about-us/">About</a>
+        <a href="/trust-and-safety/" class="active">Trust &amp; safety</a>
+        <a href="/#how">How it works</a>
+      </div>
+    </div>
+    <div class="nav-actions">
+      <a href="/login/">Sign in</a>
+      <a href="/search/" class="btn-primary">Book a carer</a>
+    </div>
+  </nav>
+
+  <article class="article">
+    <a class="crumb" href="/trust-and-safety/"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg> Trust &amp; safety</a>
+    <h1>Following along with GPS</h1>
+    <p class="lead">One of the best parts of Truffl: you can watch where your dog is, live, on every walk.</p>
+
+    <ul>
+      <li>Open the booking to follow the route in real time.</li>
+      <li>The full route is saved afterwards, so you can see exactly where they went.</li>
+      <li>It's there for your peace of mind, not to look over anyone's shoulder. Most owners love seeing their dog's adventure.</li>
+    </ul>
+
+    <div class="note">
+      <p>Live tracking is for out-and-about services like walks. For daycare and boarding, your carer checks in every day with a photo and a short update on how your dog is doing, and flags anything that needs your attention.</p>
+    </div>
+
+    <div class="footer-nav">
+      <a href="/trust-and-safety/getting-ready/">← Getting ready</a>
+      <a href="/trust-and-safety/if-something-goes-wrong/">If something goes wrong →</a>
+    </div>
+  </article>
+
+  <footer>
+    <a href="/" aria-label="Truffl Pets home">
+      <svg width="130" height="40" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="20" cy="33" r="20" fill="#C4866A" opacity="0.6"/>
+        <text x="20" y="38" font-family="'Cormorant Garamond', Georgia, serif" font-size="14" font-style="italic" fill="#F7F3EE" text-anchor="middle">truffl</text>
+        <text x="52" y="30" font-family="'Cormorant Garamond', Georgia, serif" font-size="32" font-style="italic" fill="#A8978E" letter-spacing="-0.5">truffl</text>
+      </svg>
+    </a>
+    <div class="footer-links">
+      <a href="/register/">For carers</a>
+      <a href="/about-us/">About</a>
+      <a href="/trust-and-safety/">Trust &amp; safety</a>
+      <a href="#">Contact</a>
+      <a href="#">Privacy</a>
+    </div>
+    <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>
+  </footer>
+</body>
+</html>

--- a/trust-and-safety/getting-ready/index.html
+++ b/trust-and-safety/getting-ready/index.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-T2CPSDBJ1L"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-T2CPSDBJ1L');
+</script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Getting ready — Trust &amp; safety — Truffl Pets</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --cream: #F7F3EE; --warm: #EDE7DC; --sage: #C8D5C0; --sage-dark: #8A9E82;
+      --blush: #E8D5CC; --terracotta: #C4866A; --terracotta-dark: #B8795C;
+      --brown: #5C4033; --brown-deep: #3A2E28; --text: #3A2E28; --text-mid: #7A6860;
+      --text-light: #A8978E; --border: rgba(92,64,51,0.12);
+    }
+    html { font-size: 16px; scroll-behavior: smooth; }
+    body { font-family: 'DM Sans', sans-serif; background: var(--cream); color: var(--text); line-height: 1.65; -webkit-font-smoothing: antialiased; }
+    a { text-decoration: none; color: inherit; }
+    nav { background: var(--cream); padding: 0 56px; height: 82px; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid var(--border); position: sticky; top: 0; z-index: 100; gap: 24px; flex-wrap: wrap; }
+    .nav-left { display: flex; align-items: center; gap: 32px; }
+    .nav-links { display: flex; gap: 28px; font-size: 13px; color: var(--text-mid); }
+    .nav-links a:hover, .nav-links a.active { color: var(--text); }
+    .nav-links a.active { font-weight: 500; }
+    .nav-actions { display: flex; gap: 24px; align-items: center; font-size: 13px; color: var(--text-mid); }
+    .nav-actions a:hover { color: var(--text); }
+    .btn-primary { background: var(--terracotta); color: #fff; padding: 11px 22px; border-radius: 999px; font-size: 13px; font-weight: 500; transition: background 0.2s, transform 0.2s; }
+    .btn-primary:hover { background: var(--terracotta-dark); transform: translateY(-1px); }
+    .article { max-width: 720px; margin: 0 auto; padding: 40px 24px 24px; }
+    .crumb { font-size: 13px; color: var(--text-mid); margin-bottom: 26px; display: inline-flex; align-items: center; gap: 7px; }
+    .crumb:hover { color: var(--terracotta); }
+    .article h1 { font-family: 'Cormorant Garamond', serif; font-weight: 500; font-size: 2.5rem; line-height: 1.12; color: var(--brown); margin-bottom: 18px; }
+    .lead { font-size: 1.08rem; color: var(--text-mid); margin-bottom: 30px; }
+    .article h2 { font-family: 'Cormorant Garamond', serif; font-weight: 500; font-size: 1.6rem; color: var(--brown); margin: 34px 0 12px; }
+    .article h3 { font-size: 1rem; font-weight: 600; color: var(--text); margin: 22px 0 8px; }
+    .article p { margin-bottom: 14px; color: var(--text); }
+    .article ul { list-style: none; margin: 0 0 16px; padding: 0; }
+    .article li { position: relative; padding-left: 26px; margin-bottom: 10px; color: var(--text); }
+    .article li::before { content: ''; position: absolute; left: 6px; top: 11px; width: 7px; height: 7px; border-radius: 50%; background: var(--terracotta); }
+    .article li strong { color: var(--brown); }
+    .note { background: #fff; border: 1px solid var(--border); border-left: 3px solid var(--sage-dark); border-radius: 12px; padding: 18px 20px; margin: 22px 0; }
+    .note p:last-child { margin-bottom: 0; }
+    .footer-nav { display: flex; justify-content: space-between; gap: 12px; margin-top: 40px; padding-top: 22px; border-top: 1px solid var(--border); font-size: 0.9rem; flex-wrap: wrap; }
+    .footer-nav a { color: var(--terracotta); font-weight: 500; }
+    footer { background: var(--brown-deep); color: var(--text-light); padding: 40px 56px; display: flex; align-items: center; justify-content: space-between; gap: 20px; flex-wrap: wrap; margin-top: 48px; }
+    .footer-links { display: flex; gap: 24px; font-size: 13px; color: var(--text-light); flex-wrap: wrap; }
+    .footer-links a:hover { color: #fff; }
+    .footer-copy { font-size: 12px; color: var(--text-light); opacity: 0.7; }
+    @media (max-width: 860px) { nav { padding: 0 20px; } .nav-links { display: none; } .article h1 { font-size: 2rem; } footer { padding: 32px 20px; } }
+  </style>
+</head>
+<body>
+  <nav>
+    <div class="nav-left">
+      <a href="/" class="nav-logo" aria-label="Truffl Pets home">
+        <svg width="150" height="48" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <circle cx="20" cy="33" r="20" fill="#C4866A"/>
+          <text x="20" y="38" font-family="'Cormorant Garamond', Georgia, serif" font-size="14" font-style="italic" fill="#F7F3EE" text-anchor="middle">truffl</text>
+          <text x="52" y="30" font-family="'Cormorant Garamond', Georgia, serif" font-size="32" font-style="italic" fill="#5C4033" letter-spacing="-0.5">truffl</text>
+          <text x="52" y="50" font-family="'DM Sans', sans-serif" font-size="12" font-weight="600" fill="#B0A090" letter-spacing="4">PETS</text>
+        </svg>
+      </a>
+      <div class="nav-links">
+        <a href="/">Home</a>
+        <a href="/about-us/">About</a>
+        <a href="/trust-and-safety/" class="active">Trust &amp; safety</a>
+        <a href="/#how">How it works</a>
+      </div>
+    </div>
+    <div class="nav-actions">
+      <a href="/login/">Sign in</a>
+      <a href="/search/" class="btn-primary">Book a carer</a>
+    </div>
+  </nav>
+
+  <article class="article">
+    <a class="crumb" href="/trust-and-safety/"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg> Trust &amp; safety</a>
+    <h1>Getting ready</h1>
+    <p class="lead">A few minutes of preparation is the difference between a fine booking and a great one.</p>
+
+    <h2>Sorting access</h2>
+    <p>However your carer reaches your dog, sort the details before day one so there are no surprises.</p>
+    <ul>
+      <li><strong>Walks:</strong> agree where you'll hand over, or how they'll collect your dog.</li>
+      <li><strong>Drop-ins and home sitting:</strong> your carer comes to you. Share key safe codes, gate or building access, alarm codes, and anywhere that's off limits.</li>
+      <li><strong>Daycare and boarding:</strong> your dog goes to them. Agree drop-off and pick-up times, and what to bring (food, bed, meds).</li>
+    </ul>
+    <div class="note">
+      <p>Keep access details in Truffl messages so there's a record, and never share more than your carer needs.</p>
+    </div>
+
+    <h2>Writing great notes</h2>
+    <p>Good notes are the difference between a fine booking and a great one. A few minutes here saves a lot of worry later.</p>
+    <ul>
+      <li><strong>Feeding:</strong> what, how much, when</li>
+      <li><strong>Routine:</strong> walk times, toilet habits, naps</li>
+      <li><strong>Behaviour:</strong> how they are with other dogs, people, traffic, and recall</li>
+      <li><strong>Triggers:</strong> anything that scares or overexcites them</li>
+      <li><strong>Medical:</strong> conditions, medication, allergies</li>
+      <li><strong>Vet details:</strong> practice, phone, address (more in <a class="inline" href="/trust-and-safety/if-something-goes-wrong/" style="color:var(--terracotta);border-bottom:1px solid rgba(196,134,106,0.4);">If something goes wrong</a>)</li>
+    </ul>
+    <p>For overnight stays (boarding or sitting), add the bedtime routine: how your dog settles, whether they're crated, and any night-time habits.</p>
+
+    <div class="footer-nav">
+      <a href="/trust-and-safety/choosing-your-carer/">← Choosing your carer</a>
+      <a href="/trust-and-safety/following-along-with-gps/">Following along with GPS →</a>
+    </div>
+  </article>
+
+  <footer>
+    <a href="/" aria-label="Truffl Pets home">
+      <svg width="130" height="40" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="20" cy="33" r="20" fill="#C4866A" opacity="0.6"/>
+        <text x="20" y="38" font-family="'Cormorant Garamond', Georgia, serif" font-size="14" font-style="italic" fill="#F7F3EE" text-anchor="middle">truffl</text>
+        <text x="52" y="30" font-family="'Cormorant Garamond', Georgia, serif" font-size="32" font-style="italic" fill="#A8978E" letter-spacing="-0.5">truffl</text>
+      </svg>
+    </a>
+    <div class="footer-links">
+      <a href="/register/">For carers</a>
+      <a href="/about-us/">About</a>
+      <a href="/trust-and-safety/">Trust &amp; safety</a>
+      <a href="#">Contact</a>
+      <a href="#">Privacy</a>
+    </div>
+    <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>
+  </footer>
+</body>
+</html>

--- a/trust-and-safety/if-something-goes-wrong/index.html
+++ b/trust-and-safety/if-something-goes-wrong/index.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-T2CPSDBJ1L"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-T2CPSDBJ1L');
+</script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>If something goes wrong — Trust &amp; safety — Truffl Pets</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --cream: #F7F3EE; --warm: #EDE7DC; --sage: #C8D5C0; --sage-dark: #8A9E82;
+      --blush: #E8D5CC; --terracotta: #C4866A; --terracotta-dark: #B8795C;
+      --brown: #5C4033; --brown-deep: #3A2E28; --text: #3A2E28; --text-mid: #7A6860;
+      --text-light: #A8978E; --border: rgba(92,64,51,0.12);
+    }
+    html { font-size: 16px; scroll-behavior: smooth; }
+    body { font-family: 'DM Sans', sans-serif; background: var(--cream); color: var(--text); line-height: 1.65; -webkit-font-smoothing: antialiased; }
+    a { text-decoration: none; color: inherit; }
+    nav { background: var(--cream); padding: 0 56px; height: 82px; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid var(--border); position: sticky; top: 0; z-index: 100; gap: 24px; flex-wrap: wrap; }
+    .nav-left { display: flex; align-items: center; gap: 32px; }
+    .nav-links { display: flex; gap: 28px; font-size: 13px; color: var(--text-mid); }
+    .nav-links a:hover, .nav-links a.active { color: var(--text); }
+    .nav-links a.active { font-weight: 500; }
+    .nav-actions { display: flex; gap: 24px; align-items: center; font-size: 13px; color: var(--text-mid); }
+    .nav-actions a:hover { color: var(--text); }
+    .btn-primary { background: var(--terracotta); color: #fff; padding: 11px 22px; border-radius: 999px; font-size: 13px; font-weight: 500; transition: background 0.2s, transform 0.2s; }
+    .btn-primary:hover { background: var(--terracotta-dark); transform: translateY(-1px); }
+    .article { max-width: 720px; margin: 0 auto; padding: 40px 24px 24px; }
+    .crumb { font-size: 13px; color: var(--text-mid); margin-bottom: 26px; display: inline-flex; align-items: center; gap: 7px; }
+    .crumb:hover { color: var(--terracotta); }
+    .article h1 { font-family: 'Cormorant Garamond', serif; font-weight: 500; font-size: 2.5rem; line-height: 1.12; color: var(--brown); margin-bottom: 18px; }
+    .lead { font-size: 1.08rem; color: var(--text-mid); margin-bottom: 30px; }
+    .article h2 { font-family: 'Cormorant Garamond', serif; font-weight: 500; font-size: 1.6rem; color: var(--brown); margin: 34px 0 12px; }
+    .article p { margin-bottom: 14px; color: var(--text); }
+    .article ul, .article ol { margin: 0 0 16px; padding: 0; list-style: none; counter-reset: step; }
+    .article li { position: relative; padding-left: 26px; margin-bottom: 10px; color: var(--text); }
+    .article ul li::before { content: ''; position: absolute; left: 6px; top: 11px; width: 7px; height: 7px; border-radius: 50%; background: var(--terracotta); }
+    .article ol li { padding-left: 38px; margin-bottom: 12px; }
+    .article ol li::before { counter-increment: step; content: counter(step); position: absolute; left: 0; top: 1px; width: 24px; height: 24px; border-radius: 50%; background: var(--terracotta); color: #fff; font-size: 0.8rem; font-weight: 600; display: flex; align-items: center; justify-content: center; }
+    .note { background: #fff; border: 1px solid var(--border); border-left: 3px solid var(--sage-dark); border-radius: 12px; padding: 18px 20px; margin: 22px 0; }
+    .note p:last-child { margin-bottom: 0; }
+    .urgent { background: #FBEEE8; border: 1px solid rgba(196,134,106,0.4); border-radius: 14px; padding: 20px 22px; margin: 24px 0; text-align: center; }
+    .urgent .urgent-label { font-size: 0.78rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--terracotta-dark); font-weight: 600; margin-bottom: 6px; }
+    .urgent .urgent-num { font-family: 'Cormorant Garamond', serif; font-size: 2rem; color: var(--brown); font-weight: 500; }
+    .urgent .urgent-sub { font-size: 0.85rem; color: var(--text-mid); margin-top: 4px; }
+    .footer-nav { display: flex; justify-content: space-between; gap: 12px; margin-top: 40px; padding-top: 22px; border-top: 1px solid var(--border); font-size: 0.9rem; flex-wrap: wrap; }
+    .footer-nav a { color: var(--terracotta); font-weight: 500; }
+    footer { background: var(--brown-deep); color: var(--text-light); padding: 40px 56px; display: flex; align-items: center; justify-content: space-between; gap: 20px; flex-wrap: wrap; margin-top: 48px; }
+    .footer-links { display: flex; gap: 24px; font-size: 13px; color: var(--text-light); flex-wrap: wrap; }
+    .footer-links a:hover { color: #fff; }
+    .footer-copy { font-size: 12px; color: var(--text-light); opacity: 0.7; }
+    @media (max-width: 860px) { nav { padding: 0 20px; } .nav-links { display: none; } .article h1 { font-size: 2rem; } footer { padding: 32px 20px; } }
+  </style>
+</head>
+<body>
+  <nav>
+    <div class="nav-left">
+      <a href="/" class="nav-logo" aria-label="Truffl Pets home">
+        <svg width="150" height="48" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <circle cx="20" cy="33" r="20" fill="#C4866A"/>
+          <text x="20" y="38" font-family="'Cormorant Garamond', Georgia, serif" font-size="14" font-style="italic" fill="#F7F3EE" text-anchor="middle">truffl</text>
+          <text x="52" y="30" font-family="'Cormorant Garamond', Georgia, serif" font-size="32" font-style="italic" fill="#5C4033" letter-spacing="-0.5">truffl</text>
+          <text x="52" y="50" font-family="'DM Sans', sans-serif" font-size="12" font-weight="600" fill="#B0A090" letter-spacing="4">PETS</text>
+        </svg>
+      </a>
+      <div class="nav-links">
+        <a href="/">Home</a>
+        <a href="/about-us/">About</a>
+        <a href="/trust-and-safety/" class="active">Trust &amp; safety</a>
+        <a href="/#how">How it works</a>
+      </div>
+    </div>
+    <div class="nav-actions">
+      <a href="/login/">Sign in</a>
+      <a href="/search/" class="btn-primary">Book a carer</a>
+    </div>
+  </nav>
+
+  <article class="article">
+    <a class="crumb" href="/trust-and-safety/"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg> Trust &amp; safety</a>
+    <h1>If something goes wrong</h1>
+    <p class="lead">Most bookings go perfectly. But it's worth knowing what happens if they don't.</p>
+
+    <h2>Before any booking</h2>
+    <ul>
+      <li>Add your vet's details (practice, phone, address) and keep them current</li>
+      <li>Add an emergency contact in case we can't reach you</li>
+      <li>Note any conditions, medication and allergies clearly</li>
+    </ul>
+
+    <h2>In an emergency</h2>
+    <p>Your carer is guided to:</p>
+    <ol>
+      <li>Call you or your emergency contact first</li>
+      <li>If they can't reach anyone, call your vet to decide whether urgent care is needed</li>
+      <li>Let us know on our priority line, open 24/7</li>
+    </ol>
+    <p>If it's clearly serious, like a collapse or a road accident, they'll get your dog straight to the nearest vet and call on the way. Care first, calls second.</p>
+
+    <!-- PLACEHOLDER (cover): confirm the cover's proper name, what it includes, and the conditions before launch. -->
+    <div class="note">
+      <p>Urgent vet care is the owner's responsibility to cover. If an injury or illness is a direct result of the booking, it may be eligible for Truffl cover (conditions apply).</p>
+    </div>
+
+    <!-- PLACEHOLDER (priority line): currently the founder's mobile. Swap for the permanent 24/7 support number before launch. -->
+    <div class="urgent" data-placeholder="priority-line">
+      <div class="urgent-label">Priority line · open 24 hours, every day</div>
+      <div class="urgent-num"><a href="tel:+61459790999">0459 790 999</a></div>
+      <div class="urgent-sub">For emergencies during a booking</div>
+    </div>
+
+    <div class="footer-nav">
+      <a href="/trust-and-safety/following-along-with-gps/">← Following along with GPS</a>
+      <a href="/trust-and-safety/reporting-a-concern/">Reporting a concern →</a>
+    </div>
+  </article>
+
+  <footer>
+    <a href="/" aria-label="Truffl Pets home">
+      <svg width="130" height="40" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="20" cy="33" r="20" fill="#C4866A" opacity="0.6"/>
+        <text x="20" y="38" font-family="'Cormorant Garamond', Georgia, serif" font-size="14" font-style="italic" fill="#F7F3EE" text-anchor="middle">truffl</text>
+        <text x="52" y="30" font-family="'Cormorant Garamond', Georgia, serif" font-size="32" font-style="italic" fill="#A8978E" letter-spacing="-0.5">truffl</text>
+      </svg>
+    </a>
+    <div class="footer-links">
+      <a href="/register/">For carers</a>
+      <a href="/about-us/">About</a>
+      <a href="/trust-and-safety/">Trust &amp; safety</a>
+      <a href="#">Contact</a>
+      <a href="#">Privacy</a>
+    </div>
+    <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>
+  </footer>
+</body>
+</html>

--- a/trust-and-safety/index.html
+++ b/trust-and-safety/index.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-T2CPSDBJ1L"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-T2CPSDBJ1L');
+</script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Trust &amp; safety — Truffl Pets</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <meta name="description" content="How to get the most from Truffl, safely. Choosing your carer, getting ready, following along on GPS, and what to do if something goes wrong.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --cream: #F7F3EE; --warm: #EDE7DC; --sage: #C8D5C0; --sage-dark: #8A9E82;
+      --blush: #E8D5CC; --terracotta: #C4866A; --terracotta-dark: #B8795C;
+      --brown: #5C4033; --brown-deep: #3A2E28; --text: #3A2E28; --text-mid: #7A6860;
+      --text-light: #A8978E; --border: rgba(92,64,51,0.12);
+    }
+    html { font-size: 16px; scroll-behavior: smooth; }
+    body { font-family: 'DM Sans', sans-serif; background: var(--cream); color: var(--text); line-height: 1.6; -webkit-font-smoothing: antialiased; }
+    a { text-decoration: none; color: inherit; }
+
+    nav { background: var(--cream); padding: 0 56px; height: 82px; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid var(--border); position: sticky; top: 0; z-index: 100; gap: 24px; flex-wrap: wrap; }
+    .nav-left { display: flex; align-items: center; gap: 32px; }
+    .nav-links { display: flex; gap: 28px; font-size: 13px; color: var(--text-mid); }
+    .nav-links a { transition: color 0.2s; letter-spacing: 0.02em; }
+    .nav-links a:hover, .nav-links a.active { color: var(--text); }
+    .nav-links a.active { font-weight: 500; }
+    .nav-actions { display: flex; gap: 24px; align-items: center; font-size: 13px; color: var(--text-mid); }
+    .nav-actions a:hover { color: var(--text); }
+    .btn-primary { background: var(--terracotta); color: #fff; padding: 11px 22px; border-radius: 999px; font-size: 13px; font-weight: 500; transition: background 0.2s, transform 0.2s; }
+    .btn-primary:hover { background: var(--terracotta-dark); transform: translateY(-1px); }
+
+    .wrap { max-width: 980px; margin: 0 auto; padding: 56px 24px 40px; }
+
+    .ts-hero { max-width: 680px; margin: 0 auto 44px; text-align: center; }
+    .ts-eyebrow { font-size: 12px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--terracotta); font-weight: 500; margin-bottom: 14px; }
+    .ts-hero h1 { font-family: 'Cormorant Garamond', serif; font-weight: 500; font-size: 2.8rem; line-height: 1.1; color: var(--brown); margin-bottom: 16px; }
+    .ts-hero p { font-size: 1.02rem; color: var(--text-mid); }
+
+    .ts-cards { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+    .ts-card { background: #fff; border: 1px solid var(--border); border-radius: 18px; padding: 26px 24px; transition: transform 0.2s, box-shadow 0.2s, border-color 0.2s; display: flex; flex-direction: column; }
+    .ts-card:hover { transform: translateY(-3px); box-shadow: 0 14px 30px rgba(92,64,51,0.08); border-color: rgba(196,134,106,0.4); }
+    .ts-card-ic { width: 44px; height: 44px; border-radius: 12px; background: var(--blush); color: var(--brown); display: flex; align-items: center; justify-content: center; margin-bottom: 16px; }
+    .ts-card-ic svg { width: 22px; height: 22px; }
+    .ts-card h2 { font-family: 'Cormorant Garamond', serif; font-weight: 500; font-size: 1.4rem; color: var(--brown); margin-bottom: 8px; }
+    .ts-card p { font-size: 0.9rem; color: var(--text-mid); line-height: 1.55; }
+    .ts-card .ts-arrow { margin-top: 16px; font-size: 0.85rem; color: var(--terracotta); font-weight: 500; display: inline-flex; align-items: center; gap: 6px; }
+
+    footer { background: var(--brown-deep); color: var(--text-light); padding: 48px 56px; display: flex; align-items: center; justify-content: space-between; gap: 24px; flex-wrap: wrap; margin-top: 40px; }
+    .footer-links { display: flex; gap: 28px; font-size: 13px; color: var(--text-light); flex-wrap: wrap; }
+    .footer-links a:hover { color: #fff; }
+    .footer-copy { font-size: 12px; color: var(--text-light); opacity: 0.7; }
+
+    @media (max-width: 860px) {
+      nav { padding: 0 20px; }
+      .nav-links { display: none; }
+      .ts-cards { grid-template-columns: 1fr; }
+      .ts-hero h1 { font-size: 2.2rem; }
+      footer { padding: 36px 20px; }
+    }
+  </style>
+</head>
+<body>
+  <nav>
+    <div class="nav-left">
+      <a href="/" class="nav-logo" aria-label="Truffl Pets home">
+        <svg width="150" height="48" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <circle cx="20" cy="5.5" r="6" fill="none" stroke="#C4866A" stroke-width="2.5"/>
+          <circle cx="20" cy="5.5" r="2.8" fill="#F7F3EE"/>
+          <rect x="16.5" y="10.5" width="7" height="9" rx="3" fill="#C4866A"/>
+          <circle cx="20" cy="33" r="20" fill="#C4866A"/>
+          <text x="20" y="35.5" font-family="'Cormorant Garamond', Georgia, serif" font-size="14" font-style="italic" fill="#F7F3EE" text-anchor="middle" letter-spacing="-0.3">truffl</text>
+          <text x="52" y="30" font-family="'Cormorant Garamond', Georgia, serif" font-size="32" font-style="italic" fill="#5C4033" letter-spacing="-0.5">truffl</text>
+          <text x="52" y="50" font-family="'DM Sans', sans-serif" font-size="12" font-weight="600" fill="#B0A090" letter-spacing="4">PETS</text>
+        </svg>
+      </a>
+      <div class="nav-links">
+        <a href="/">Home</a>
+        <a href="/about-us/">About</a>
+        <a href="/trust-and-safety/" class="active">Trust &amp; safety</a>
+        <a href="/#how">How it works</a>
+      </div>
+    </div>
+    <div class="nav-actions">
+      <a href="/login/">Sign in</a>
+      <a href="/search/" class="btn-primary">Book a carer</a>
+    </div>
+  </nav>
+
+  <div class="wrap">
+    <div class="ts-hero">
+      <div class="ts-eyebrow">Trust &amp; safety</div>
+      <h1>Everything worth knowing</h1>
+      <p>Your dog is family, and handing them to someone new takes trust. We vet every carer before they join Truffl, but a few simple habits of your own make all the difference. Here's everything worth knowing.</p>
+    </div>
+
+    <div class="ts-cards">
+      <a class="ts-card" href="/trust-and-safety/choosing-your-carer/">
+        <span class="ts-card-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>
+        <h2>Choosing your carer</h2>
+        <p>How we vet carers, and how to use the meet &amp; greet to find the right one.</p>
+        <span class="ts-arrow">Read more →</span>
+      </a>
+      <a class="ts-card" href="/trust-and-safety/getting-ready/">
+        <span class="ts-card-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg></span>
+        <h2>Getting ready</h2>
+        <p>Sort access and write notes that set your carer up well.</p>
+        <span class="ts-arrow">Read more →</span>
+      </a>
+      <a class="ts-card" href="/trust-and-safety/following-along-with-gps/">
+        <span class="ts-card-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg></span>
+        <h2>Following along with GPS</h2>
+        <p>See where your dog is in real time, every walk.</p>
+        <span class="ts-arrow">Read more →</span>
+      </a>
+      <a class="ts-card" href="/trust-and-safety/if-something-goes-wrong/">
+        <span class="ts-card-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg></span>
+        <h2>If something goes wrong</h2>
+        <p>Vets, emergencies, and what to do if you're worried.</p>
+        <span class="ts-arrow">Read more →</span>
+      </a>
+      <a class="ts-card" href="/trust-and-safety/reporting-a-concern/">
+        <span class="ts-card-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z"/><line x1="4" y1="22" x2="4" y2="15"/></svg></span>
+        <h2>Reporting a concern</h2>
+        <p>How to tell us if something doesn't feel right.</p>
+        <span class="ts-arrow">Read more →</span>
+      </a>
+      <a class="ts-card" href="/trust-and-safety/keeping-it-on-truffl/">
+        <span class="ts-card-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg></span>
+        <h2>Keeping it on Truffl</h2>
+        <p>Why booking, chatting and paying here keeps you covered.</p>
+        <span class="ts-arrow">Read more →</span>
+      </a>
+    </div>
+  </div>
+
+  <footer>
+    <a href="/" aria-label="Truffl Pets home">
+      <svg width="130" height="40" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="20" cy="33" r="20" fill="#C4866A" opacity="0.6"/>
+        <text x="20" y="38" font-family="'Cormorant Garamond', Georgia, serif" font-size="14" font-style="italic" fill="#F7F3EE" text-anchor="middle">truffl</text>
+        <text x="52" y="30" font-family="'Cormorant Garamond', Georgia, serif" font-size="32" font-style="italic" fill="#A8978E" letter-spacing="-0.5">truffl</text>
+        <text x="52" y="50" font-family="'DM Sans', sans-serif" font-size="12" font-weight="600" fill="#A8978E" letter-spacing="4" opacity="0.6">PETS</text>
+      </svg>
+    </a>
+    <div class="footer-links">
+      <a href="/register/">For carers</a>
+      <a href="/about-us/">About</a>
+      <a href="/trust-and-safety/">Trust &amp; safety</a>
+      <a href="#">Contact</a>
+      <a href="#">Privacy</a>
+    </div>
+    <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>
+  </footer>
+</body>
+</html>

--- a/trust-and-safety/keeping-it-on-truffl/index.html
+++ b/trust-and-safety/keeping-it-on-truffl/index.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-T2CPSDBJ1L"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-T2CPSDBJ1L');
+</script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Keeping it on Truffl — Trust &amp; safety — Truffl Pets</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --cream: #F7F3EE; --warm: #EDE7DC; --sage: #C8D5C0; --sage-dark: #8A9E82;
+      --blush: #E8D5CC; --terracotta: #C4866A; --terracotta-dark: #B8795C;
+      --brown: #5C4033; --brown-deep: #3A2E28; --text: #3A2E28; --text-mid: #7A6860;
+      --text-light: #A8978E; --border: rgba(92,64,51,0.12);
+    }
+    html { font-size: 16px; scroll-behavior: smooth; }
+    body { font-family: 'DM Sans', sans-serif; background: var(--cream); color: var(--text); line-height: 1.65; -webkit-font-smoothing: antialiased; }
+    a { text-decoration: none; color: inherit; }
+    nav { background: var(--cream); padding: 0 56px; height: 82px; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid var(--border); position: sticky; top: 0; z-index: 100; gap: 24px; flex-wrap: wrap; }
+    .nav-left { display: flex; align-items: center; gap: 32px; }
+    .nav-links { display: flex; gap: 28px; font-size: 13px; color: var(--text-mid); }
+    .nav-links a:hover, .nav-links a.active { color: var(--text); }
+    .nav-links a.active { font-weight: 500; }
+    .nav-actions { display: flex; gap: 24px; align-items: center; font-size: 13px; color: var(--text-mid); }
+    .nav-actions a:hover { color: var(--text); }
+    .btn-primary { background: var(--terracotta); color: #fff; padding: 11px 22px; border-radius: 999px; font-size: 13px; font-weight: 500; transition: background 0.2s, transform 0.2s; }
+    .btn-primary:hover { background: var(--terracotta-dark); transform: translateY(-1px); }
+    .article { max-width: 720px; margin: 0 auto; padding: 40px 24px 24px; }
+    .crumb { font-size: 13px; color: var(--text-mid); margin-bottom: 26px; display: inline-flex; align-items: center; gap: 7px; }
+    .crumb:hover { color: var(--terracotta); }
+    .article h1 { font-family: 'Cormorant Garamond', serif; font-weight: 500; font-size: 2.5rem; line-height: 1.12; color: var(--brown); margin-bottom: 18px; }
+    .lead { font-size: 1.08rem; color: var(--text-mid); margin-bottom: 30px; }
+    .article p { margin-bottom: 14px; color: var(--text); }
+    .article ul { list-style: none; margin: 0 0 16px; padding: 0; }
+    .article li { position: relative; padding-left: 26px; margin-bottom: 10px; color: var(--text); }
+    .article li::before { content: ''; position: absolute; left: 6px; top: 11px; width: 7px; height: 7px; border-radius: 50%; background: var(--terracotta); }
+    .article li strong { color: var(--brown); }
+    .note { background: #fff; border: 1px solid var(--border); border-left: 3px solid var(--sage-dark); border-radius: 12px; padding: 18px 20px; margin: 22px 0; }
+    .note p:last-child { margin-bottom: 0; }
+    .footer-nav { display: flex; justify-content: space-between; gap: 12px; margin-top: 40px; padding-top: 22px; border-top: 1px solid var(--border); font-size: 0.9rem; flex-wrap: wrap; }
+    .footer-nav a { color: var(--terracotta); font-weight: 500; }
+    footer { background: var(--brown-deep); color: var(--text-light); padding: 40px 56px; display: flex; align-items: center; justify-content: space-between; gap: 20px; flex-wrap: wrap; margin-top: 48px; }
+    .footer-links { display: flex; gap: 24px; font-size: 13px; color: var(--text-light); flex-wrap: wrap; }
+    .footer-links a:hover { color: #fff; }
+    .footer-copy { font-size: 12px; color: var(--text-light); opacity: 0.7; }
+    @media (max-width: 860px) { nav { padding: 0 20px; } .nav-links { display: none; } .article h1 { font-size: 2rem; } footer { padding: 32px 20px; } }
+  </style>
+</head>
+<body>
+  <nav>
+    <div class="nav-left">
+      <a href="/" class="nav-logo" aria-label="Truffl Pets home">
+        <svg width="150" height="48" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <circle cx="20" cy="33" r="20" fill="#C4866A"/>
+          <text x="20" y="38" font-family="'Cormorant Garamond', Georgia, serif" font-size="14" font-style="italic" fill="#F7F3EE" text-anchor="middle">truffl</text>
+          <text x="52" y="30" font-family="'Cormorant Garamond', Georgia, serif" font-size="32" font-style="italic" fill="#5C4033" letter-spacing="-0.5">truffl</text>
+          <text x="52" y="50" font-family="'DM Sans', sans-serif" font-size="12" font-weight="600" fill="#B0A090" letter-spacing="4">PETS</text>
+        </svg>
+      </a>
+      <div class="nav-links">
+        <a href="/">Home</a>
+        <a href="/about-us/">About</a>
+        <a href="/trust-and-safety/" class="active">Trust &amp; safety</a>
+        <a href="/#how">How it works</a>
+      </div>
+    </div>
+    <div class="nav-actions">
+      <a href="/login/">Sign in</a>
+      <a href="/search/" class="btn-primary">Book a carer</a>
+    </div>
+  </nav>
+
+  <article class="article">
+    <a class="crumb" href="/trust-and-safety/"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg> Trust &amp; safety</a>
+    <h1>Keeping it on Truffl</h1>
+    <p class="lead">It's tempting to take things off-platform once you know a carer, but keeping everything in Truffl is what keeps you protected.</p>
+
+    <ul>
+      <li><strong>Payments:</strong> paying through Truffl means a clear record, the cover that comes with a booking, and you're only ever charged after each service is done.</li>
+      <li><strong>Messages:</strong> keeping chat here gives you a written history if anything is ever in question.</li>
+      <li><strong>GPS and support:</strong> tracking and our help only work for bookings made through Truffl.</li>
+    </ul>
+
+    <div class="note">
+      <p>If a carer ever asks to arrange or pay outside Truffl, that's worth <a href="/trust-and-safety/reporting-a-concern/" style="color:var(--terracotta);font-weight:500;">reporting</a>.</p>
+    </div>
+
+    <div class="footer-nav">
+      <a href="/trust-and-safety/reporting-a-concern/">← Reporting a concern</a>
+      <a href="/trust-and-safety/">All topics →</a>
+    </div>
+  </article>
+
+  <footer>
+    <a href="/" aria-label="Truffl Pets home">
+      <svg width="130" height="40" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="20" cy="33" r="20" fill="#C4866A" opacity="0.6"/>
+        <text x="20" y="38" font-family="'Cormorant Garamond', Georgia, serif" font-size="14" font-style="italic" fill="#F7F3EE" text-anchor="middle">truffl</text>
+        <text x="52" y="30" font-family="'Cormorant Garamond', Georgia, serif" font-size="32" font-style="italic" fill="#A8978E" letter-spacing="-0.5">truffl</text>
+      </svg>
+    </a>
+    <div class="footer-links">
+      <a href="/register/">For carers</a>
+      <a href="/about-us/">About</a>
+      <a href="/trust-and-safety/">Trust &amp; safety</a>
+      <a href="#">Contact</a>
+      <a href="#">Privacy</a>
+    </div>
+    <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>
+  </footer>
+</body>
+</html>

--- a/trust-and-safety/reporting-a-concern/index.html
+++ b/trust-and-safety/reporting-a-concern/index.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-T2CPSDBJ1L"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-T2CPSDBJ1L');
+</script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reporting a concern — Trust &amp; safety — Truffl Pets</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --cream: #F7F3EE; --warm: #EDE7DC; --sage: #C8D5C0; --sage-dark: #8A9E82;
+      --blush: #E8D5CC; --terracotta: #C4866A; --terracotta-dark: #B8795C;
+      --brown: #5C4033; --brown-deep: #3A2E28; --text: #3A2E28; --text-mid: #7A6860;
+      --text-light: #A8978E; --border: rgba(92,64,51,0.12);
+    }
+    html { font-size: 16px; scroll-behavior: smooth; }
+    body { font-family: 'DM Sans', sans-serif; background: var(--cream); color: var(--text); line-height: 1.65; -webkit-font-smoothing: antialiased; }
+    a { text-decoration: none; color: inherit; }
+    nav { background: var(--cream); padding: 0 56px; height: 82px; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid var(--border); position: sticky; top: 0; z-index: 100; gap: 24px; flex-wrap: wrap; }
+    .nav-left { display: flex; align-items: center; gap: 32px; }
+    .nav-links { display: flex; gap: 28px; font-size: 13px; color: var(--text-mid); }
+    .nav-links a:hover, .nav-links a.active { color: var(--text); }
+    .nav-links a.active { font-weight: 500; }
+    .nav-actions { display: flex; gap: 24px; align-items: center; font-size: 13px; color: var(--text-mid); }
+    .nav-actions a:hover { color: var(--text); }
+    .btn-primary { background: var(--terracotta); color: #fff; padding: 11px 22px; border-radius: 999px; font-size: 13px; font-weight: 500; transition: background 0.2s, transform 0.2s; }
+    .btn-primary:hover { background: var(--terracotta-dark); transform: translateY(-1px); }
+    .article { max-width: 720px; margin: 0 auto; padding: 40px 24px 24px; }
+    .crumb { font-size: 13px; color: var(--text-mid); margin-bottom: 26px; display: inline-flex; align-items: center; gap: 7px; }
+    .crumb:hover { color: var(--terracotta); }
+    .article h1 { font-family: 'Cormorant Garamond', serif; font-weight: 500; font-size: 2.5rem; line-height: 1.12; color: var(--brown); margin-bottom: 18px; }
+    .lead { font-size: 1.08rem; color: var(--text-mid); margin-bottom: 30px; }
+    .article p { margin-bottom: 14px; color: var(--text); }
+    .article ul { list-style: none; margin: 0 0 16px; padding: 0; }
+    .article li { position: relative; padding-left: 26px; margin-bottom: 10px; color: var(--text); }
+    .article li::before { content: ''; position: absolute; left: 6px; top: 11px; width: 7px; height: 7px; border-radius: 50%; background: var(--terracotta); }
+    .article a.inline { color: var(--terracotta); font-weight: 500; border-bottom: 1px solid rgba(196,134,106,0.4); }
+    .email-box { background: #fff; border: 1px solid var(--border); border-radius: 14px; padding: 22px; margin: 24px 0; text-align: center; }
+    .email-box a { font-family: 'Cormorant Garamond', serif; font-size: 1.6rem; color: var(--terracotta-dark); font-weight: 500; }
+    .footer-nav { display: flex; justify-content: space-between; gap: 12px; margin-top: 40px; padding-top: 22px; border-top: 1px solid var(--border); font-size: 0.9rem; flex-wrap: wrap; }
+    .footer-nav a { color: var(--terracotta); font-weight: 500; }
+    footer { background: var(--brown-deep); color: var(--text-light); padding: 40px 56px; display: flex; align-items: center; justify-content: space-between; gap: 20px; flex-wrap: wrap; margin-top: 48px; }
+    .footer-links { display: flex; gap: 24px; font-size: 13px; color: var(--text-light); flex-wrap: wrap; }
+    .footer-links a:hover { color: #fff; }
+    .footer-copy { font-size: 12px; color: var(--text-light); opacity: 0.7; }
+    @media (max-width: 860px) { nav { padding: 0 20px; } .nav-links { display: none; } .article h1 { font-size: 2rem; } footer { padding: 32px 20px; } }
+  </style>
+</head>
+<body>
+  <nav>
+    <div class="nav-left">
+      <a href="/" class="nav-logo" aria-label="Truffl Pets home">
+        <svg width="150" height="48" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <circle cx="20" cy="33" r="20" fill="#C4866A"/>
+          <text x="20" y="38" font-family="'Cormorant Garamond', Georgia, serif" font-size="14" font-style="italic" fill="#F7F3EE" text-anchor="middle">truffl</text>
+          <text x="52" y="30" font-family="'Cormorant Garamond', Georgia, serif" font-size="32" font-style="italic" fill="#5C4033" letter-spacing="-0.5">truffl</text>
+          <text x="52" y="50" font-family="'DM Sans', sans-serif" font-size="12" font-weight="600" fill="#B0A090" letter-spacing="4">PETS</text>
+        </svg>
+      </a>
+      <div class="nav-links">
+        <a href="/">Home</a>
+        <a href="/about-us/">About</a>
+        <a href="/trust-and-safety/" class="active">Trust &amp; safety</a>
+        <a href="/#how">How it works</a>
+      </div>
+    </div>
+    <div class="nav-actions">
+      <a href="/login/">Sign in</a>
+      <a href="/search/" class="btn-primary">Book a carer</a>
+    </div>
+  </nav>
+
+  <article class="article">
+    <a class="crumb" href="/trust-and-safety/"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg> Trust &amp; safety</a>
+    <h1>Reporting a concern</h1>
+    <p class="lead">If something doesn't feel right, we want to know. Trust is the whole point of Truffl, and we take every concern seriously.</p>
+
+    <!-- PLACEHOLDER (reporting email): confirm the real address before launch. -->
+    <div class="email-box" data-placeholder="safety-email">
+      <a href="mailto:safety@trufflpets.com">safety@trufflpets.com</a>
+    </div>
+
+    <ul>
+      <li>Tell us what happened in your own words. Screenshots and detail help.</li>
+      <li>We investigate every concern urgently, handle it sensitively, and keep it confidential unless you tell us otherwise.</li>
+    </ul>
+
+    <p>You can raise anything: a carer who didn't follow your notes, something that felt off at a meet &amp; greet, or a genuine safety worry. We would always rather know than not, so please tell us.</p>
+
+    <div class="footer-nav">
+      <a href="/trust-and-safety/if-something-goes-wrong/">← If something goes wrong</a>
+      <a href="/trust-and-safety/keeping-it-on-truffl/">Keeping it on Truffl →</a>
+    </div>
+  </article>
+
+  <footer>
+    <a href="/" aria-label="Truffl Pets home">
+      <svg width="130" height="40" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="20" cy="33" r="20" fill="#C4866A" opacity="0.6"/>
+        <text x="20" y="38" font-family="'Cormorant Garamond', Georgia, serif" font-size="14" font-style="italic" fill="#F7F3EE" text-anchor="middle">truffl</text>
+        <text x="52" y="30" font-family="'Cormorant Garamond', Georgia, serif" font-size="32" font-style="italic" fill="#A8978E" letter-spacing="-0.5">truffl</text>
+      </svg>
+    </a>
+    <div class="footer-links">
+      <a href="/register/">For carers</a>
+      <a href="/about-us/">About</a>
+      <a href="/trust-and-safety/">Trust &amp; safety</a>
+      <a href="#">Contact</a>
+      <a href="#">Privacy</a>
+    </div>
+    <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
Implements [TRU-15](https://linear.app/truffl-pets/issue/TRU-15/customer-tips-safety-guidance) — a customer-facing Trust & Safety content hub, plus a one-way "Truffl" channel in the message centre that points customers to it.

### Hub (`/trust-and-safety`)
Landing page + six sub-pages with verbatim copy in the marketing voice, service-aware where relevant:
1. Choosing your carer · 2. Getting ready · 3. Following along with GPS · 4. If something goes wrong · 5. Reporting a concern · 6. Keeping it on Truffl

- "Choosing your carer" links out to the in-booking meet & greet flow rather than duplicating it (per the TRU-14 companion note).
- Launch placeholders — priority line `0459 790 999`, `safety@trufflpets.com`, and the cover terms — are marked with `<!-- PLACEHOLDER ... -->` comments and `data-placeholder` hooks so they're easy to find and swap.

### Header / footer
Persistent **Trust & safety** link added to the home nav + footer, and the about-us nav + footer.

### Message-centre nudge — one-way "Truffl" channel
The messaging model is strictly customer↔provider, so rather than invent a fake system user, this adds a dedicated `system_messages` channel (migration `20260616`):
- Recipient-keyed table, **RLS: read + mark-read your own; no client INSERT** — only SECURITY DEFINER triggers write (EXECUTE revoked from anon/authenticated).
- Triggers post a **welcome + safety** note on customer signup (`customer_profiles` insert) and a **safety nudge on the first booking**.
- `/messages` renders these as a **pinned, verified "Truffl" conversation** — incoming bubbles with CTA buttons to the hub, and a **disabled composer** ("one-way channel — you can't reply here").
- Unread notifications feed the message-centre badge on the customer-facing pages.

The `conversations` table, its RLS, and the party-name views are untouched.

### Testing (Preview + DB)
- ✅ Both triggers fire (welcome + first-booking) — verified in a rollback transaction; nothing persisted.
- ✅ `/messages`: Truffl pinned top with verified tick + unread count; thread shows incoming bubbles + "Open Help & Safety" CTAs → `/trust-and-safety/`; composer is disabled; opening marks read (UI dot clears + DB `read_at` set, messages preserved).
- ✅ Hub landing renders 6 cards with correct links; "If something goes wrong" shows numbered emergency steps + priority-line callout; breadcrumbs/cross-links work.
- ✅ Security advisors: no new findings from the table/functions (RLS on, EXECUTE revoked, no new views).

> [!NOTE]
> The "Supabase Preview" check will be red as agreed — migration applied via MCP and committed for version control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)