### PR TITLE
TRU-131: fix booking time-window slider rendering as boxed fields

### DIFF
--- a/book/index.html
+++ b/book/index.html
@@ -76,8 +76,9 @@
   .win-wrap { position: relative; height: 34px; margin: 8px 2px 2px; }
   .win-track { position: absolute; top: 15px; left: 0; right: 0; height: 4px; background: var(--border); border-radius: 2px; }
   .win-fill { position: absolute; top: 15px; height: 4px; background: var(--terracotta); border-radius: 2px; }
-  .win-wrap input[type=range] { position: absolute; top: 0; left: 0; width: 100%; height: 34px; margin: 0; background: none; pointer-events: none; -webkit-appearance: none; appearance: none; }
-  .win-wrap input[type=range]:focus { outline: none; }
+  /* Reset the generic .field input styling (border/padding/radius/bg) so the range inputs render as bare sliders, not boxed fields. */
+  .win-wrap input[type=range] { position: absolute; top: 0; left: 0; width: 100%; height: 34px; margin: 0; padding: 0; border: none; border-radius: 0; background: none; pointer-events: none; -webkit-appearance: none; appearance: none; }
+  .win-wrap input[type=range]:focus { outline: none; box-shadow: none; }
   /* Centre the 20px thumb on the 4px track: margin-top = (4 - 20) / 2 = -8px. */
   .win-wrap input[type=range]::-webkit-slider-runnable-track { height: 4px; background: none; }
   .win-wrap input[type=range]::-webkit-slider-thumb { pointer-events: auto; -webkit-appearance: none; width: 20px; height: 20px; border-radius: 50%; background: #fff; border: 2px solid var(--terracotta); cursor: pointer; margin-top: -8px; box-shadow: 0 1px 3px rgba(61,43,31,0.2); }


### PR DESCRIPTION
## Bug

On `/book/?provider=…`, the "Preferred time window" dual-handle slider rendered with an unwanted bordered/rounded box framing the whole track. The same slider on the search filter was fine.

## Cause

The booking page's generic field rule —

```css
.field input, .field select, .field textarea { border: 1px solid var(--border); border-radius: 10px; padding: 10px 14px; background: var(--warm-white); }
```

— applies to **every** input inside a `.field`. The slider's two `<input type=range>` handles live inside a `.field`, and the `.win-wrap input[type=range]` reset only cleared `background` and `appearance` — not `border`, `border-radius` or `padding`. So each full-width range input drew a bordered rounded box, producing the frame.

Search is unaffected because its slider inputs aren't inside a `.field`, so that rule never matches them. (My earlier read that TRU-109 had already fixed this was wrong — TRU-109 only centred the thumbs; the box is a separate issue.)

## Fix

Extend the `.win-wrap input[type=range]` reset to also clear `border`, `border-radius`, `padding`, and the `:focus` box-shadow. The booking slider now matches the search slider: a bare track with two centred thumbs and the terracotta fill between them.

## Testing

Verified in Preview against the booking page's own stylesheet: range inputs now compute `border: 0`, `border-radius: 0`, `padding: 0`, transparent background; the framing box is gone and the slider renders identically to search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)