### PR TITLE
TRU-125: Carer check-ins for daycare/boarding (daily photo + update)

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -136,6 +136,27 @@
   }
   .status-pending { background: var(--warning-bg); color: var(--warning); }
   .status-confirmed { background: var(--success-bg); color: var(--success); }
+  /* Check-in prompts + composer (TRU-125) */
+  .checkin-prompt { margin-top: 8px; font-size: 0.78rem; font-weight: 600; display: inline-flex; align-items: center; padding: 3px 10px; border-radius: 20px; }
+  .checkin-prompt.due { background: var(--warning-bg); color: var(--warning); }
+  .checkin-prompt.ok { background: var(--success-bg); color: var(--success); }
+  .ci-card { background: var(--warm-white); border-radius: 16px; padding: 1.5rem; max-width: 440px; width: 100%; max-height: 92vh; overflow-y: auto; }
+  .ci-card h2 { font-family: 'Cormorant Garamond', serif; font-weight: 500; font-size: 1.4rem; color: var(--brown); }
+  .ci-photo { display: block; border: 1.5px dashed var(--border); border-radius: 12px; padding: 18px; text-align: center; cursor: pointer; background: var(--cream); margin-bottom: 12px; transition: border-color 0.18s; }
+  .ci-photo:hover { border-color: var(--terracotta); }
+  .ci-photo.has-photo { border-style: solid; border-color: var(--sage); padding: 8px; }
+  .ci-photo #ciPhotoInner { display: flex; flex-direction: column; align-items: center; gap: 4px; font-size: 0.84rem; color: var(--text-secondary); }
+  .ci-photo .ci-photo-plus { font-size: 1.6rem; color: var(--terracotta); line-height: 1; }
+  .ci-photo .ci-photo-note { font-size: 0.72rem; color: var(--text-muted); }
+  .ci-photo img { max-width: 100%; max-height: 180px; border-radius: 8px; display: block; margin: 0 auto 6px; }
+  .ci-text { width: 100%; border: 1px solid var(--border); border-radius: 10px; padding: 10px 12px; font: inherit; font-size: 0.88rem; resize: vertical; margin-bottom: 12px; }
+  .ci-text:focus { outline: none; border-color: var(--border-focus); }
+  .ci-chips { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 12px; }
+  .ci-chip { font: inherit; font-size: 0.8rem; padding: 6px 12px; border-radius: 20px; border: 1px solid var(--border); background: #fff; color: var(--text-secondary); cursor: pointer; }
+  .ci-chip.on { background: var(--terracotta); border-color: var(--terracotta); color: #fff; }
+  .ci-concern { display: flex; align-items: center; gap: 8px; font-size: 0.84rem; color: var(--text-secondary); cursor: pointer; }
+  .ci-concern input { accent-color: var(--terracotta); }
+  .ci-error { color: var(--error); font-size: 0.82rem; margin-top: 8px; min-height: 1em; }
 
   /* Empty state */
   .empty { text-align: center; padding: 2.5rem 1rem; color: var(--text-muted); font-size: 0.9rem; }
@@ -299,6 +320,9 @@ const SERVICE_LABELS = {
 let authToken = null, authUid = null;
 let userData = null, providerProfile = null, providerServices = [], bookings = [], series = [];
 let dashCancelId = null;
+// Check-in composer state (TRU-125)
+const CHECKIN_TAGS = ['Very well behaved', 'Lots of energy', 'Calm & relaxed', 'Ate well', 'A little unsettled', 'Loved their walk'];
+let checkinDraft = null; // { bookingId, type, tags:Set, photoUrl, concern }
 
 const DAY_SHORT = { 1: 'Mon', 2: 'Tue', 3: 'Wed', 4: 'Thu', 5: 'Fri', 6: 'Sat', 7: 'Sun' };
 function formatTimeOfDay(t) {
@@ -486,6 +510,13 @@ async function loadBookings() {
       : 'Pet';
     b._service_type = svcMap[b.service_id];
   });
+
+  // Check-in status (arrival/daily counts + nights) for non-walk stays.
+  try {
+    const st = await sbGet('booking_checkin_status', `booking_id=in.(${ids.join(',')})&select=*`);
+    const byId = Object.fromEntries(st.map(s => [s.booking_id, s]));
+    bookings.forEach(b => { b._checkin = byId[b.id] || null; });
+  } catch(e) { /* non-fatal */ }
 }
 
 async function loadSeries() {
@@ -670,12 +701,9 @@ function renderBookingsTab() {
           <div class="bc-time">${bookingTimeLine(b)}</div>
           ${b.customer_notes ? `<div class="bc-notes">"${esc(b.customer_notes)}"</div>` : ''}
           ${bookingDetailsHtml(b)}
+          ${stayPromptHtml(b)}
         </div>
-        <div class="bc-actions">${dashCancelId === b.id ? dashCancelConfirm(b) : `
-          <button class="bc-btn start-walk" onclick="window.location.href='/walk/?booking=${b.id}'">Start walk</button>
-          <button class="bc-btn message" onclick="window.location.href='/messages/?booking=${b.id}'">Message <span class="bc-msg-badge" id="cardbadge-${b.id}" style="display:none;">0</span></button>
-          <button class="bc-btn decline" onclick="dashShowCancel('${b.id}')">Cancel</button>
-        `}</div>
+        <div class="bc-actions">${dashCancelId === b.id ? dashCancelConfirm(b) : confirmedActions(b)}</div>
       </div>
     `).join('');
   }
@@ -685,6 +713,129 @@ function renderBookingsTab() {
   }
 
   area.innerHTML = html;
+}
+
+/* ── Carer check-ins for non-walk stays (TRU-125) ── */
+function bookingIsStay(b) {
+  return b._checkin ? b._checkin.requires_checkins
+    : (b._service_type && b._service_type !== 'dog_walking' && !b.is_meet_and_greet);
+}
+function stayPromptHtml(b) {
+  const ck = b._checkin;
+  if (!ck || !ck.requires_checkins) return '';
+  let txt, cls;
+  if (ck.arrival_count < 1) { txt = 'Arrival check-in needed'; cls = 'due'; }
+  else if (ck.daily_count < ck.nights) { txt = `Evening update due · ${ck.daily_count}/${ck.nights} done`; cls = 'due'; }
+  else { txt = 'All check-ins done'; cls = 'ok'; }
+  return `<div class="checkin-prompt ${cls}">${cls === 'ok' ? '✓ ' : ''}${txt}</div>`;
+}
+function confirmedActions(b) {
+  const msg = `<button class="bc-btn message" onclick="window.location.href='/messages/?booking=${b.id}'">Message <span class="bc-msg-badge" id="cardbadge-${b.id}" style="display:none;">0</span></button>`;
+  const cancel = `<button class="bc-btn decline" onclick="dashShowCancel('${b.id}')">Cancel</button>`;
+  if (!bookingIsStay(b)) {
+    return `<button class="bc-btn start-walk" onclick="window.location.href='/walk/?booking=${b.id}'">Start walk</button>${msg}${cancel}`;
+  }
+  const ck = b._checkin;
+  const done = ck && ck.arrival_count >= 1 && ck.daily_count >= ck.nights;
+  return `<button class="bc-btn start-walk" onclick="openCheckin('${b.id}')">Post check-in</button>
+    <button class="bc-btn accept" onclick="markStayComplete('${b.id}')"${done ? '' : ' style="opacity:.6;"'}>Mark complete</button>${msg}${cancel}`;
+}
+
+function closeCheckin() { const o = document.getElementById('checkinModal'); if (o) o.remove(); checkinDraft = null; }
+function openCheckin(bookingId) {
+  const b = bookings.find(x => x.id === bookingId);
+  if (!b) return;
+  const ck = b._checkin;
+  const type = (ck && ck.arrival_count < 1) ? 'arrival' : 'daily';
+  checkinDraft = { bookingId, type, tags: new Set(), photoUrl: null, concern: false };
+  const heading = type === 'arrival' ? 'Arrival check-in' : 'Daily update';
+  const sub = type === 'arrival'
+    ? `Let ${esc((b._customer_name || 'the owner').split(' ')[0])} know ${esc(b._pet_label || 'their dog')} has arrived and is settling in.`
+    : `A quick update on how ${esc(b._pet_label || 'their dog')} is getting on.`;
+  const chips = CHECKIN_TAGS.map(t => `<button type="button" class="ci-chip" onclick="toggleCheckinTag('${encodeURIComponent(t)}',this)">${esc(t)}</button>`).join('');
+  const o = document.createElement('div');
+  o.id = 'checkinModal';
+  o.style.cssText = 'position:fixed;inset:0;background:rgba(40,30,25,.55);display:flex;align-items:center;justify-content:center;padding:1rem;z-index:1000;';
+  o.innerHTML = `
+    <div class="ci-card">
+      <h2 style="margin:0 0 2px;">${heading}</h2>
+      <p style="font-size:0.85rem;color:var(--text-muted);margin:0 0 14px;">${sub}</p>
+      <label class="ci-photo" id="ciPhotoLabel">
+        <input type="file" accept="image/*" capture="environment" id="ciPhoto" onchange="onCheckinPhoto(this)" style="display:none;">
+        <div id="ciPhotoInner"><span class="ci-photo-plus">＋</span><span>Take a photo (required)</span><span class="ci-photo-note">Snap one now — it can't be uploaded from your gallery</span></div>
+      </label>
+      <textarea id="ciMessage" rows="3" placeholder="How are they doing? Eating, toileting, mood…" class="ci-text"></textarea>
+      <div class="ci-chips">${chips}</div>
+      <label class="ci-concern"><input type="checkbox" id="ciConcern" onchange="checkinDraft.concern=this.checked"> Flag something for the owner to look at</label>
+      <div id="ciMsg" class="ci-error"></div>
+      <div style="display:flex;gap:10px;justify-content:flex-end;margin-top:14px;flex-wrap:wrap;">
+        <button class="bc-btn decline" onclick="closeCheckin()">Cancel</button>
+        <button class="bc-btn accept" id="ciSubmit" onclick="submitCheckin()">Send to owner</button>
+      </div>
+    </div>`;
+  document.body.appendChild(o);
+}
+function toggleCheckinTag(enc, el) {
+  const t = decodeURIComponent(enc);
+  if (checkinDraft.tags.has(t)) { checkinDraft.tags.delete(t); el.classList.remove('on'); }
+  else { checkinDraft.tags.add(t); el.classList.add('on'); }
+}
+async function onCheckinPhoto(input) {
+  const file = input.files && input.files[0];
+  if (!file) return;
+  const label = document.getElementById('ciPhotoLabel');
+  const inner = document.getElementById('ciPhotoInner');
+  inner.innerHTML = '<span class="ci-photo-note">Uploading…</span>';
+  try {
+    const ext = (file.name.split('.').pop() || 'jpg').toLowerCase();
+    const fileName = `${checkinDraft.bookingId}/${Date.now()}.${ext}`;
+    const r = await fetch(`${SUPABASE_URL}/storage/v1/object/walk-photos/${fileName}`, {
+      method: 'POST',
+      headers: { 'apikey': SUPABASE_ANON_KEY, 'Authorization': `Bearer ${authToken}`, 'Content-Type': file.type || 'image/jpeg' },
+      body: file
+    });
+    if (!r.ok) throw new Error('Upload failed');
+    checkinDraft.photoUrl = `${SUPABASE_URL}/storage/v1/object/public/walk-photos/${fileName}`;
+    label.classList.add('has-photo');
+    inner.innerHTML = `<img src="${checkinDraft.photoUrl}" alt="check-in photo"><span class="ci-photo-note">Photo added · tap to change</span>`;
+  } catch(e) {
+    inner.innerHTML = '<span class="ci-photo-note" style="color:var(--error);">Upload failed — tap to retry</span>';
+  }
+}
+async function submitCheckin() {
+  const d = checkinDraft;
+  const msgEl = document.getElementById('ciMsg');
+  if (!d.photoUrl) { msgEl.textContent = 'A photo is required — please take one.'; return; }
+  const btn = document.getElementById('ciSubmit');
+  btn.disabled = true; btn.textContent = 'Sending…';
+  try {
+    await sbInsert('booking_updates', {
+      booking_id: d.bookingId, provider_user_id: authUid, update_type: d.type,
+      message: (document.getElementById('ciMessage').value || '').trim() || null,
+      tags: [...d.tags], photo_url: d.photoUrl, has_concern: d.concern
+    });
+    closeCheckin();
+    await loadBookings();
+    renderBookingsTab();
+    showMsg('Check-in sent to the owner.', 'success');
+  } catch(e) {
+    msgEl.textContent = e.message;
+    btn.disabled = false; btn.textContent = 'Send to owner';
+  }
+}
+async function markStayComplete(bookingId) {
+  try {
+    await sbPatch('bookings', 'id', bookingId, { status: 'completed', completed_at: new Date().toISOString() });
+    await loadBookings();
+    renderBookingsTab();
+    showMsg('Booking marked complete.', 'success');
+  } catch(e) {
+    const b = bookings.find(x => x.id === bookingId), ck = b && b._checkin;
+    if (/check-?ins? required/i.test(e.message) || /check_violation/i.test(e.message)) {
+      const need = ck ? `Post the arrival check-in and ${ck.nights} evening update${ck.nights > 1 ? 's' : ''} first.` : 'Post the required check-ins first.';
+      showMsg('Can\'t complete yet — ' + need, 'error');
+    } else { showMsg(e.message, 'error'); }
+  }
 }
 
 function renderDashboard() {

--- a/supabase/migrations/20260617_tru125_booking_updates.sql
+++ b/supabase/migrations/20260617_tru125_booking_updates.sql
@@ -1,0 +1,152 @@
+-- TRU-125: carer check-ins for non-walk stays (boarding/sitting).
+-- A photo + short update so owners have peace of mind when there's no live GPS.
+--
+-- Repurposes the pre-existing empty `booking_updates` stub (keeping its
+-- message/photo_url/sent_at columns so the legacy active_walk_view stays valid)
+-- and adds the check-in columns. Applied to the live DB via apply_migration;
+-- committed here for version control.
+
+ALTER TABLE public.booking_updates
+  ADD COLUMN IF NOT EXISTS provider_user_id uuid,
+  ADD COLUMN IF NOT EXISTS update_type      text,
+  ADD COLUMN IF NOT EXISTS tags             text[] NOT NULL DEFAULT '{}',
+  ADD COLUMN IF NOT EXISTS has_concern      boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS created_at       timestamptz NOT NULL DEFAULT now();
+
+ALTER TABLE public.booking_updates ALTER COLUMN sent_at SET DEFAULT now();
+ALTER TABLE public.booking_updates
+  ALTER COLUMN provider_user_id SET NOT NULL,
+  ALTER COLUMN update_type SET NOT NULL,
+  ALTER COLUMN photo_url SET NOT NULL;
+
+ALTER TABLE public.booking_updates DROP CONSTRAINT IF EXISTS booking_updates_update_type_check;
+ALTER TABLE public.booking_updates ADD CONSTRAINT booking_updates_update_type_check CHECK (update_type IN ('arrival','daily','completion'));
+ALTER TABLE public.booking_updates DROP CONSTRAINT IF EXISTS booking_updates_booking_id_fkey;
+ALTER TABLE public.booking_updates ADD CONSTRAINT booking_updates_booking_id_fkey FOREIGN KEY (booking_id) REFERENCES public.bookings(id) ON DELETE CASCADE;
+
+CREATE INDEX IF NOT EXISTS idx_booking_updates_booking ON public.booking_updates(booking_id, created_at);
+
+ALTER TABLE public.booking_updates ENABLE ROW LEVEL SECURITY;
+
+-- The carer who owns the booking posts their own check-ins.
+DROP POLICY IF EXISTS carer_insert_booking_update ON public.booking_updates;
+CREATE POLICY carer_insert_booking_update ON public.booking_updates
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    provider_user_id = auth.uid()
+    AND EXISTS (SELECT 1 FROM public.bookings b JOIN public.provider_profiles pp ON pp.id = b.provider_id
+                WHERE b.id = booking_updates.booking_id AND pp.user_id = auth.uid())
+  );
+
+-- Both parties to the booking can read the check-ins.
+DROP POLICY IF EXISTS parties_read_booking_update ON public.booking_updates;
+CREATE POLICY parties_read_booking_update ON public.booking_updates
+  FOR SELECT TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM public.bookings b
+            LEFT JOIN public.provider_profiles pp ON pp.id = b.provider_id
+            LEFT JOIN public.customer_profiles cp ON cp.id = b.customer_id
+            WHERE b.id = booking_updates.booking_id AND (pp.user_id = auth.uid() OR cp.user_id = auth.uid()))
+  );
+
+-- Which bookings need check-ins, and how many nights. Non-walk, non-M&G services
+-- require an arrival check-in plus one "evening" daily per night.
+CREATE OR REPLACE FUNCTION public.booking_checkin_spec(p_booking_id uuid)
+ RETURNS TABLE(requires boolean, nights int)
+ LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+  SELECT
+    (svc.service_type IS DISTINCT FROM 'dog_walking' AND NOT COALESCE(b.is_meet_and_greet, false)) AS requires,
+    GREATEST(1, (COALESCE(b.ends_at, b.scheduled_at)::date - b.scheduled_at::date))::int AS nights
+  FROM public.bookings b JOIN public.provider_services svc ON svc.id = b.service_id
+  WHERE b.id = p_booking_id;
+$function$;
+REVOKE ALL ON FUNCTION public.booking_checkin_spec(uuid) FROM PUBLIC, anon, authenticated;
+
+-- Completion gate: a non-walk stay can't be marked completed until the required
+-- check-ins exist. Server-side so a client can't bypass it. Walks and meet &
+-- greets are exempt (they complete through their own flows).
+CREATE OR REPLACE FUNCTION public.trg_stay_completion_gate()
+ RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+DECLARE v_requires boolean; v_nights int; v_arr int; v_daily int;
+BEGIN
+  IF NEW.status = 'completed' AND OLD.status IS DISTINCT FROM 'completed' THEN
+    SELECT requires, nights INTO v_requires, v_nights FROM public.booking_checkin_spec(NEW.id);
+    IF v_requires THEN
+      SELECT count(*) FILTER (WHERE update_type = 'arrival'),
+             count(*) FILTER (WHERE update_type = 'daily')
+        INTO v_arr, v_daily FROM public.booking_updates WHERE booking_id = NEW.id;
+      IF v_arr < 1 OR v_daily < v_nights THEN
+        RAISE EXCEPTION 'Check-ins required before completing (have % arrival, % of % daily)', v_arr, v_daily, v_nights
+          USING ERRCODE = 'check_violation';
+      END IF;
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$function$;
+REVOKE ALL ON FUNCTION public.trg_stay_completion_gate() FROM PUBLIC, anon, authenticated;
+
+DROP TRIGGER IF EXISTS stay_completion_gate ON public.bookings;
+CREATE TRIGGER stay_completion_gate
+  BEFORE UPDATE OF status ON public.bookings
+  FOR EACH ROW EXECUTE FUNCTION public.trg_stay_completion_gate();
+
+-- Notify the owner in-app on each check-in (rides the one-way "Truffl" channel
+-- from TRU-15). Concern flag gets a more prominent message. Push/email come later
+-- with the native app + email infra.
+CREATE OR REPLACE FUNCTION public.trg_booking_update_notify()
+ RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+DECLARE v_customer uuid; v_carer text; v_dog text; v_body text;
+BEGIN
+  SELECT cp.user_id, COALESCE(cu.first_name, 'Your carer')
+    INTO v_customer, v_carer
+  FROM public.bookings b
+  JOIN public.customer_profiles cp ON cp.id = b.customer_id
+  JOIN public.provider_profiles pp ON pp.id = b.provider_id
+  JOIN public.users cu ON cu.id = pp.user_id
+  WHERE b.id = NEW.booking_id;
+
+  SELECT COALESCE(string_agg(p.name, ' & '), 'your dog') INTO v_dog
+  FROM public.booking_pets bp JOIN public.pets p ON p.id = bp.pet_id
+  WHERE bp.booking_id = NEW.booking_id;
+
+  IF v_customer IS NULL THEN RETURN NEW; END IF;
+
+  IF NEW.has_concern THEN
+    v_body := '⚠️ ' || v_carer || ' flagged something on ' || COALESCE(v_dog,'your dog') || '''s stay that may need a look. Tap to see the details.';
+  ELSE
+    v_body := '📸 ' || v_carer || ' shared a new check-in on ' || COALESCE(v_dog,'your dog') || '''s stay — tap to see how they''re getting on.';
+  END IF;
+
+  PERFORM public.post_system_message(v_customer, v_body, '/track/?booking=' || NEW.booking_id, 'See the update');
+  RETURN NEW;
+END;
+$function$;
+REVOKE ALL ON FUNCTION public.trg_booking_update_notify() FROM PUBLIC, anon, authenticated;
+
+DROP TRIGGER IF EXISTS booking_update_notify ON public.booking_updates;
+CREATE TRIGGER booking_update_notify
+  AFTER INSERT ON public.booking_updates
+  FOR EACH ROW EXECUTE FUNCTION public.trg_booking_update_notify();
+
+-- Per-booking check-in status for the dashboard + owner view. A definer view
+-- (bypasses RLS) scoped by auth.uid() in the WHERE, matching the existing
+-- *_party_names views — security_invoker would return nothing because neither
+-- party can read the counterparty's profile row that the view joins. This trips
+-- the security_definer_view advisor lint, which is accepted/intentional here.
+CREATE VIEW public.booking_checkin_status AS
+  SELECT b.id AS booking_id,
+    GREATEST(1, (COALESCE(b.ends_at, b.scheduled_at)::date - b.scheduled_at::date))::int AS nights,
+    (svc.service_type IS DISTINCT FROM 'dog_walking' AND NOT COALESCE(b.is_meet_and_greet, false)) AS requires_checkins,
+    (SELECT count(*) FROM public.booking_updates u WHERE u.booking_id = b.id AND u.update_type = 'arrival') AS arrival_count,
+    (SELECT count(*) FROM public.booking_updates u WHERE u.booking_id = b.id AND u.update_type = 'daily') AS daily_count,
+    (SELECT count(*) FROM public.booking_updates u WHERE u.booking_id = b.id) AS total_count,
+    (SELECT max(created_at) FROM public.booking_updates u WHERE u.booking_id = b.id AND u.update_type = 'daily') AS last_daily_at
+  FROM public.bookings b
+  JOIN public.provider_services svc ON svc.id = b.service_id
+  JOIN public.provider_profiles pp ON pp.id = b.provider_id
+  JOIN public.customer_profiles cp ON cp.id = b.customer_id
+  WHERE pp.user_id = auth.uid() OR cp.user_id = auth.uid();

--- a/track/index.html
+++ b/track/index.html
@@ -58,6 +58,17 @@
   .section-title{font-family:'Cormorant Garamond',serif;font-weight:500;font-size:1.1rem;color:var(--brown);margin-bottom:0.75rem;}
 
   .update-feed{display:flex;flex-direction:column;gap:8px;margin-top:1rem;}
+  /* Owner check-in feed (TRU-125) */
+  .ci-feed-item{background:var(--warm-white);border:1px solid var(--border);border-radius:14px;padding:14px;}
+  .ci-feed-item.concern{border-color:var(--warning);background:var(--warning-bg);}
+  .ci-concern-flag{display:flex;align-items:center;gap:6px;font-size:0.78rem;font-weight:600;color:var(--warning);margin-bottom:8px;}
+  .ci-feed-head{display:flex;justify-content:space-between;align-items:baseline;gap:8px;margin-bottom:8px;}
+  .ci-feed-type{font-size:0.82rem;font-weight:600;color:var(--brown);}
+  .ci-feed-time{font-size:0.72rem;color:var(--text-muted);}
+  .ci-feed-photo{width:100%;border-radius:10px;display:block;margin-bottom:8px;max-height:360px;object-fit:cover;}
+  .ci-feed-msg{font-size:0.88rem;color:var(--text-primary);line-height:1.5;}
+  .ci-feed-tags{display:flex;flex-wrap:wrap;gap:6px;margin-top:8px;}
+  .ci-tag{font-size:0.74rem;padding:3px 10px;border-radius:20px;background:var(--cream);border:1px solid var(--border);color:var(--text-secondary);}
   .update-item{display:flex;gap:10px;padding:10px 12px;background:var(--warm-white);border:1px solid var(--border);border-radius:10px;font-size:0.82rem;}
   .update-icon{width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;flex-shrink:0;font-size:0.75rem;}
   .update-icon svg{width:15px;height:15px;}
@@ -435,12 +446,77 @@ function renderSummary(allUpdates) {
   }
 }
 
+function esc(s){ return (s||'').toString().replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
+
+/* ── Owner view of carer check-ins for non-walk stays (TRU-125) ── */
+function checkinFeedItemHtml(u){
+  const label = u.update_type === 'arrival' ? 'Arrival · settling in' : 'Daily update';
+  const time = new Date(u.created_at).toLocaleString('en-AU', { weekday: 'short', day: 'numeric', month: 'short', hour: 'numeric', minute: '2-digit', hour12: true });
+  const tags = (u.tags || []).map(t => `<span class="ci-tag">${esc(t)}</span>`).join('');
+  return `<div class="ci-feed-item${u.has_concern ? ' concern' : ''}">
+    ${u.has_concern ? '<div class="ci-concern-flag"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg> Flagged for your attention</div>' : ''}
+    <div class="ci-feed-head"><span class="ci-feed-type">${label}</span><span class="ci-feed-time">${time}</span></div>
+    ${u.photo_url ? `<img class="ci-feed-photo" src="${esc(u.photo_url)}" alt="Check-in photo" loading="lazy" onerror="this.style.display='none'">` : ''}
+    ${u.message ? `<div class="ci-feed-msg">${esc(u.message)}</div>` : ''}
+    ${tags ? `<div class="ci-feed-tags">${tags}</div>` : ''}
+  </div>`;
+}
+async function renderStayUpdates(){
+  const area = document.getElementById('trackContent');
+  const complete = booking.status === 'completed';
+  let updates = [];
+  try { updates = await sbGet('booking_updates', `booking_id=eq.${bookingId}&order=created_at.asc&select=*`); } catch(e){}
+
+  let dateStr = booking.scheduled_at ? formatScheduledAt(booking.scheduled_at) : 'Dates TBC';
+  if (booking.ends_at) {
+    const ci = new Date(booking.scheduled_at).toLocaleDateString('en-AU', { weekday: 'short', day: 'numeric', month: 'short' });
+    const co = new Date(booking.ends_at).toLocaleDateString('en-AU', { weekday: 'short', day: 'numeric', month: 'short' });
+    dateStr = `${ci} → ${co}`;
+  }
+  const carer = (providerName || 'Your carer').split(' ')[0];
+  const empty = `<div class="empty-state" style="text-align:center;padding:1.25rem;color:var(--text-muted);font-size:0.84rem;">No check-ins yet — ${esc(carer)} will share a photo and update once ${esc(petName || 'your dog')} arrives.</div>`;
+
+  area.innerHTML = `
+    <div class="status-bar ${complete ? 'done' : 'active'}">${complete ? '✓ Stay complete' : 'Stay in progress'}</div>
+    <div class="booking-card">
+      <div style="font-size:0.78rem;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.08em;margin-bottom:10px;">Your booking</div>
+      <div style="font-size:0.95rem;font-weight:500;color:var(--text-primary);margin-bottom:2px;">${esc(petName || 'Your pet')}${petBreed ? ' · ' + esc(petBreed) : ''}</div>
+      <div style="font-size:0.85rem;color:var(--text-secondary);margin-bottom:6px;">Carer: ${esc(providerName || 'Your carer')}</div>
+      <div style="font-size:0.82rem;color:var(--text-muted);">${esc(dateStr)}</div>
+      <a href="/messages/?booking=${bookingId}" style="display:inline-flex;align-items:center;gap:7px;margin-top:14px;padding:9px 16px;border:1px solid var(--border);border-radius:10px;color:var(--text-secondary);text-decoration:none;font-size:0.85rem;font-weight:500;">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/></svg>
+        Message ${esc(carer)}
+      </a>
+    </div>
+    <div class="section-title">Check-ins from ${esc(carer)}</div>
+    <div class="update-feed" id="stayFeed">${updates.length ? updates.map(checkinFeedItemHtml).join('') : empty}</div>
+    ${complete ? `<div style="margin-top:1.25rem;text-align:center;"><a href="/review/?booking=${booking.id}" style="display:inline-block;padding:12px 32px;background:var(--terracotta);color:white;border-radius:10px;font-weight:500;text-decoration:none;font-size:0.9rem;">Leave a review</a></div>` : ''}
+  `;
+  if (!complete) pollInterval = setInterval(pollStayUpdates, 20000);
+}
+async function pollStayUpdates(){
+  try {
+    const updates = await sbGet('booking_updates', `booking_id=eq.${bookingId}&order=created_at.asc&select=*`);
+    const feed = document.getElementById('stayFeed');
+    if (feed && updates.length) feed.innerHTML = updates.map(checkinFeedItemHtml).join('');
+    const fresh = await sbGet('bookings', `id=eq.${bookingId}&select=status`);
+    if (fresh.length && fresh[0].status === 'completed' && booking.status !== 'completed') {
+      booking.status = 'completed';
+      if (pollInterval) { clearInterval(pollInterval); pollInterval = null; }
+      renderStayUpdates();
+    }
+  } catch(e){ /* transient */ }
+}
+
 async function refreshMsgBadge() {
   if (!authToken || !authUid) return;
   try {
     const rows = await sbGet('messages', `sender_id=neq.${authUid}&read_at=is.null&select=id`);
+    let sysUnread = 0;
+    try { const sm = await sbGet('system_messages', `recipient_user_id=eq.${authUid}&read_at=is.null&select=id`); sysUnread = sm.length; } catch(e) {}
+    const total = rows.length + sysUnread;
     const badge = document.getElementById('navMsgBadge');
-    if (badge) { badge.textContent = rows.length > 9 ? '9+' : String(rows.length); badge.style.display = rows.length > 0 ? '' : 'none'; }
+    if (badge) { badge.textContent = total > 9 ? '9+' : String(total); badge.style.display = total > 0 ? '' : 'none'; }
   } catch (e) { /* non-fatal */ }
 }
 
@@ -506,6 +582,15 @@ async function init() {
         petBreed = pets.length === 1 ? (pets[0].breed || '') : '';
       }
     } catch (e) {}
+
+    // Non-walk stays (boarding/sitting) show the carer check-in feed, not the walk tracker.
+    try {
+      const st = await sbGet('booking_checkin_status', `booking_id=eq.${bookingId}&select=requires_checkins`);
+      if (st.length && st[0].requires_checkins) {
+        await renderStayUpdates();
+        return;
+      }
+    } catch(e) { /* fall through to walk view */ }
 
     const sessions = await sbGet('walk_sessions', `booking_id=eq.${bookingId}&select=*&order=created_at.desc&limit=1`);
 


### PR DESCRIPTION
Implements [TRU-125](https://linear.app/truffl-pets/issue/TRU-125/carer-check-ins-for-daycare-and-boarding-daily-photo-update). For non-walk stays (boarding/sitting) there's no live GPS to follow, so carers post a **photo + short update**; the owner sees them on the booking detail and gets an in-app notification.

### Scope decisions (confirmed)
- **Cadence keyed off booking shape**, not the fuzzy service names: non-walk → **arrival check-in + one evening per night**; walks keep their existing GPS/updates flow. (daycare/drop-in aren't bookable service types yet — the framework picks them up when they are.)
- **Notifications: in-app now** (rides the TRU-15 one-way "Truffl" channel); push/email deferred to the native app + email infra.
- **Enforcement: dashboard prompts + block completion** (no real-time nagging — that needs push from the native app).
- **Photo: required, camera-capture** via the `capture` attribute; true camera-only enforcement arrives with the Capacitor app.

### Schema (`supabase/migrations/20260617_tru125_booking_updates.sql`, applied via MCP)
- Repurposes the **empty legacy `booking_updates` stub** (keeps `message/photo_url/sent_at` so the legacy `active_walk_view` stays valid); adds `provider_user_id`, `update_type`, `tags[]`, required `photo_url`, `has_concern`, `created_at`.
- **RLS**: carer of the booking inserts their own; both parties read; no update/delete.
- **`booking_checkin_status`**: a definer view scoped by `auth.uid()` (like the `*_party_names` views) — `security_invoker` returns nothing because neither party can read the counterparty's profile row.
- **Completion gate** (`BEFORE UPDATE` on bookings): a non-walk stay can't be completed until arrival + one daily per night exist. Walks & M&G exempt.
- **Notify trigger**: posts to the owner on each check-in (more prominent copy when a concern is flagged).

### Surfaces
- **dashboard/** (carer): outstanding-check-in prompts + a composer (camera photo, text, tags, concern), photo → `walk-photos` bucket, completion gated by the trigger.
- **track/** (owner): non-walk bookings render the check-in feed (photos, tags, message, concern highlight) and poll for new ones; the notification deep-links here.

### Testing
The browser Preview harness was unavailable, so the functional core was verified against the **live REST API with real user tokens** (the exact calls the frontend makes):
- ✅ Carer posts arrival → blocked from completing (gate) → posts daily → completes.
- ✅ `booking_checkin_status` returns correct nights/counts for the carer (the definer-view fix; caught a real RLS bug here).
- ✅ Owner reads the feed (arrival + daily ⚠); non-party (different customer) reads **0** (RLS isolation).
- ✅ Both notification variants (normal + concern) fire with the correct `/track/?booking=` link.
- ✅ Schema gate/notify also verified earlier in a rollback transaction. All test data cleaned up.

> [!NOTE]
> Browser-driven UI verification still pending (Preview was blocked mid-session by an Xcode-license issue, now resolved). The data/security layer is fully proven; the UI is a straightforward render of it. The "Supabase Preview" check will be red as agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)