### PR TITLE
TRU-133: active-walk resume overlay (+ completed-walk access)

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -81,6 +81,16 @@
   .tab:hover { color: var(--text-secondary); }
   .tab.active { color: var(--terracotta); border-bottom-color: var(--terracotta); }
 
+  /* Active walk resume bar (TRU-133) */
+  .active-walk-bar { display:flex; align-items:center; gap:14px; background:var(--warm-white); border:1px solid var(--border); border-left:4px solid var(--terracotta); border-radius:14px; padding:14px 16px; margin-bottom:1.25rem; text-decoration:none; color:inherit; transition:box-shadow .2s, transform .15s; }
+  .active-walk-bar:hover { box-shadow:0 6px 18px -8px rgba(61,43,31,.2); transform:translateY(-1px); }
+  .awb-pulse { width:10px; height:10px; border-radius:50%; background:var(--success); flex-shrink:0; animation:awbPulse 1.5s infinite; }
+  @keyframes awbPulse { 0%,100%{opacity:1;} 50%{opacity:.3;} }
+  .awb-text { display:flex; flex-direction:column; flex:1; min-width:0; }
+  .awb-text strong { font-size:.95rem; color:var(--brown); }
+  .awb-sub { font-size:.8rem; color:var(--text-muted); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+  .awb-resume { display:inline-flex; align-items:center; gap:6px; background:var(--terracotta); color:#fff; padding:9px 18px; border-radius:999px; font-size:.85rem; font-weight:600; flex-shrink:0; }
+
   .tab-content { display: none; }
   .tab-content.active { display: block; animation: fadeIn 0.25s ease; }
 
@@ -745,6 +755,8 @@ function renderBookingsTab() {
   const confirmed = bookings.filter(b => b.status === 'confirmed' && !b.is_meet_and_greet);
   // M&G bookings whose series is still awaiting the meet & greet.
   const mgBookings = bookings.filter(b => b.is_meet_and_greet && mgSeriesById[b.series_id]);
+  const inProgress = bookings.filter(b => b.status === 'in_progress');
+  const completedWalks = bookings.filter(b => b.status === 'completed' && !bookingIsStay(b) && !b.is_meet_and_greet);
   const area = document.getElementById('tab-bookings');
 
   let html = '';
@@ -813,7 +825,39 @@ function renderBookingsTab() {
     `).join('');
   }
 
-  if (pending.length === 0 && confirmed.length === 0 && series.length === 0 && mgBookings.length === 0) {
+  if (inProgress.length > 0) {
+    html += `<div class="card-title" style="margin-top:1.5rem;margin-bottom:0.75rem;">In progress</div>`;
+    html += inProgress.map(b => `
+      <div class="booking-card">
+        <div class="bc-info">
+          <div class="bc-customer">${b._customer_name || 'Customer'}</div>
+          <div class="bc-pet">${b._pet_label || 'Pet'}</div>
+          <span class="bc-service">${SERVICE_LABELS[b._service_type] || b._service_type || 'Service'}</span>
+        </div>
+        <div class="bc-actions">
+          <button class="bc-btn start-walk" onclick="window.location.href='/walk/?booking=${b.id}'">Resume walk</button>
+          <button class="bc-btn message" onclick="window.location.href='/messages/?booking=${b.id}'">Message</button>
+        </div>
+      </div>`).join('');
+  }
+
+  if (completedWalks.length > 0) {
+    html += `<div class="card-title" style="margin-top:1.5rem;margin-bottom:0.75rem;">Completed walks (${completedWalks.length})</div>`;
+    html += completedWalks.map(b => `
+      <div class="booking-card">
+        <div class="bc-info">
+          <div class="bc-customer">${b._customer_name || 'Customer'}</div>
+          <div class="bc-pet">${b._pet_label || 'Pet'}</div>
+          <span class="bc-service">${SERVICE_LABELS[b._service_type] || b._service_type || 'Service'}</span>
+          <div class="bc-time">${bookingTimeLine(b)}</div>
+        </div>
+        <div class="bc-actions">
+          <button class="bc-btn message" onclick="window.location.href='/walk/?booking=${b.id}'">View summary</button>
+        </div>
+      </div>`).join('');
+  }
+
+  if (pending.length === 0 && confirmed.length === 0 && series.length === 0 && mgBookings.length === 0 && inProgress.length === 0 && completedWalks.length === 0) {
     html = `<div class="empty"><div class="empty-icon"><svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3.5" y="5" width="17" height="15" rx="2"/><path d="M3.5 9.5h17M8 3v4M16 3v4"/></svg></div>No bookings yet. Once customers book you, their requests will appear here.</div>`;
   }
 
@@ -1077,6 +1121,27 @@ function mgOverlay(html) {
 }
 function closeMgOverlay() { const o = document.getElementById('mgOverlay'); if (o) o.remove(); }
 
+/* Persistent "active walk" overlay so a carer can always get back into an
+   in-progress walk after leaving it / reopening the app (TRU-133). */
+function activeWalkBarHtml() {
+  const active = bookings.filter(b => b.status === 'in_progress');
+  if (!active.length) return '';
+  return active.map(b => {
+    const sub = [b._pet_label, b._customer_name].filter(Boolean).join(' · ') || 'Tap to resume';
+    return `
+    <a class="active-walk-bar" href="/walk/?booking=${b.id}">
+      <span class="awb-pulse"></span>
+      <span class="awb-text">
+        <strong>Walk in progress</strong>
+        <span class="awb-sub">${esc(sub)}</span>
+      </span>
+      <span class="awb-resume">Resume
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+      </span>
+    </a>`;
+  }).join('');
+}
+
 function renderDashboard() {
   const initials = ((userData.first_name||'')[0]||'') + ((userData.last_name||'')[0]||'');
   document.getElementById('navUser').innerHTML = `<a href="/profile/" title="Your profile" style="display:flex;align-items:center;gap:8px;text-decoration:none;color:inherit;"><div class="nav-avatar">${initials}</div><span class="nav-name">${userData.first_name}</span></a>`;
@@ -1091,6 +1156,8 @@ function renderDashboard() {
       <h1>Hey, ${userData.first_name}</h1>
       <p>${pending.length > 0 ? `You have ${pending.length} new booking request${pending.length !== 1 ? 's' : ''}` : 'Your dashboard — manage bookings, services, and your profile.'}</p>
     </div>
+
+    ${activeWalkBarHtml()}
 
     ${ackGateBannerHtml()}
 


### PR DESCRIPTION
## Bug fixed

A carer who left an in-progress walk — or whose app reopened to the dashboard after being backgrounded — had **no way back into the active walk**, so walks got stuck `in_progress` and couldn't be completed (hit during TRU-56 testing; 3 walks left stuck).

> Scope: this PR fixes **only** the resume/active-walk bug from TRU-133. The other items in that ticket (remove search, bespoke home, side nav, carer-feature optimisation) are deliberately untouched.

## Changes (`dashboard/index.html`)

- **Persistent "Walk in progress" overlay bar** at the top of the dashboard that resumes any `in_progress` walk → `/walk/?booking=…`. Lives outside the tab content, so it's visible on every tab. Shows pet + customer.
- **"In progress" section** in the Bookings tab with a **Resume walk** button (belt-and-suspenders with the bar).
- **"Completed walks" section** with a **View summary** link, so finished walks are reachable too (the "access completed ones as well" part of the bug).
- Empty-state check updated so these new sections aren't wiped.

The dashboard is served to both the website and the native app (remote WebView), so this fixes both surfaces at once, as the ticket noted.

## Verification

Signed in as a provider with 2 in-progress + 2 completed walks (screenshot): the overlay bars render and link to the right `/walk/?booking=…`, the In progress / Completed walks sections appear, no console errors. Mobile-width layout intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)