### PR TITLE
TRU-132: privacy policy page (+ repoint footer Privacy links)

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -713,7 +713,7 @@
       <a href="/about-us/">About</a>
       <a href="/trust-and-safety/">Trust &amp; safety</a>
       <a href="#">Contact</a>
-      <a href="#">Privacy</a>
+      <a href="/privacy/">Privacy</a>
     </div>
     <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>
   </footer>

--- a/index.html
+++ b/index.html
@@ -868,7 +868,7 @@
       <a href="/about-us/">About</a>
       <a href="/trust-and-safety/">Trust &amp; safety</a>
       <a href="#">Contact</a>
-      <a href="#">Privacy</a>
+      <a href="/privacy/">Privacy</a>
     </div>
     <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>
   </footer>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -1,0 +1,239 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-T2CPSDBJ1L"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-T2CPSDBJ1L');
+</script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy policy — Truffl Pets</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <meta name="description" content="How Truffl Pets collects, uses, stores and protects your personal information.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --cream: #F7F3EE; --warm: #EDE7DC; --sage: #C8D5C0; --sage-dark: #8A9E82;
+      --blush: #E8D5CC; --terracotta: #C4866A; --terracotta-dark: #B8795C;
+      --brown: #5C4033; --brown-deep: #3A2E28; --text: #3A2E28; --text-mid: #7A6860;
+      --text-light: #A8978E; --border: rgba(92,64,51,0.12);
+    }
+    html { font-size: 16px; scroll-behavior: smooth; }
+    body { font-family: 'DM Sans', sans-serif; background: var(--cream); color: var(--text); line-height: 1.65; -webkit-font-smoothing: antialiased; }
+    a { text-decoration: none; color: inherit; }
+    nav { background: var(--cream); padding: 0 56px; height: 82px; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid var(--border); position: sticky; top: 0; z-index: 100; gap: 24px; flex-wrap: wrap; }
+    .nav-left { display: flex; align-items: center; gap: 32px; }
+    .nav-links { display: flex; gap: 28px; font-size: 13px; color: var(--text-mid); }
+    .nav-links a:hover, .nav-links a.active { color: var(--text); }
+    .nav-links a.active { font-weight: 500; }
+    .nav-actions { display: flex; gap: 24px; align-items: center; font-size: 13px; color: var(--text-mid); }
+    .nav-actions a:hover { color: var(--text); }
+    .btn-primary { background: var(--terracotta); color: #fff; padding: 11px 22px; border-radius: 999px; font-size: 13px; font-weight: 500; transition: background 0.2s, transform 0.2s; }
+    .btn-primary:hover { background: var(--terracotta-dark); transform: translateY(-1px); }
+    .article { max-width: 720px; margin: 0 auto; padding: 40px 24px 24px; }
+    .crumb { font-size: 13px; color: var(--text-mid); margin-bottom: 26px; display: inline-flex; align-items: center; gap: 7px; }
+    .crumb:hover { color: var(--terracotta); }
+    .article h1 { font-family: 'Cormorant Garamond', serif; font-weight: 500; font-size: 2.5rem; line-height: 1.12; color: var(--brown); margin-bottom: 10px; }
+    .updated { font-size: 0.85rem; color: var(--text-light); margin-bottom: 22px; }
+    .lead { font-size: 1.08rem; color: var(--text-mid); margin-bottom: 30px; }
+    .article h2 { font-family: 'Cormorant Garamond', serif; font-weight: 500; font-size: 1.6rem; color: var(--brown); margin: 34px 0 12px; }
+    .article h3 { font-size: 1rem; font-weight: 600; color: var(--text); margin: 22px 0 8px; }
+    .article p { margin-bottom: 14px; color: var(--text); }
+    .article ul { list-style: none; margin: 0 0 16px; padding: 0; }
+    .article li { position: relative; padding-left: 26px; margin-bottom: 10px; color: var(--text); }
+    .article li::before { content: ''; position: absolute; left: 6px; top: 11px; width: 7px; height: 7px; border-radius: 50%; background: var(--terracotta); }
+    .article li strong { color: var(--brown); }
+    .article a.inline { color: var(--terracotta); border-bottom: 1px solid rgba(196,134,106,0.4); }
+    .note { background: #fff; border: 1px solid var(--border); border-left: 3px solid var(--sage-dark); border-radius: 12px; padding: 18px 20px; margin: 22px 0; }
+    .note p:last-child { margin-bottom: 0; }
+    .toc { background: #fff; border: 1px solid var(--border); border-radius: 14px; padding: 20px 24px; margin: 28px 0 8px; }
+    .toc-title { font-size: 0.8rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-light); margin-bottom: 12px; }
+    .toc ol { list-style: none; margin: 0; padding: 0; columns: 2; column-gap: 32px; }
+    .toc li { padding-left: 0; margin-bottom: 8px; font-size: 0.92rem; }
+    .toc li::before { display: none; }
+    .toc a { color: var(--text-mid); }
+    .toc a:hover { color: var(--terracotta); }
+    footer { background: var(--brown-deep); color: var(--text-light); padding: 40px 56px; display: flex; align-items: center; justify-content: space-between; gap: 20px; flex-wrap: wrap; margin-top: 48px; }
+    .footer-links { display: flex; gap: 24px; font-size: 13px; color: var(--text-light); flex-wrap: wrap; }
+    .footer-links a:hover { color: #fff; }
+    .footer-copy { font-size: 12px; color: var(--text-light); opacity: 0.7; }
+    @media (max-width: 860px) { nav { padding: 0 20px; } .nav-links { display: none; } .article h1 { font-size: 2rem; } .toc ol { columns: 1; } footer { padding: 32px 20px; } }
+  </style>
+</head>
+<body>
+  <nav>
+    <div class="nav-left">
+      <a href="/" class="nav-logo" aria-label="Truffl Pets home">
+        <svg width="150" height="48" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <circle cx="20" cy="33" r="20" fill="#C4866A"/>
+          <text x="20" y="38" font-family="'Cormorant Garamond', Georgia, serif" font-size="14" font-style="italic" fill="#F7F3EE" text-anchor="middle">truffl</text>
+          <text x="52" y="30" font-family="'Cormorant Garamond', Georgia, serif" font-size="32" font-style="italic" fill="#5C4033" letter-spacing="-0.5">truffl</text>
+          <text x="52" y="50" font-family="'DM Sans', sans-serif" font-size="12" font-weight="600" fill="#B0A090" letter-spacing="4">PETS</text>
+        </svg>
+      </a>
+      <div class="nav-links">
+        <a href="/">Home</a>
+        <a href="/about-us/">About</a>
+        <a href="/trust-and-safety/">Trust &amp; safety</a>
+        <a href="/#how">How it works</a>
+      </div>
+    </div>
+    <div class="nav-actions">
+      <a href="/login/">Sign in</a>
+      <a href="/search/" class="btn-primary">Book a carer</a>
+    </div>
+  </nav>
+
+  <article class="article">
+    <a class="crumb" href="/"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg> Home</a>
+    <h1>Privacy policy</h1>
+    <!-- PLACEHOLDER: confirm effective date before launch -->
+    <p class="updated" data-placeholder="effective-date">Last updated: 22 June 2026</p>
+    <p class="lead">Truffl Pets connects pet owners with vetted local carers in Sydney. This policy explains what personal information we collect, how we use it, who we share it with, and the choices and rights you have. It applies to our website, our mobile apps, and the services we provide through them.</p>
+
+    <div class="note">
+      <!-- PLACEHOLDER: confirm legal entity name + ABN before launch -->
+      <p>Truffl Pets <span data-placeholder="legal-entity">(legal entity name and ABN to be confirmed)</span> is the organisation responsible for your personal information. We handle it in accordance with the Australian <em>Privacy Act 1988</em> (Cth) and the Australian Privacy Principles (APPs).</p>
+    </div>
+
+    <div class="toc">
+      <div class="toc-title">On this page</div>
+      <ol>
+        <li><a href="#collect">1. Information we collect</a></li>
+        <li><a href="#use">2. How we use it</a></li>
+        <li><a href="#location">3. Location &amp; GPS</a></li>
+        <li><a href="#sharing">4. Who we share it with</a></li>
+        <li><a href="#storage">5. Storage &amp; security</a></li>
+        <li><a href="#retention">6. How long we keep it</a></li>
+        <li><a href="#rights">7. Your rights &amp; choices</a></li>
+        <li><a href="#children">8. Children</a></li>
+        <li><a href="#changes">9. Changes to this policy</a></li>
+        <li><a href="#contact">10. Contact us</a></li>
+      </ol>
+    </div>
+
+    <h2 id="collect">1. Information we collect</h2>
+    <p>We collect information you give us directly, information generated as you use Truffl, and a small amount of technical information from your device.</p>
+
+    <h3>Account details</h3>
+    <ul>
+      <li>Your name, email address, phone number and password when you register.</li>
+      <li>Whether you are an owner or a carer, and your suburb or service area.</li>
+      <li>For carers: profile information, the services you offer, availability, and the records we use for vetting (such as identity and background-check details).</li>
+    </ul>
+
+    <h3>Pet information</h3>
+    <ul>
+      <li>Your pet's name, breed, age, temperament, routine, dietary and medical needs, and any notes you add to help a carer look after them.</li>
+    </ul>
+
+    <h3>Bookings, messages &amp; photos</h3>
+    <ul>
+      <li>Details of the bookings you make or accept, meet &amp; greets, and check-ins.</li>
+      <li>Messages you exchange with the other party through Truffl, and system messages we send you.</li>
+      <li>Photos and updates a carer shares during a booking.</li>
+    </ul>
+
+    <h3>Location &amp; GPS</h3>
+    <ul>
+      <li>During a walk, the carer's app records GPS location so owners can follow along live and review the route afterwards. See <a class="inline" href="#location">Location &amp; GPS</a> below.</li>
+    </ul>
+
+    <h3>Technical &amp; usage information</h3>
+    <ul>
+      <li>Basic device and browser information, and how you use the site and apps, collected through analytics so we can keep Truffl working and improve it.</li>
+    </ul>
+
+    <h2 id="use">2. How we use your information</h2>
+    <p>We use your information to:</p>
+    <ul>
+      <li>Create and manage your account and match owners with suitable carers.</li>
+      <li>Enable and manage bookings, meet &amp; greets, messaging, check-ins and live walk tracking.</li>
+      <li>Vet carers and keep the Truffl community safe.</li>
+      <li>Send you service messages — booking confirmations, updates, reminders and safety notices.</li>
+      <li>Respond to your questions and handle any concerns or disputes.</li>
+      <li>Understand how Truffl is used so we can improve it, keep it secure, and prevent misuse.</li>
+      <li>Meet our legal obligations.</li>
+    </ul>
+
+    <h2 id="location">3. Location &amp; GPS</h2>
+    <p>Live location is central to how Truffl gives owners peace of mind. When a carer starts a walk, the carer's device shares its GPS location for the duration of that walk. This lets the owner see where their dog is in real time and review the route once the walk is finished.</p>
+    <ul>
+      <li>Location is collected from the <strong>carer's</strong> device only while a walk is active — not before it starts or after it ends.</li>
+      <li>The route and distance are saved to the booking so the owner can view them afterwards.</li>
+      <li>On mobile, the app will ask for location permission, and you can withdraw it at any time in your device settings. Withdrawing location permission may prevent live tracking from working.</li>
+    </ul>
+
+    <h2 id="sharing">4. Who we share your information with</h2>
+    <p>We do not sell your personal information. We share it only where it is needed to provide the service:</p>
+    <ul>
+      <li><strong>Between owners and carers.</strong> When you book or accept a booking, the other party sees the information they need to provide or receive care — for example a carer sees your pet's details and relevant notes, and you see the carer's profile.</li>
+      <li><strong>Service providers who help us run Truffl.</strong> We use trusted third parties to host data and understand usage:
+        <ul>
+          <li><strong>Supabase</strong> — our database and authentication provider, where your account, booking, message and pet data is stored.</li>
+          <li><strong>Google Analytics</strong> — to understand how the site and apps are used. This uses cookies and similar technologies and processes limited usage and device data.</li>
+        </ul>
+      </li>
+      <li><strong>Where the law requires it,</strong> or to protect the safety of people or animals, or to investigate misuse of Truffl.</li>
+    </ul>
+    <div class="note">
+      <p>Some of these providers may store or process data outside Australia. We take reasonable steps to ensure your information is handled consistently with this policy and the APPs.</p>
+    </div>
+
+    <h2 id="storage">5. Storage &amp; security</h2>
+    <p>Your data is stored with our database provider, Supabase, and protected by access controls so that owners and carers can only see the information relevant to their own account and bookings. We use encryption in transit and apply reasonable technical and organisational measures to protect your information. No system is perfectly secure, so we cannot guarantee absolute security, but we work to protect your data and to respond quickly if something goes wrong.</p>
+
+    <h2 id="retention">6. How long we keep your information</h2>
+    <p>We keep your information while your account is active and for as long as we need it to provide the service, comply with our legal obligations, resolve disputes, and enforce our agreements. When information is no longer needed for these purposes, we delete it or de-identify it. If you close your account, you can ask us to delete your personal information, subject to any records we are required to keep.</p>
+
+    <h2 id="rights">7. Your rights &amp; choices</h2>
+    <p>You can:</p>
+    <ul>
+      <li><strong>Access and correct</strong> most of your account, pet and profile information directly in Truffl.</li>
+      <li><strong>Request a copy</strong> of the personal information we hold about you, or ask us to correct or delete it, by contacting us.</li>
+      <li><strong>Manage notifications</strong> and, on mobile, control location permissions through your device settings.</li>
+      <li><strong>Control analytics cookies</strong> through your browser settings or available opt-out tools.</li>
+    </ul>
+    <p>We will respond to privacy requests within a reasonable time. If you are not satisfied with how we handle a request, you can contact the Office of the Australian Information Commissioner (OAIC) at <a class="inline" href="https://www.oaic.gov.au" target="_blank" rel="noopener">oaic.gov.au</a>.</p>
+
+    <h2 id="children">8. Children</h2>
+    <p>Truffl is intended for adults. We do not knowingly collect personal information from anyone under 18. If you believe a child has provided us with personal information, please contact us and we will delete it.</p>
+
+    <h2 id="changes">9. Changes to this policy</h2>
+    <p>We may update this policy from time to time as Truffl evolves or as the law changes. When we make material changes we will update the date at the top of this page and, where appropriate, let you know in the app or by email. Your continued use of Truffl after a change means you accept the updated policy.</p>
+
+    <h2 id="contact">10. Contact us</h2>
+    <p>If you have a question about this policy or about how we handle your personal information, or you want to make a privacy request, contact us at:</p>
+    <ul>
+      <li><strong>Email:</strong> <a class="inline" href="mailto:privacy@trufflpets.com" data-placeholder="privacy-email">privacy@trufflpets.com</a></li>
+    </ul>
+
+    <p style="margin-top:28px;">See also our <a class="inline" href="/trust-and-safety/">Trust &amp; safety</a> guidance.</p>
+  </article>
+
+  <footer>
+    <a href="/" aria-label="Truffl Pets home">
+      <svg width="130" height="40" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="20" cy="33" r="20" fill="#C4866A" opacity="0.6"/>
+        <text x="20" y="38" font-family="'Cormorant Garamond', Georgia, serif" font-size="14" font-style="italic" fill="#F7F3EE" text-anchor="middle">truffl</text>
+        <text x="52" y="30" font-family="'Cormorant Garamond', Georgia, serif" font-size="32" font-style="italic" fill="#A8978E" letter-spacing="-0.5">truffl</text>
+      </svg>
+    </a>
+    <div class="footer-links">
+      <a href="/register/">For carers</a>
+      <a href="/about-us/">About</a>
+      <a href="/trust-and-safety/">Trust &amp; safety</a>
+      <a href="#">Contact</a>
+      <a href="/privacy/">Privacy</a>
+    </div>
+    <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>
+  </footer>
+</body>
+</html>

--- a/trust-and-safety/choosing-your-carer/index.html
+++ b/trust-and-safety/choosing-your-carer/index.html
@@ -134,7 +134,7 @@
       <a href="/about-us/">About</a>
       <a href="/trust-and-safety/">Trust &amp; safety</a>
       <a href="#">Contact</a>
-      <a href="#">Privacy</a>
+      <a href="/privacy/">Privacy</a>
     </div>
     <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>
   </footer>

--- a/trust-and-safety/following-along-with-gps/index.html
+++ b/trust-and-safety/following-along-with-gps/index.html
@@ -115,7 +115,7 @@
       <a href="/about-us/">About</a>
       <a href="/trust-and-safety/">Trust &amp; safety</a>
       <a href="#">Contact</a>
-      <a href="#">Privacy</a>
+      <a href="/privacy/">Privacy</a>
     </div>
     <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>
   </footer>

--- a/trust-and-safety/getting-ready/index.html
+++ b/trust-and-safety/getting-ready/index.html
@@ -130,7 +130,7 @@
       <a href="/about-us/">About</a>
       <a href="/trust-and-safety/">Trust &amp; safety</a>
       <a href="#">Contact</a>
-      <a href="#">Privacy</a>
+      <a href="/privacy/">Privacy</a>
     </div>
     <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>
   </footer>

--- a/trust-and-safety/if-something-goes-wrong/index.html
+++ b/trust-and-safety/if-something-goes-wrong/index.html
@@ -139,7 +139,7 @@
       <a href="/about-us/">About</a>
       <a href="/trust-and-safety/">Trust &amp; safety</a>
       <a href="#">Contact</a>
-      <a href="#">Privacy</a>
+      <a href="/privacy/">Privacy</a>
     </div>
     <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>
   </footer>

--- a/trust-and-safety/index.html
+++ b/trust-and-safety/index.html
@@ -158,7 +158,7 @@
       <a href="/about-us/">About</a>
       <a href="/trust-and-safety/">Trust &amp; safety</a>
       <a href="#">Contact</a>
-      <a href="#">Privacy</a>
+      <a href="/privacy/">Privacy</a>
     </div>
     <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>
   </footer>

--- a/trust-and-safety/keeping-it-on-truffl/index.html
+++ b/trust-and-safety/keeping-it-on-truffl/index.html
@@ -115,7 +115,7 @@
       <a href="/about-us/">About</a>
       <a href="/trust-and-safety/">Trust &amp; safety</a>
       <a href="#">Contact</a>
-      <a href="#">Privacy</a>
+      <a href="/privacy/">Privacy</a>
     </div>
     <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>
   </footer>

--- a/trust-and-safety/reporting-a-concern/index.html
+++ b/trust-and-safety/reporting-a-concern/index.html
@@ -117,7 +117,7 @@
       <a href="/about-us/">About</a>
       <a href="/trust-and-safety/">Trust &amp; safety</a>
       <a href="#">Contact</a>
-      <a href="#">Privacy</a>
+      <a href="/privacy/">Privacy</a>
     </div>
     <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>
   </footer>


### PR DESCRIPTION
## What

Adds a `/privacy/` page and wires up the previously-dead "Privacy" footer links across the site. Both app stores hard-require a **live privacy policy URL** before submission ([TRU-57](https://linear.app/truffl-pets/issue/TRU-57), [TRU-58](https://linear.app/truffl-pets/issue/TRU-58)), and the data-collection content also feeds the Apple privacy nutrition label + Google Data Safety form ([TRU-128](https://linear.app/truffl-pets/issue/TRU-128)).

## Changes

- **New `/privacy/index.html`** — static content page in the marketing palette (same nav/footer/article styling as the Trust & safety sub-pages). Sections: information we collect (account, pet, bookings/messages/photos, location/GPS, usage), how we use it, a dedicated Location & GPS section, who we share with, storage & security, retention, rights & choices (APPs), children, changes, contact. Includes an on-page table of contents.
- **Repointed 9 dead `Privacy` links** from `href="#"` → `/privacy/` (`index.html`, `about-us/`, `trust-and-safety/` hub + 6 sub-pages).

## Confirmed with Tom

- Privacy contact: **privacy@trufflpets.com**
- Governing law: **Australian Privacy Act 1988 / APPs**; legal entity name + ABN left as placeholder
- Third parties disclosed: **Supabase** (storage) + **Google Analytics** (gtag, live on every page). Stripe/payments omitted until live.

## Pre-launch placeholders

Tagged with `data-placeholder` (consistent with the existing convention): `legal-entity` (entity name + ABN), `effective-date`, `privacy-email`.

## Testing

Verified in Preview: page renders in palette with no console errors, all 10 TOC anchors present, footer link resolves to `/privacy/`, and the layout collapses correctly on mobile (TOC → 1 column).

🤖 Generated with [Claude Code](https://claude.com/claude-code)