### PR TITLE
TRU-56: background geolocation on /walk/ (native)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -38,4 +38,11 @@
     <!-- Permissions -->
 
     <uses-permission android:name="android.permission.INTERNET" />
+
+    <!-- Background geolocation during walks (TRU-56) -->
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -45,4 +45,6 @@
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
+    <!-- Keeps the CPU awake so pings continue with the screen off -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 </manifest>

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -47,5 +47,13 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Truffl uses your location during a walk so the pet's owner can follow along live and see the route.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Truffl keeps tracking your location during a walk — even with the screen locked — so the owner can follow along live until you end the walk.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>location</string>
+	</array>
 </dict>
 </plist>

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "run:android": "cap run android"
   },
   "dependencies": {
+    "@capacitor-community/background-geolocation": "^1.2.26",
     "@capacitor/android": "^8.4.1",
     "@capacitor/core": "^8.4.1",
     "@capacitor/ios": "^8.4.1"

--- a/walk/index.html
+++ b/walk/index.html
@@ -181,6 +181,8 @@ const UPDATE_ICONS = {
 let authToken=null, authUid=null;
 let booking=null, walkSession=null, map=null, polyline=null;
 let gpsPoints=[], watchId=null, timerInterval=null, wakeLock=null;
+let bgWatcherId=null, lastPingTs=0;
+const PING_INTERVAL_MS=10000; // native: persist a ping at most every 10s
 let hasComment=false, hasPhoto=false;
 let updates=[];
 let customerName='', petName='', petBreed='';
@@ -287,21 +289,60 @@ function updateMap(lat,lng){
   window._currentMarker=L.circleMarker([lat,lng],{radius:8,color:'#C4755B',fillColor:'#C4755B',fillOpacity:1}).addTo(map);
 }
 
+function isNative(){ return !!(window.Capacitor && typeof window.Capacitor.isNativePlatform==='function' && window.Capacitor.isNativePlatform()); }
+
+// Shared: record one GPS fix — init the map on the first fix, draw it, persist the ping.
+async function recordPing(lat,lng,accuracy){
+  const pt={lat,lng,acc:Math.round(accuracy||0)};
+  if(!map) initMap(pt.lat,pt.lng);
+  gpsPoints.push(pt);
+  updateMap(pt.lat,pt.lng);
+  updateStats();
+  try{
+    await sbInsert('gps_pings',{walk_session_id:walkSession.id,lat:pt.lat,lng:pt.lng,accuracy_metres:pt.acc,recorded_at:new Date().toISOString()});
+  }catch(e){}
+}
+
 async function startGpsTracking(){
+  if(isNative()) return startNativeGpsTracking();
+  // Web fallback — unchanged behaviour (records every fix).
   if(!navigator.geolocation){showMsg('GPS not available on this device.','error');return;}
   watchId=navigator.geolocation.watchPosition(
-    async(pos)=>{
-      const pt={lat:pos.coords.latitude,lng:pos.coords.longitude,acc:Math.round(pos.coords.accuracy)};
-      gpsPoints.push(pt);
-      updateMap(pt.lat,pt.lng);
-      updateStats();
-      try{
-        await sbInsert('gps_pings',{walk_session_id:walkSession.id,lat:pt.lat,lng:pt.lng,accuracy_metres:pt.acc,recorded_at:new Date().toISOString()});
-      }catch(e){}
-    },
+    (pos)=>recordPing(pos.coords.latitude,pos.coords.longitude,pos.coords.accuracy),
     (err)=>{showMsg('GPS error: '+err.message,'error');},
     {enableHighAccuracy:true,maximumAge:5000,timeout:15000}
   );
+}
+
+// Native: keeps tracking with the screen locked / app backgrounded. The plugin streams
+// continuously (distance-filtered), so throttle persisted pings to PING_INTERVAL_MS.
+async function startNativeGpsTracking(){
+  const BG=window.Capacitor.Plugins&&window.Capacitor.Plugins.BackgroundGeolocation;
+  if(!BG){showMsg('GPS not available on this device.','error');return;}
+  try{
+    bgWatcherId=await BG.addWatcher(
+      {
+        backgroundMessage:'Tracking your walk so the owner can follow along live.',
+        backgroundTitle:'Truffl — walk in progress',
+        requestPermissions:true,
+        stale:false,
+        distanceFilter:5
+      },
+      (location,error)=>{
+        if(error){
+          if(error.code==='NOT_AUTHORIZED'){
+            showMsg('Location permission is needed to track the walk. Enable “Always” for Truffl in Settings.','error');
+          }
+          return;
+        }
+        if(!location) return;
+        const now=Date.now();
+        if(now-lastPingTs < PING_INTERVAL_MS) return;
+        lastPingTs=now;
+        recordPing(location.latitude,location.longitude,location.accuracy);
+      }
+    );
+  }catch(e){showMsg('Could not start GPS: '+((e&&e.message)||e),'error');}
 }
 
 async function startWalk(){
@@ -393,6 +434,7 @@ async function endWalk(){
   clearMsg();
   if(!hasComment||!hasPhoto){showMsg('Please add at least one comment/mood and one photo before ending the walk.','error');return;}
   try{
+    if(bgWatcherId!==null){ try{ await window.Capacitor.Plugins.BackgroundGeolocation.removeWatcher({id:bgWatcherId}); }catch(e){} bgWatcherId=null; }
     if(watchId!==null) navigator.geolocation.clearWatch(watchId);
     if(timerInterval) clearInterval(timerInterval);
     if(wakeLock){try{wakeLock.release();}catch(e){}}
@@ -513,7 +555,10 @@ function renderActiveWalk(){
   `;
 
   setTimeout(()=>{
-    if(navigator.geolocation){
+    if(isNative()){
+      // Native fixes come from the plugin watcher; show the map now, it recenters on the first ping.
+      initMap(-33.87,151.21);
+    } else if(navigator.geolocation){
       navigator.geolocation.getCurrentPosition(
         (pos)=>initMap(pos.coords.latitude,pos.coords.longitude),
         ()=>initMap(-33.87,151.21)

--- a/walk/index.html
+++ b/walk/index.html
@@ -484,7 +484,9 @@ function renderPreWalk(){
 
     <div class="gps-notice">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
-      <div><strong>Heads up:</strong> GPS tracking requires this screen to stay open during the walk. Pop your phone in your pocket with the screen on — we'll keep it awake for you. This is how your customer sees the live route.</div>
+      ${isNative()
+        ? `<div><strong>Location permission:</strong> When prompted, choose <strong>"Allow all the time"</strong> so GPS keeps tracking while your screen is locked. If you only see "While using the app", grant that first, then open Settings › Truffl › Location and switch it to "Allow all the time". This is how your customer sees the live route.</div>`
+        : `<div><strong>Heads up:</strong> GPS tracking requires this screen to stay open during the walk. Pop your phone in your pocket with the screen on — we'll keep it awake for you. This is how your customer sees the live route.</div>`}
     </div>
 
     <div class="walk-controls">


### PR DESCRIPTION
## What

When `/walk/` runs inside the Capacitor shell, GPS now continues tracking with the screen locked / app backgrounded, via `@capacitor-community/background-geolocation`. On the web, the existing `navigator.geolocation` behaviour is **unchanged** (the ticket's key constraint).

## Changes

- **`walk/index.html`** — `isNative()` (`window.Capacitor.isNativePlatform()`) branch:
  - **Native:** `BackgroundGeolocation.addWatcher` with `requestPermissions: true` and `distanceFilter`. The plugin streams continuously, so persisted pings are throttled to a **10s interval** (reconciles the ticket's "10s" with the page's `watchPosition` model). `endWalk` removes the watcher; the map initialises immediately and recenters on the first ping (fixes the blank map seen in the bare WebView).
  - **Web:** `watchPosition` path unchanged — records every fix.
  - Shared `recordPing()` does map-init + draw + Supabase insert for both paths.
- **iOS `Info.plist`** — `NSLocationWhenInUseUsageDescription`, `NSLocationAlwaysAndWhenInUseUsageDescription`, `UIBackgroundModes: location`.
- **Android `AndroidManifest.xml`** — fine/coarse/**background** location + `FOREGROUND_SERVICE` / `FOREGROUND_SERVICE_LOCATION`.
- **`package.json`** — add the plugin.

## Verification

- Web: inline scripts parse cleanly; `isNative()` is `false` in the browser, so the unchanged `navigator.geolocation` fallback is used.

## Needs your Mac (TRU-129)

```bash
cd ~/truffl && git pull
npm install        # pulls the new plugin + updates package-lock
npx cap sync
npm run open:ios   # / open:android
```

Then on a **real device** (simulator GPS is faked): start a walk, grant **Always** location, **lock the phone**, and confirm rows keep landing in `gps_pings`. On iOS the permission prompt should request "Always Allow"; on Android, background location.

## Notes

- Universal links / store config remain TRU-57/58. `appId`/`appName` still placeholder pending TRU-128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)