### PR TITLE
TRU-126: Carer guidelines hub + acknowledgement gate

### DIFF
--- a/carer-guidelines/emergencies-and-safety/index.html
+++ b/carer-guidelines/emergencies-and-safety/index.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-T2CPSDBJ1L"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-T2CPSDBJ1L');
+</script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Emergencies and safety — Carer guidelines — Truffl Pets</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=DM+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --cream:#FAF7F2; --warm-white:#FFFDF9; --sage:#8B9E7E; --sage-dark:#6B7E5E;
+      --terracotta:#C4755B; --terracotta-light:#D4917B; --blush:#E8C4B8; --brown:#3D2B1F;
+      --text-primary:#3D2B1F; --text-secondary:#6B5B4E; --text-muted:#9B8B7E; --border:#E8E0D6;
+      --success:#5B8C5A; --warning:#C0862B; --warning-bg:#FEF3E2;
+    }
+    *{margin:0;padding:0;box-sizing:border-box;}
+    body{font-family:'DM Sans',sans-serif;background:var(--cream);color:var(--text-primary);min-height:100vh;-webkit-font-smoothing:antialiased;line-height:1.65;}
+    a{text-decoration:none;color:inherit;}
+    .nav{position:sticky;top:0;z-index:100;background:var(--warm-white);border-bottom:1px solid var(--border);padding:0 2rem;height:64px;display:flex;align-items:center;justify-content:space-between;}
+    .nav-right{display:flex;align-items:center;gap:18px;font-size:0.85rem;color:var(--text-secondary);}
+    .nav-right a:hover{color:var(--terracotta);}
+    .article{max-width:680px;margin:0 auto;padding:2rem 1.5rem 3rem;}
+    .crumb{font-size:0.82rem;color:var(--text-muted);margin-bottom:1.4rem;display:inline-flex;align-items:center;gap:6px;}
+    .crumb:hover{color:var(--terracotta);}
+    .article h1{font-family:'Cormorant Garamond',serif;font-weight:500;font-size:2.1rem;color:var(--brown);margin-bottom:0.4rem;}
+    .ack-badge{display:inline-block;font-size:0.66rem;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:var(--warning);background:var(--warning-bg);padding:3px 10px;border-radius:20px;margin-bottom:1.2rem;}
+    .lead{font-size:1rem;color:var(--text-secondary);margin-bottom:1.4rem;}
+    .article h2{font-size:1rem;font-weight:600;color:var(--brown);margin:1.5rem 0 0.4rem;}
+    .article p{margin-bottom:0.9rem;}
+    .article strong{color:var(--brown);}
+    ol.steps{list-style:none;counter-reset:s;margin:0 0 1rem;padding:0;}
+    ol.steps li{position:relative;padding-left:38px;margin-bottom:0.7rem;}
+    ol.steps li::before{counter-increment:s;content:counter(s);position:absolute;left:0;top:0;width:24px;height:24px;border-radius:50%;background:var(--terracotta);color:#fff;font-size:0.8rem;font-weight:600;display:flex;align-items:center;justify-content:center;}
+    .urgent{background:#FBEEE8;border:1px solid rgba(196,117,91,0.4);border-radius:12px;padding:16px 18px;margin:1.4rem 0;text-align:center;}
+    .urgent-label{font-size:0.72rem;letter-spacing:0.08em;text-transform:uppercase;color:var(--terracotta);font-weight:600;margin-bottom:4px;}
+    .urgent-num{font-family:'Cormorant Garamond',serif;font-size:1.7rem;color:var(--brown);font-weight:500;}
+    .urgent-num a{color:var(--brown);}
+    .ack-box{margin-top:2rem;background:var(--warm-white);border:1px solid var(--border);border-radius:14px;padding:1.4rem;}
+    .ack-box p{font-size:0.88rem;color:var(--text-secondary);margin-bottom:1rem;}
+    .ack-btn{background:var(--terracotta);color:#fff;border:0;border-radius:10px;padding:12px 24px;font:inherit;font-size:0.9rem;font-weight:500;cursor:pointer;}
+    .ack-btn:hover{background:var(--terracotta-light);}
+    .ack-btn:disabled{opacity:0.6;cursor:default;}
+    .ack-done{display:flex;align-items:center;gap:8px;color:var(--success);font-weight:500;font-size:0.92rem;}
+    .footer-nav{display:flex;justify-content:space-between;gap:12px;margin-top:2rem;padding-top:1.2rem;border-top:1px solid var(--border);font-size:0.88rem;}
+    .footer-nav a{color:var(--terracotta);font-weight:500;}
+    @media(max-width:720px){.nav{padding:0 1rem;}}
+  </style>
+</head>
+<body>
+  <nav class="nav">
+    <a href="/dashboard/" aria-label="Truffl Pets dashboard">
+      <svg width="140" height="44" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="20" cy="33" r="20" fill="#C4755B"/>
+        <text x="20" y="38" font-family="'Cormorant Garamond', Georgia, serif" font-size="14" font-style="italic" fill="#FFFDF9" text-anchor="middle">truffl</text>
+        <text x="52" y="30" font-family="'Cormorant Garamond', Georgia, serif" font-size="32" font-style="italic" fill="#3D2B1F" letter-spacing="-0.5">truffl</text>
+      </svg>
+    </a>
+    <div class="nav-right"><a href="/carer-guidelines/">All guidelines</a><a href="/dashboard/">Dashboard</a></div>
+  </nav>
+
+  <article class="article">
+    <a class="crumb" href="/carer-guidelines/"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg> Carer guidelines</a>
+    <h1>Emergencies and safety</h1>
+    <div class="ack-badge">Acknowledge on join</div>
+    <p class="lead">Most bookings go perfectly. But if something goes wrong, you need to know exactly what to do without hesitating. Read this carefully.</p>
+
+    <h2>If a dog is unwell or hurt</h2>
+    <ol class="steps">
+      <li>Call the owner or their emergency contact first.</li>
+      <li>If you can't reach anyone, call the dog's vet to decide if urgent care is needed.</li>
+      <li>Then let us know on the priority line.</li>
+    </ol>
+    <p>If it's clearly serious, like a collapse or a road accident, get the dog straight to the nearest vet and call on the way. Care first, calls second.</p>
+    <!-- PLACEHOLDER (cover): inherited from TRU-15 — confirm the cover's name/terms before launch. -->
+    <p>Vet details are in the meet &amp; greet notes. Urgent vet fees are the owner's responsibility.</p>
+
+    <h2>If a dog is aggressive or you are bitten</h2>
+    <p>Get yourself safe first — your safety comes before anything else. Once you're safe, contact us immediately and we'll guide you through it.</p>
+
+    <!-- PLACEHOLDER (priority line): founder mobile; swap for the permanent 24/7 support number before launch. -->
+    <div class="urgent" data-placeholder="priority-line">
+      <div class="urgent-label">Priority line · open 24 hours, every day</div>
+      <div class="urgent-num"><a href="tel:+61459790999">0459 790 999</a></div>
+    </div>
+
+    <div class="ack-box" id="ackBox" style="display:none;">
+      <p>By acknowledging, you confirm you've read this and know what to do in an emergency.</p>
+      <button class="ack-btn" id="ackBtn" onclick="acknowledge()">I've read this and I understand</button>
+      <div class="ack-done" id="ackDone" style="display:none;"></div>
+    </div>
+
+    <div class="footer-nav">
+      <a href="/carer-guidelines/keeping-owners-in-the-loop/">← Keeping owners in the loop</a>
+      <a href="/carer-guidelines/reporting-a-concern/">Reporting a concern →</a>
+    </div>
+  </article>
+
+  <script>
+    const SUPABASE_URL='https://gadflsntbnbnnxbpiral.supabase.co';
+    const SUPABASE_ANON_KEY='eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdhZGZsc250Ym5ibm54YnBpcmFsIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzUwNjcwNTcsImV4cCI6MjA5MDY0MzA1N30.g5ZrqeAX9U5l7oDZEbQFrU5j10828dUF0QuJ0ZlHXK8';
+    const ACK_COLUMN='acknowledged_safety_at';
+    let session=null;
+    function fmt(iso){ try { return new Date(iso).toLocaleDateString('en-AU',{day:'numeric',month:'long',year:'numeric'}); } catch(e){ return ''; } }
+    function showDone(iso){ document.getElementById('ackBtn').style.display='none'; const d=document.getElementById('ackDone'); d.style.display='flex'; d.innerHTML='<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg> Acknowledged on '+fmt(iso); }
+    async function acknowledge(){
+      const btn=document.getElementById('ackBtn'); btn.disabled=true; btn.textContent='Saving…';
+      const now=new Date().toISOString();
+      try {
+        const r=await fetch(`${SUPABASE_URL}/rest/v1/provider_profiles?user_id=eq.${session.user_id}`,{method:'PATCH',headers:{'Content-Type':'application/json','apikey':SUPABASE_ANON_KEY,'Authorization':`Bearer ${session.access_token}`,'Prefer':'return=minimal'},body:JSON.stringify({[ACK_COLUMN]:now})});
+        if(!r.ok) throw new Error('save failed');
+        showDone(now);
+      } catch(e){ btn.disabled=false; btn.textContent='I\'ve read this and I understand'; }
+    }
+    (async function(){
+      try { const s=localStorage.getItem('truffl_session'); if(s) session=JSON.parse(s); } catch(e){}
+      if(!session || session.role!=='provider') return;
+      document.getElementById('ackBox').style.display='block';
+      try {
+        const r=await fetch(`${SUPABASE_URL}/rest/v1/provider_profiles?user_id=eq.${session.user_id}&select=${ACK_COLUMN}`,{headers:{'apikey':SUPABASE_ANON_KEY,'Authorization':`Bearer ${session.access_token}`}});
+        const rows=await r.json();
+        if(rows[0] && rows[0][ACK_COLUMN]) showDone(rows[0][ACK_COLUMN]);
+      } catch(e){}
+    })();
+  </script>
+</body>
+</html>

--- a/carer-guidelines/index.html
+++ b/carer-guidelines/index.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-T2CPSDBJ1L"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-T2CPSDBJ1L');
+</script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Carer guidelines — Truffl Pets</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=DM+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --cream:#FAF7F2; --warm-white:#FFFDF9; --sage:#8B9E7E; --sage-light:#C2D1B5;
+      --sage-dark:#6B7E5E; --terracotta:#C4755B; --terracotta-light:#D4917B;
+      --blush:#E8C4B8; --brown:#3D2B1F; --brown-muted:#8B7355;
+      --text-primary:#3D2B1F; --text-secondary:#6B5B4E; --text-muted:#9B8B7E;
+      --border:#E8E0D6; --success:#5B8C5A; --success-bg:#EDF5ED; --warning:#C0862B; --warning-bg:#FEF3E2;
+    }
+    *{margin:0;padding:0;box-sizing:border-box;}
+    body{font-family:'DM Sans',sans-serif;background:var(--cream);color:var(--text-primary);min-height:100vh;-webkit-font-smoothing:antialiased;line-height:1.6;}
+    a{text-decoration:none;color:inherit;}
+    .nav{position:sticky;top:0;z-index:100;background:var(--warm-white);border-bottom:1px solid var(--border);padding:0 2rem;height:64px;display:flex;align-items:center;justify-content:space-between;}
+    .nav-right{display:flex;align-items:center;gap:18px;font-size:0.85rem;color:var(--text-secondary);}
+    .nav-right a:hover{color:var(--terracotta);}
+    .wrap{max-width:920px;margin:0 auto;padding:2.5rem 1.5rem 4rem;}
+    .hub-head{margin-bottom:2rem;}
+    .hub-head h1{font-family:'Cormorant Garamond',serif;font-weight:500;font-size:2.2rem;color:var(--brown);margin-bottom:0.6rem;}
+    .hub-head p{font-size:0.95rem;color:var(--text-secondary);max-width:620px;}
+    .cards{display:grid;grid-template-columns:repeat(2,1fr);gap:16px;}
+    .card{background:var(--warm-white);border:1px solid var(--border);border-radius:14px;padding:1.4rem;transition:transform 0.18s,box-shadow 0.18s,border-color 0.18s;display:flex;flex-direction:column;}
+    .card:hover{transform:translateY(-2px);box-shadow:0 10px 24px rgba(61,43,31,0.07);border-color:rgba(196,117,91,0.4);}
+    .card-top{display:flex;align-items:center;gap:10px;margin-bottom:8px;}
+    .card-ic{width:38px;height:38px;border-radius:10px;background:var(--blush);color:var(--brown);display:flex;align-items:center;justify-content:center;flex-shrink:0;}
+    .card-ic svg{width:20px;height:20px;}
+    .card h2{font-family:'Cormorant Garamond',serif;font-weight:500;font-size:1.25rem;color:var(--brown);}
+    .ack-badge{display:inline-block;font-size:0.64rem;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:var(--warning);background:var(--warning-bg);padding:2px 8px;border-radius:20px;margin-top:3px;}
+    .card p{font-size:0.86rem;color:var(--text-secondary);}
+    .card .arrow{margin-top:12px;font-size:0.82rem;color:var(--terracotta);font-weight:500;}
+    @media(max-width:720px){.cards{grid-template-columns:1fr;}.nav{padding:0 1rem;}}
+  </style>
+</head>
+<body>
+  <nav class="nav">
+    <a href="/dashboard/" aria-label="Truffl Pets dashboard">
+      <svg width="140" height="44" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="20" cy="33" r="20" fill="#C4755B"/>
+        <text x="20" y="38" font-family="'Cormorant Garamond', Georgia, serif" font-size="14" font-style="italic" fill="#FFFDF9" text-anchor="middle">truffl</text>
+        <text x="52" y="30" font-family="'Cormorant Garamond', Georgia, serif" font-size="32" font-style="italic" fill="#3D2B1F" letter-spacing="-0.5">truffl</text>
+        <text x="52" y="50" font-family="'DM Sans', sans-serif" font-size="12" font-weight="600" fill="#B0A090" letter-spacing="4">PETS</text>
+      </svg>
+    </a>
+    <div class="nav-right"><a href="/dashboard/">← Dashboard</a></div>
+  </nav>
+
+  <div class="wrap">
+    <div class="hub-head">
+      <h1>Carer guidelines</h1>
+      <p>Looking after someone's dog is a real responsibility, and we want you set up to do it brilliantly. This is everything you need: how we work, what owners expect, and what to do when it counts. A couple of these you'll acknowledge when you join, the rest are here whenever you need them.</p>
+    </div>
+
+    <div class="cards">
+      <a class="card" href="/carer-guidelines/your-commitments/">
+        <div class="card-top"><span class="card-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg></span><div><h2>Your commitments</h2><span class="ack-badge">Acknowledge</span></div></div>
+        <p>The standards every Truffl carer signs up to.</p>
+        <span class="arrow">Read more →</span>
+      </a>
+      <a class="card" href="/carer-guidelines/meet-and-greets/">
+        <div class="card-top"><span class="card-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span><div><h2>Meet &amp; greets</h2></div></div>
+        <p>How to make a great first impression and decide if a job's right for you.</p>
+        <span class="arrow">Read more →</span>
+      </a>
+      <a class="card" href="/carer-guidelines/keeping-owners-in-the-loop/">
+        <div class="card-top"><span class="card-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg></span><div><h2>Keeping owners in the loop</h2></div></div>
+        <p>GPS on walks, and updates for daycare and boarding.</p>
+        <span class="arrow">Read more →</span>
+      </a>
+      <a class="card" href="/carer-guidelines/emergencies-and-safety/">
+        <div class="card-top"><span class="card-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg></span><div><h2>Emergencies and safety</h2><span class="ack-badge">Acknowledge</span></div></div>
+        <p>What to do if something goes wrong, fast.</p>
+        <span class="arrow">Read more →</span>
+      </a>
+      <a class="card" href="/carer-guidelines/reporting-a-concern/">
+        <div class="card-top"><span class="card-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z"/><line x1="4" y1="22" x2="4" y2="15"/></svg></span><div><h2>Reporting a concern</h2></div></div>
+        <p>How to tell us if something isn't right.</p>
+        <span class="arrow">Read more →</span>
+      </a>
+      <a class="card" href="/carer-guidelines/vetting-and-cover/">
+        <div class="card-top"><span class="card-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg></span><div><h2>Vetting and cover</h2></div></div>
+        <p>What you completed to join, and what covers you.</p>
+        <span class="arrow">Read more →</span>
+      </a>
+    </div>
+  </div>
+</body>
+</html>

--- a/carer-guidelines/keeping-owners-in-the-loop/index.html
+++ b/carer-guidelines/keeping-owners-in-the-loop/index.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-T2CPSDBJ1L"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-T2CPSDBJ1L');
+</script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Keeping owners in the loop — Carer guidelines — Truffl Pets</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=DM+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --cream:#FAF7F2; --warm-white:#FFFDF9; --sage:#8B9E7E; --sage-dark:#6B7E5E;
+      --terracotta:#C4755B; --terracotta-light:#D4917B; --blush:#E8C4B8; --brown:#3D2B1F;
+      --text-primary:#3D2B1F; --text-secondary:#6B5B4E; --text-muted:#9B8B7E; --border:#E8E0D6;
+    }
+    *{margin:0;padding:0;box-sizing:border-box;}
+    body{font-family:'DM Sans',sans-serif;background:var(--cream);color:var(--text-primary);min-height:100vh;-webkit-font-smoothing:antialiased;line-height:1.65;}
+    a{text-decoration:none;color:inherit;}
+    .nav{position:sticky;top:0;z-index:100;background:var(--warm-white);border-bottom:1px solid var(--border);padding:0 2rem;height:64px;display:flex;align-items:center;justify-content:space-between;}
+    .nav-right{display:flex;align-items:center;gap:18px;font-size:0.85rem;color:var(--text-secondary);}
+    .nav-right a:hover{color:var(--terracotta);}
+    .article{max-width:680px;margin:0 auto;padding:2rem 1.5rem 3rem;}
+    .crumb{font-size:0.82rem;color:var(--text-muted);margin-bottom:1.4rem;display:inline-flex;align-items:center;gap:6px;}
+    .crumb:hover{color:var(--terracotta);}
+    .article h1{font-family:'Cormorant Garamond',serif;font-weight:500;font-size:2.1rem;color:var(--brown);margin-bottom:0.8rem;}
+    .lead{font-size:1rem;color:var(--text-secondary);margin-bottom:1.4rem;}
+    .article h2{font-size:1rem;font-weight:600;color:var(--brown);margin:1.5rem 0 0.4rem;}
+    .article p{margin-bottom:0.9rem;}
+    .article strong{color:var(--brown);}
+    .note{background:var(--warm-white);border:1px solid var(--border);border-left:3px solid var(--sage-dark);border-radius:10px;padding:14px 16px;margin:1.2rem 0;font-size:0.9rem;color:var(--text-secondary);}
+    .note a{color:var(--terracotta);font-weight:500;}
+    .footer-nav{display:flex;justify-content:space-between;gap:12px;margin-top:2rem;padding-top:1.2rem;border-top:1px solid var(--border);font-size:0.88rem;}
+    .footer-nav a{color:var(--terracotta);font-weight:500;}
+    @media(max-width:720px){.nav{padding:0 1rem;}}
+  </style>
+</head>
+<body>
+  <nav class="nav">
+    <a href="/dashboard/" aria-label="Truffl Pets dashboard">
+      <svg width="140" height="44" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="20" cy="33" r="20" fill="#C4755B"/>
+        <text x="20" y="38" font-family="'Cormorant Garamond', Georgia, serif" font-size="14" font-style="italic" fill="#FFFDF9" text-anchor="middle">truffl</text>
+        <text x="52" y="30" font-family="'Cormorant Garamond', Georgia, serif" font-size="32" font-style="italic" fill="#3D2B1F" letter-spacing="-0.5">truffl</text>
+      </svg>
+    </a>
+    <div class="nav-right"><a href="/carer-guidelines/">All guidelines</a><a href="/dashboard/">Dashboard</a></div>
+  </nav>
+
+  <article class="article">
+    <a class="crumb" href="/carer-guidelines/"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg> Carer guidelines</a>
+    <h1>Keeping owners in the loop</h1>
+    <p class="lead">A little communication goes a long way. Owners relax when they can see their dog is having a good time.</p>
+
+    <h2>On walks</h2>
+    <p>GPS tracks the route live, so owners can follow along. Just head out and do your thing. The route saves automatically when you're done.</p>
+
+    <h2>Daycare and boarding</h2>
+    <p>Send a check-in each day with a photo and a quick note on how the dog's doing: eating, toileting, mood. At the start of a stay, a quick "arrived and settling in" message puts an owner at ease. For boarding, an update each evening is plenty, but flag anything that's off straight away rather than waiting for the daily.</p>
+
+    <div class="note">Daycare and boarding check-ins are built right into your booking — you'll be prompted for the ones that are due. <a href="/dashboard/">Open your dashboard</a> to post one.</div>
+
+    <div class="footer-nav">
+      <a href="/carer-guidelines/meet-and-greets/">← Meet &amp; greets</a>
+      <a href="/carer-guidelines/emergencies-and-safety/">Emergencies and safety →</a>
+    </div>
+  </article>
+</body>
+</html>

--- a/carer-guidelines/meet-and-greets/index.html
+++ b/carer-guidelines/meet-and-greets/index.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-T2CPSDBJ1L"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-T2CPSDBJ1L');
+</script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Meet &amp; greets — Carer guidelines — Truffl Pets</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=DM+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --cream:#FAF7F2; --warm-white:#FFFDF9; --sage:#8B9E7E; --sage-dark:#6B7E5E;
+      --terracotta:#C4755B; --terracotta-light:#D4917B; --blush:#E8C4B8; --brown:#3D2B1F;
+      --text-primary:#3D2B1F; --text-secondary:#6B5B4E; --text-muted:#9B8B7E; --border:#E8E0D6;
+    }
+    *{margin:0;padding:0;box-sizing:border-box;}
+    body{font-family:'DM Sans',sans-serif;background:var(--cream);color:var(--text-primary);min-height:100vh;-webkit-font-smoothing:antialiased;line-height:1.65;}
+    a{text-decoration:none;color:inherit;}
+    .nav{position:sticky;top:0;z-index:100;background:var(--warm-white);border-bottom:1px solid var(--border);padding:0 2rem;height:64px;display:flex;align-items:center;justify-content:space-between;}
+    .nav-right{display:flex;align-items:center;gap:18px;font-size:0.85rem;color:var(--text-secondary);}
+    .nav-right a:hover{color:var(--terracotta);}
+    .article{max-width:680px;margin:0 auto;padding:2rem 1.5rem 3rem;}
+    .crumb{font-size:0.82rem;color:var(--text-muted);margin-bottom:1.4rem;display:inline-flex;align-items:center;gap:6px;}
+    .crumb:hover{color:var(--terracotta);}
+    .article h1{font-family:'Cormorant Garamond',serif;font-weight:500;font-size:2.1rem;color:var(--brown);margin-bottom:0.8rem;}
+    .lead{font-size:1rem;color:var(--text-secondary);margin-bottom:1.4rem;}
+    .article h2{font-size:1rem;font-weight:600;color:var(--brown);margin:1.5rem 0 0.4rem;}
+    .article p{margin-bottom:0.9rem;}
+    .article strong{color:var(--brown);}
+    .article ul{list-style:none;margin:0 0 1rem;padding:0;}
+    .article li{position:relative;padding-left:24px;margin-bottom:0.6rem;}
+    .article li::before{content:'';position:absolute;left:5px;top:10px;width:6px;height:6px;border-radius:50%;background:var(--terracotta);}
+    .article li strong{color:var(--brown);}
+    .note{background:var(--warm-white);border:1px solid var(--border);border-left:3px solid var(--sage-dark);border-radius:10px;padding:14px 16px;margin:1.2rem 0;font-size:0.9rem;color:var(--text-secondary);}
+    .note a{color:var(--terracotta);font-weight:500;}
+    .footer-nav{display:flex;justify-content:space-between;gap:12px;margin-top:2rem;padding-top:1.2rem;border-top:1px solid var(--border);font-size:0.88rem;}
+    .footer-nav a{color:var(--terracotta);font-weight:500;}
+    @media(max-width:720px){.nav{padding:0 1rem;}}
+  </style>
+</head>
+<body>
+  <nav class="nav">
+    <a href="/dashboard/" aria-label="Truffl Pets dashboard">
+      <svg width="140" height="44" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="20" cy="33" r="20" fill="#C4755B"/>
+        <text x="20" y="38" font-family="'Cormorant Garamond', Georgia, serif" font-size="14" font-style="italic" fill="#FFFDF9" text-anchor="middle">truffl</text>
+        <text x="52" y="30" font-family="'Cormorant Garamond', Georgia, serif" font-size="32" font-style="italic" fill="#3D2B1F" letter-spacing="-0.5">truffl</text>
+      </svg>
+    </a>
+    <div class="nav-right"><a href="/carer-guidelines/">All guidelines</a><a href="/dashboard/">Dashboard</a></div>
+  </nav>
+
+  <article class="article">
+    <a class="crumb" href="/carer-guidelines/"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg> Carer guidelines</a>
+    <h1>Meet &amp; greets</h1>
+    <p class="lead">Every first booking with a new owner starts with a free meet &amp; greet. It's how they decide you're right for their dog, and just as importantly, how you decide the job's right for you.</p>
+
+    <h2>Make a great impression</h2>
+    <p>Turn up on time and make a fuss of the dog. Ask about them: routine, quirks, what they love, what sets them off. Be honest about what you can and can't take on, because owners trust straight talk.</p>
+
+    <h2>What to check, by service</h2>
+    <ul>
+      <li><strong>Walks:</strong> how the dog is on lead, with other dogs and traffic, and their recall.</li>
+      <li><strong>Drop-ins and home sitting:</strong> access, the alarm, what's off limits, and the routine while you're there.</li>
+      <li><strong>Daycare and boarding:</strong> show the owner your space, the yard, and any other pets that'll be around.</li>
+      <li><strong>Overnight stays:</strong> the bedtime routine and how the dog settles.</li>
+    </ul>
+
+    <p>It goes both ways. If the job or the dog isn't right for you, you can step back after the meet, no hard feelings. Better an honest no than a booking that doesn't work.</p>
+
+    <div class="note">When a meet &amp; greet is arranged, you'll get the short, just-in-time version on your <a href="/dashboard/">dashboard</a> and in the message thread. This page is the fuller standing reference.</div>
+
+    <div class="footer-nav">
+      <a href="/carer-guidelines/your-commitments/">← Your commitments</a>
+      <a href="/carer-guidelines/keeping-owners-in-the-loop/">Keeping owners in the loop →</a>
+    </div>
+  </article>
+</body>
+</html>

--- a/carer-guidelines/reporting-a-concern/index.html
+++ b/carer-guidelines/reporting-a-concern/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-T2CPSDBJ1L"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-T2CPSDBJ1L');
+</script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reporting a concern — Carer guidelines — Truffl Pets</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=DM+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --cream:#FAF7F2; --warm-white:#FFFDF9; --sage:#8B9E7E; --sage-dark:#6B7E5E;
+      --terracotta:#C4755B; --terracotta-light:#D4917B; --blush:#E8C4B8; --brown:#3D2B1F;
+      --text-primary:#3D2B1F; --text-secondary:#6B5B4E; --text-muted:#9B8B7E; --border:#E8E0D6;
+    }
+    *{margin:0;padding:0;box-sizing:border-box;}
+    body{font-family:'DM Sans',sans-serif;background:var(--cream);color:var(--text-primary);min-height:100vh;-webkit-font-smoothing:antialiased;line-height:1.65;}
+    a{text-decoration:none;color:inherit;}
+    .nav{position:sticky;top:0;z-index:100;background:var(--warm-white);border-bottom:1px solid var(--border);padding:0 2rem;height:64px;display:flex;align-items:center;justify-content:space-between;}
+    .nav-right{display:flex;align-items:center;gap:18px;font-size:0.85rem;color:var(--text-secondary);}
+    .nav-right a:hover{color:var(--terracotta);}
+    .article{max-width:680px;margin:0 auto;padding:2rem 1.5rem 3rem;}
+    .crumb{font-size:0.82rem;color:var(--text-muted);margin-bottom:1.4rem;display:inline-flex;align-items:center;gap:6px;}
+    .crumb:hover{color:var(--terracotta);}
+    .article h1{font-family:'Cormorant Garamond',serif;font-weight:500;font-size:2.1rem;color:var(--brown);margin-bottom:0.8rem;}
+    .lead{font-size:1rem;color:var(--text-secondary);margin-bottom:1.4rem;}
+    .article p{margin-bottom:0.9rem;}
+    .article ul{list-style:none;margin:0 0 1rem;padding:0;}
+    .article li{position:relative;padding-left:24px;margin-bottom:0.6rem;}
+    .article li::before{content:'';position:absolute;left:5px;top:10px;width:6px;height:6px;border-radius:50%;background:var(--terracotta);}
+    .email-box{background:var(--warm-white);border:1px solid var(--border);border-radius:12px;padding:18px;margin:1.2rem 0;text-align:center;}
+    .email-box a{font-family:'Cormorant Garamond',serif;font-size:1.4rem;color:var(--terracotta);font-weight:500;}
+    .footer-nav{display:flex;justify-content:space-between;gap:12px;margin-top:2rem;padding-top:1.2rem;border-top:1px solid var(--border);font-size:0.88rem;}
+    .footer-nav a{color:var(--terracotta);font-weight:500;}
+    @media(max-width:720px){.nav{padding:0 1rem;}}
+  </style>
+</head>
+<body>
+  <nav class="nav">
+    <a href="/dashboard/" aria-label="Truffl Pets dashboard">
+      <svg width="140" height="44" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="20" cy="33" r="20" fill="#C4755B"/>
+        <text x="20" y="38" font-family="'Cormorant Garamond', Georgia, serif" font-size="14" font-style="italic" fill="#FFFDF9" text-anchor="middle">truffl</text>
+        <text x="52" y="30" font-family="'Cormorant Garamond', Georgia, serif" font-size="32" font-style="italic" fill="#3D2B1F" letter-spacing="-0.5">truffl</text>
+      </svg>
+    </a>
+    <div class="nav-right"><a href="/carer-guidelines/">All guidelines</a><a href="/dashboard/">Dashboard</a></div>
+  </nav>
+
+  <article class="article">
+    <a class="crumb" href="/carer-guidelines/"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg> Carer guidelines</a>
+    <h1>Reporting a concern</h1>
+    <p class="lead">If something doesn't feel right, tell us. Whether it's an owner, a dog, or a situation that worried you, we'd always rather know.</p>
+
+    <!-- PLACEHOLDER (reporting email): inherited from TRU-15 — confirm the real address before launch. -->
+    <div class="email-box" data-placeholder="safety-email"><a href="mailto:safety@trufflpets.com">safety@trufflpets.com</a></div>
+
+    <ul>
+      <li>Tell us what happened in your own words. Detail helps.</li>
+      <li>We investigate every concern urgently and handle it sensitively, in confidence unless you tell us otherwise.</li>
+    </ul>
+
+    <p>You won't get in trouble for raising something in good faith. That's exactly what we want you to do.</p>
+
+    <div class="footer-nav">
+      <a href="/carer-guidelines/emergencies-and-safety/">← Emergencies and safety</a>
+      <a href="/carer-guidelines/vetting-and-cover/">Vetting and cover →</a>
+    </div>
+  </article>
+</body>
+</html>

--- a/carer-guidelines/vetting-and-cover/index.html
+++ b/carer-guidelines/vetting-and-cover/index.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-T2CPSDBJ1L"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-T2CPSDBJ1L');
+</script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Vetting and cover — Carer guidelines — Truffl Pets</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=DM+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --cream:#FAF7F2; --warm-white:#FFFDF9; --sage:#8B9E7E; --sage-dark:#6B7E5E;
+      --terracotta:#C4755B; --terracotta-light:#D4917B; --blush:#E8C4B8; --brown:#3D2B1F;
+      --text-primary:#3D2B1F; --text-secondary:#6B5B4E; --text-muted:#9B8B7E; --border:#E8E0D6;
+    }
+    *{margin:0;padding:0;box-sizing:border-box;}
+    body{font-family:'DM Sans',sans-serif;background:var(--cream);color:var(--text-primary);min-height:100vh;-webkit-font-smoothing:antialiased;line-height:1.65;}
+    a{text-decoration:none;color:inherit;}
+    .nav{position:sticky;top:0;z-index:100;background:var(--warm-white);border-bottom:1px solid var(--border);padding:0 2rem;height:64px;display:flex;align-items:center;justify-content:space-between;}
+    .nav-right{display:flex;align-items:center;gap:18px;font-size:0.85rem;color:var(--text-secondary);}
+    .nav-right a:hover{color:var(--terracotta);}
+    .article{max-width:680px;margin:0 auto;padding:2rem 1.5rem 3rem;}
+    .crumb{font-size:0.82rem;color:var(--text-muted);margin-bottom:1.4rem;display:inline-flex;align-items:center;gap:6px;}
+    .crumb:hover{color:var(--terracotta);}
+    .article h1{font-family:'Cormorant Garamond',serif;font-weight:500;font-size:2.1rem;color:var(--brown);margin-bottom:0.8rem;}
+    .lead{font-size:1rem;color:var(--text-secondary);margin-bottom:1.4rem;}
+    .article h2{font-size:1rem;font-weight:600;color:var(--brown);margin:1.5rem 0 0.4rem;}
+    .article p{margin-bottom:0.9rem;}
+    .article ul{list-style:none;margin:0 0 1rem;padding:0;}
+    .article li{position:relative;padding-left:24px;margin-bottom:0.6rem;}
+    .article li::before{content:'';position:absolute;left:5px;top:10px;width:6px;height:6px;border-radius:50%;background:var(--terracotta);}
+    .footer-nav{display:flex;justify-content:space-between;gap:12px;margin-top:2rem;padding-top:1.2rem;border-top:1px solid var(--border);font-size:0.88rem;}
+    .footer-nav a{color:var(--terracotta);font-weight:500;}
+    @media(max-width:720px){.nav{padding:0 1rem;}}
+  </style>
+</head>
+<body>
+  <nav class="nav">
+    <a href="/dashboard/" aria-label="Truffl Pets dashboard">
+      <svg width="140" height="44" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="20" cy="33" r="20" fill="#C4755B"/>
+        <text x="20" y="38" font-family="'Cormorant Garamond', Georgia, serif" font-size="14" font-style="italic" fill="#FFFDF9" text-anchor="middle">truffl</text>
+        <text x="52" y="30" font-family="'Cormorant Garamond', Georgia, serif" font-size="32" font-style="italic" fill="#3D2B1F" letter-spacing="-0.5">truffl</text>
+      </svg>
+    </a>
+    <div class="nav-right"><a href="/carer-guidelines/">All guidelines</a><a href="/dashboard/">Dashboard</a></div>
+  </nav>
+
+  <article class="article">
+    <a class="crumb" href="/carer-guidelines/"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg> Carer guidelines</a>
+    <h1>Vetting and cover</h1>
+    <p class="lead">You did the work to get here, and that's worth knowing about.</p>
+
+    <h2>What you completed to join</h2>
+    <ul>
+      <li>ID verification, so owners know you're you.</li>
+      <li>An in-person meeting and a hands-on pet care demo.</li>
+      <li>Profile verification, so your address and experience are confirmed, not just claimed.</li>
+    </ul>
+    <p>That vetting is a big part of why owners trust Truffl carers, and why it's worth keeping your profile accurate and up to date.</p>
+
+    <h2>Your cover</h2>
+    <!-- PLACEHOLDER (cover): inherited from TRU-15 — confirm what cover applies to carers and its terms before launch. -->
+    <p>Details of the cover that applies to you while you're on a Truffl booking will be confirmed here before launch.</p>
+
+    <div class="footer-nav">
+      <a href="/carer-guidelines/reporting-a-concern/">← Reporting a concern</a>
+      <a href="/carer-guidelines/">All guidelines →</a>
+    </div>
+  </article>
+</body>
+</html>

--- a/carer-guidelines/your-commitments/index.html
+++ b/carer-guidelines/your-commitments/index.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-T2CPSDBJ1L"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-T2CPSDBJ1L');
+</script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Your commitments — Carer guidelines — Truffl Pets</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=DM+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --cream:#FAF7F2; --warm-white:#FFFDF9; --sage:#8B9E7E; --sage-light:#C2D1B5;
+      --sage-dark:#6B7E5E; --terracotta:#C4755B; --terracotta-light:#D4917B;
+      --blush:#E8C4B8; --brown:#3D2B1F; --brown-muted:#8B7355;
+      --text-primary:#3D2B1F; --text-secondary:#6B5B4E; --text-muted:#9B8B7E;
+      --border:#E8E0D6; --success:#5B8C5A; --success-bg:#EDF5ED; --warning:#C0862B; --warning-bg:#FEF3E2;
+    }
+    *{margin:0;padding:0;box-sizing:border-box;}
+    body{font-family:'DM Sans',sans-serif;background:var(--cream);color:var(--text-primary);min-height:100vh;-webkit-font-smoothing:antialiased;line-height:1.65;}
+    a{text-decoration:none;color:inherit;}
+    .nav{position:sticky;top:0;z-index:100;background:var(--warm-white);border-bottom:1px solid var(--border);padding:0 2rem;height:64px;display:flex;align-items:center;justify-content:space-between;}
+    .nav-right{display:flex;align-items:center;gap:18px;font-size:0.85rem;color:var(--text-secondary);}
+    .nav-right a:hover{color:var(--terracotta);}
+    .article{max-width:680px;margin:0 auto;padding:2rem 1.5rem 3rem;}
+    .crumb{font-size:0.82rem;color:var(--text-muted);margin-bottom:1.4rem;display:inline-flex;align-items:center;gap:6px;}
+    .crumb:hover{color:var(--terracotta);}
+    .article h1{font-family:'Cormorant Garamond',serif;font-weight:500;font-size:2.1rem;color:var(--brown);margin-bottom:0.4rem;}
+    .ack-badge{display:inline-block;font-size:0.66rem;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;color:var(--warning);background:var(--warning-bg);padding:3px 10px;border-radius:20px;margin-bottom:1.2rem;}
+    .lead{font-size:1rem;color:var(--text-secondary);margin-bottom:1.4rem;}
+    .article h2{font-size:1rem;font-weight:600;color:var(--brown);margin:1.5rem 0 0.4rem;}
+    .article p{margin-bottom:0.9rem;}
+    .article strong{color:var(--brown);}
+    .ack-box{margin-top:2rem;background:var(--warm-white);border:1px solid var(--border);border-radius:14px;padding:1.4rem;}
+    .ack-box p{font-size:0.88rem;color:var(--text-secondary);margin-bottom:1rem;}
+    .ack-btn{background:var(--terracotta);color:#fff;border:0;border-radius:10px;padding:12px 24px;font:inherit;font-size:0.9rem;font-weight:500;cursor:pointer;}
+    .ack-btn:hover{background:var(--terracotta-light);}
+    .ack-btn:disabled{opacity:0.6;cursor:default;}
+    .ack-done{display:flex;align-items:center;gap:8px;color:var(--success);font-weight:500;font-size:0.92rem;}
+    .footer-nav{display:flex;justify-content:space-between;gap:12px;margin-top:2rem;padding-top:1.2rem;border-top:1px solid var(--border);font-size:0.88rem;}
+    .footer-nav a{color:var(--terracotta);font-weight:500;}
+    @media(max-width:720px){.nav{padding:0 1rem;}}
+  </style>
+</head>
+<body>
+  <nav class="nav">
+    <a href="/dashboard/" aria-label="Truffl Pets dashboard">
+      <svg width="140" height="44" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="20" cy="33" r="20" fill="#C4755B"/>
+        <text x="20" y="38" font-family="'Cormorant Garamond', Georgia, serif" font-size="14" font-style="italic" fill="#FFFDF9" text-anchor="middle">truffl</text>
+        <text x="52" y="30" font-family="'Cormorant Garamond', Georgia, serif" font-size="32" font-style="italic" fill="#3D2B1F" letter-spacing="-0.5">truffl</text>
+      </svg>
+    </a>
+    <div class="nav-right"><a href="/carer-guidelines/">All guidelines</a><a href="/dashboard/">Dashboard</a></div>
+  </nav>
+
+  <article class="article">
+    <a class="crumb" href="/carer-guidelines/"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg> Carer guidelines</a>
+    <h1>Your commitments</h1>
+    <div class="ack-badge">Acknowledge on join</div>
+    <p class="lead">Owners trust Truffl carers because we hold a real standard. These are the commitments you make to every owner and dog. They are not optional, and they are what keep this community worth being part of.</p>
+
+    <h2>Showing up</h2>
+    <p>Turn up on time, every time. If you're running late, message the owner straight away. Only accept work you can genuinely commit to. If you have to cancel, do it as early as you can, since repeated last-minute cancellations affect your standing.</p>
+
+    <h2>Communication</h2>
+    <p>Reply to owners promptly, before and during a booking, and keep them informed if anything changes.</p>
+
+    <h2>Access and homes</h2>
+    <p>When you're given keys, codes or entry to a home, treat them as you'd want yours treated. Use only what you need for the job, stay out of spaces that aren't part of it, and never share access details with anyone.</p>
+
+    <h2>Keeping it on Truffl</h2>
+    <p>Keep bookings, messages and payments on Truffl. It protects you as much as the owner: it's how you're covered, how you get paid reliably, and how we can step in if there's ever a dispute. Taking work off-platform puts you outside that protection, and it's against our terms.</p>
+
+    <div class="ack-box" id="ackBox" style="display:none;">
+      <p>By acknowledging, you confirm you've read and agree to uphold these commitments on every booking.</p>
+      <button class="ack-btn" id="ackBtn" onclick="acknowledge()">I've read this and I agree</button>
+      <div class="ack-done" id="ackDone" style="display:none;"></div>
+    </div>
+
+    <div class="footer-nav">
+      <a href="/carer-guidelines/">← All guidelines</a>
+      <a href="/carer-guidelines/meet-and-greets/">Meet &amp; greets →</a>
+    </div>
+  </article>
+
+  <script>
+    const SUPABASE_URL='https://gadflsntbnbnnxbpiral.supabase.co';
+    const SUPABASE_ANON_KEY='eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdhZGZsc250Ym5ibm54YnBpcmFsIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzUwNjcwNTcsImV4cCI6MjA5MDY0MzA1N30.g5ZrqeAX9U5l7oDZEbQFrU5j10828dUF0QuJ0ZlHXK8';
+    const ACK_COLUMN='acknowledged_commitments_at';
+    let session=null;
+    function fmt(iso){ try { return new Date(iso).toLocaleDateString('en-AU',{day:'numeric',month:'long',year:'numeric'}); } catch(e){ return ''; } }
+    function showDone(iso){ document.getElementById('ackBtn').style.display='none'; const d=document.getElementById('ackDone'); d.style.display='flex'; d.innerHTML='<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg> Acknowledged on '+fmt(iso); }
+    async function acknowledge(){
+      const btn=document.getElementById('ackBtn'); btn.disabled=true; btn.textContent='Saving…';
+      const now=new Date().toISOString();
+      try {
+        const r=await fetch(`${SUPABASE_URL}/rest/v1/provider_profiles?user_id=eq.${session.user_id}`,{method:'PATCH',headers:{'Content-Type':'application/json','apikey':SUPABASE_ANON_KEY,'Authorization':`Bearer ${session.access_token}`,'Prefer':'return=minimal'},body:JSON.stringify({[ACK_COLUMN]:now})});
+        if(!r.ok) throw new Error('save failed');
+        showDone(now);
+      } catch(e){ btn.disabled=false; btn.textContent='I\'ve read this and I agree'; }
+    }
+    (async function(){
+      try { const s=localStorage.getItem('truffl_session'); if(s) session=JSON.parse(s); } catch(e){}
+      if(!session || session.role!=='provider') return; // only carers see the acknowledge box
+      document.getElementById('ackBox').style.display='block';
+      try {
+        const r=await fetch(`${SUPABASE_URL}/rest/v1/provider_profiles?user_id=eq.${session.user_id}&select=${ACK_COLUMN}`,{headers:{'apikey':SUPABASE_ANON_KEY,'Authorization':`Bearer ${session.access_token}`}});
+        const rows=await r.json();
+        if(rows[0] && rows[0][ACK_COLUMN]) showDone(rows[0][ACK_COLUMN]);
+      } catch(e){}
+    })();
+  </script>
+</body>
+</html>

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -136,6 +136,15 @@
   }
   .status-pending { background: var(--warning-bg); color: var(--warning); }
   .status-confirmed { background: var(--success-bg); color: var(--success); }
+  /* Carer guidelines acknowledgement gate (TRU-126) */
+  .ack-gate { background: var(--warning-bg); border: 1px solid #F0D9A8; border-radius: 14px; padding: 1.1rem 1.25rem; margin-bottom: 1.5rem; }
+  .ack-gate-title { font-weight: 600; color: var(--brown); margin-bottom: 4px; }
+  .ack-gate p { font-size: 0.86rem; color: var(--text-secondary); margin-bottom: 12px; }
+  .ack-gate-links { display: flex; flex-wrap: wrap; gap: 10px; }
+  .ack-gate-item { display: inline-flex; align-items: center; gap: 7px; padding: 8px 14px; border-radius: 10px; background: var(--warm-white); border: 1px solid var(--border); font-size: 0.84rem; font-weight: 500; color: var(--text-primary); text-decoration: none; }
+  .ack-gate-item:hover { border-color: var(--terracotta); }
+  .ack-gate-item.done { color: var(--success); border-color: var(--success-bg); }
+  .ack-gate-dot { width: 13px; height: 13px; border-radius: 50%; border: 2px solid var(--warning); display: inline-block; }
   /* Meet & greet chips (TRU-14) */
   .mg-chips { display: flex; flex-wrap: wrap; gap: 8px; }
   .mg-chip { font: inherit; font-size: 0.82rem; padding: 6px 12px; border-radius: 20px; border: 1px solid var(--border); background: #fff; color: var(--text-secondary); cursor: pointer; }
@@ -296,6 +305,7 @@
     </svg>
   </a>
   <div class="nav-right">
+    <a href="/carer-guidelines/">Guidelines</a>
     <a href="/messages/" class="nav-msg" id="navMsg" title="Messages" aria-label="Messages">
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/></svg>
       <span class="nav-msg-badge" id="navMsgBadge" style="display:none;">0</span>
@@ -480,8 +490,36 @@ function bookingTimeLine(b) {
   return `${day} · ${b.duration_mins ? b.duration_mins + '-min · ' : ''}between ${t1}–${t2}`;
 }
 
+/* ── Carer guidelines acknowledgement gate (TRU-126) ── */
+function guidelinesAcknowledged() {
+  return !!(providerProfile && providerProfile.acknowledged_commitments_at && providerProfile.acknowledged_safety_at);
+}
+function requireGuidelines() {
+  if (guidelinesAcknowledged()) return true;
+  showMsg('Please review and acknowledge your carer guidelines before taking bookings — see the banner at the top.', 'error');
+  window.scrollTo({ top: 0, behavior: 'smooth' });
+  return false;
+}
+function ackGateBannerHtml() {
+  if (guidelinesAcknowledged()) return '';
+  const c = !!providerProfile.acknowledged_commitments_at, s = !!providerProfile.acknowledged_safety_at;
+  const done = (c ? 1 : 0) + (s ? 1 : 0);
+  const item = (ok, href, label) => `<a class="ack-gate-item ${ok ? 'done' : ''}" href="${href}">${ok
+    ? '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg>'
+    : '<span class="ack-gate-dot"></span>'} ${label}</a>`;
+  return `<div class="ack-gate">
+    <div class="ack-gate-title">Before you can accept bookings</div>
+    <p>Read and acknowledge these two pages — ${done} of 2 done.</p>
+    <div class="ack-gate-links">
+      ${item(c, '/carer-guidelines/your-commitments/', 'Your commitments')}
+      ${item(s, '/carer-guidelines/emergencies-and-safety/', 'Emergencies and safety')}
+    </div>
+  </div>`;
+}
+
 async function acceptBooking(bookingId) {
   clearMsg();
+  if (!requireGuidelines()) return;
   try {
     await sbPatch('bookings', 'id', bookingId, { status: 'confirmed' });
     showMsg('Booking confirmed!', 'success');
@@ -599,6 +637,7 @@ async function loadMgSeries() {
 }
 
 async function acceptSeries(id) {
+  if (!requireGuidelines()) return;
   try {
     await sbPatch('booking_series', 'id', id, { status: 'active' });
     await loadSeries();
@@ -1052,6 +1091,8 @@ function renderDashboard() {
       <h1>Hey, ${userData.first_name}</h1>
       <p>${pending.length > 0 ? `You have ${pending.length} new booking request${pending.length !== 1 ? 's' : ''}` : 'Your dashboard — manage bookings, services, and your profile.'}</p>
     </div>
+
+    ${ackGateBannerHtml()}
 
     <div class="tabs">
       <button class="tab active" data-tab="bookings" onclick="switchTab('bookings')">Bookings${pending.length > 0 ? ` (${pending.length})` : ''}</button>

--- a/supabase/migrations/20260618_tru126_carer_guideline_acks.sql
+++ b/supabase/migrations/20260618_tru126_carer_guideline_acks.sql
@@ -1,0 +1,8 @@
+-- TRU-126: carers acknowledge the two standards/safety guideline pages once before
+-- they can take bookings. Providers already have UPDATE RLS on their own row, so
+-- the acknowledge action is a direct PATCH; no new policy needed.
+--
+-- Applied to the live DB via apply_migration; committed here for version control.
+ALTER TABLE public.provider_profiles
+  ADD COLUMN IF NOT EXISTS acknowledged_commitments_at timestamptz,
+  ADD COLUMN IF NOT EXISTS acknowledged_safety_at      timestamptz;


### PR DESCRIPTION
Implements [TRU-126](https://linear.app/truffl-pets/issue/TRU-126/carer-guidelines-and-resource-hub-carer-dashboard) — the carer-facing counterpart to [TRU-15](https://linear.app/truffl-pets/issue/TRU-15/customer-tips-safety-guidance). A guidelines + resource hub in the carer dashboard, where the protocols TRU-15 describes to owners live as the carer's own instructions.

### Hub (`/carer-guidelines`)
Landing + six sub-pages with verbatim copy in the **app palette** (since it lives in the carer dashboard), warm baseline with a firmer tone on the two acknowledge pages:
1. Your commitments *(acknowledge)* · 2. Meet & greets · 3. Keeping owners in the loop · 4. Emergencies and safety *(acknowledge)* · 5. Reporting a concern · 6. Vetting and cover

- "Meet & greets" links to the TRU-14 in-booking guidance; "Keeping owners in the loop" points at the TRU-125 check-ins — neither duplicated.
- Launch placeholders (priority line, `safety@trufflpets.com`, cover terms) marked with `PLACEHOLDER` comments + `data-placeholder` hooks.

### Acknowledge-on-join gate
- `provider_profiles` gains `acknowledged_commitments_at` + `acknowledged_safety_at` (migration `20260618`). Carers already have UPDATE RLS on their own row, so the acknowledge action is a direct PATCH.
- The two acknowledge pages show an **"I've read & agree"** button for the logged-in carer that timestamps the column (and shows the acknowledged date if already done).
- **Dashboard:** a *Guidelines* nav link; a gate **banner** (progress N/2, links to the two pages) shown until both are acknowledged; `acceptBooking` + `acceptSeries` are **blocked** with a prompt until then.

### Testing (Preview)
- ✅ Gate banner at **0/2**; Accept blocked with a prompt; Guidelines nav link present.
- ✅ Both acknowledge pages: button → timestamp persists (verified in DB); re-shows "Acknowledged on …".
- ✅ After acknowledging both: banner gone, **Accept succeeds** ("Booking confirmed!").
- ✅ Hub + sub-pages render; the two ACKNOWLEDGE badges show. All JS parse-checked. Test data cleaned up.

> [!NOTE]
> Enforcement is client-side (banner + blocked accept actions) — a determined carer could bypass the UI. A server-side gate (trigger on booking acceptance) is a possible hardening follow-up, deliberately left out to avoid abruptly blocking existing carers via a DB trigger without sign-off. The "Supabase Preview" check will be red as agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)