### PR TITLE
TRU-117: 5 transactional email templates

### DIFF
--- a/emails/emails/booking-confirmed.tsx
+++ b/emails/emails/booking-confirmed.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { TrufflEmailLayout, Heading, Paragraph, Details } from '../components/TrufflEmailLayout';
+
+// Trigger: a provider accepts a booking → sent to the customer.
+interface Props {
+  customerName?: string;
+  carerName?: string;
+  petName?: string;
+  serviceLabel?: string;
+  whenText?: string;
+  bookingUrl?: string;
+}
+
+export default function BookingConfirmed({
+  customerName = 'Sarah',
+  carerName = 'Olivia W.',
+  petName = 'Biscuit',
+  serviceLabel = 'Dog walking · 30 min',
+  whenText = 'Tomorrow, 9:00–9:30 AM',
+  bookingUrl = 'https://trufflpets.com/track/',
+}: Props) {
+  return (
+    <TrufflEmailLayout
+      preview={`Your booking with ${carerName} is confirmed`}
+      cta={{ label: 'View booking', href: bookingUrl }}
+      footnote="You're receiving this because you have a booking with Truffl Pets."
+    >
+      <Heading>Your booking is confirmed</Heading>
+      <Paragraph>
+        Hi {customerName}, good news — {carerName} has confirmed your booking for {petName}.
+        Here are the details:
+      </Paragraph>
+      <Details
+        rows={[
+          ['Service', serviceLabel],
+          ['Carer', carerName],
+          ['Pet', petName],
+          ['When', whenText],
+        ]}
+      />
+      <Paragraph>
+        We'll let you know the moment the walk starts so you can follow along live.
+      </Paragraph>
+    </TrufflEmailLayout>
+  );
+}

--- a/emails/emails/booking-request.tsx
+++ b/emails/emails/booking-request.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { TrufflEmailLayout, Heading, Paragraph, Details } from '../components/TrufflEmailLayout';
+
+// Trigger: a customer requests a booking → sent to the provider.
+interface Props {
+  carerName?: string;
+  customerName?: string;
+  petName?: string;
+  serviceLabel?: string;
+  whenText?: string;
+  dashboardUrl?: string;
+}
+
+export default function BookingRequest({
+  carerName = 'Olivia',
+  customerName = 'Sarah',
+  petName = 'Biscuit',
+  serviceLabel = 'Dog walking · 30 min',
+  whenText = 'Tomorrow, 9:00–9:30 AM',
+  dashboardUrl = 'https://trufflpets.com/dashboard/',
+}: Props) {
+  return (
+    <TrufflEmailLayout
+      preview={`New booking request from ${customerName}`}
+      cta={{ label: 'Review request', href: dashboardUrl }}
+      footnote="You're receiving this because you're a carer on Truffl Pets. Responding promptly helps you win the booking."
+    >
+      <Heading>You have a new booking request</Heading>
+      <Paragraph>
+        Hi {carerName}, {customerName} would like to book you for {petName}. Have a look and
+        accept it from your dashboard:
+      </Paragraph>
+      <Details
+        rows={[
+          ['Customer', customerName],
+          ['Pet', petName],
+          ['Service', serviceLabel],
+          ['When', whenText],
+        ]}
+      />
+      <Paragraph>The sooner you respond, the better the experience for the owner.</Paragraph>
+    </TrufflEmailLayout>
+  );
+}

--- a/emails/emails/new-message.tsx
+++ b/emails/emails/new-message.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { TrufflEmailLayout, Heading, Paragraph } from '../components/TrufflEmailLayout';
+
+// Trigger: a new message is sent → sent to the other party (owner or carer).
+interface Props {
+  recipientName?: string;
+  senderName?: string;
+  snippet?: string;
+  messagesUrl?: string;
+}
+
+export default function NewMessage({
+  recipientName = 'Sarah',
+  senderName = 'Olivia',
+  snippet = 'Hi! Just checking which gate you’d like me to use for pickup tomorrow?',
+  messagesUrl = 'https://trufflpets.com/messages/',
+}: Props) {
+  return (
+    <TrufflEmailLayout
+      preview={`New message from ${senderName}`}
+      cta={{ label: 'Reply in Truffl', href: messagesUrl }}
+      footnote="You're receiving this because you have an active conversation on Truffl Pets. Please keep messages on Truffl so there's a record."
+    >
+      <Heading>New message from {senderName}</Heading>
+      <Paragraph>Hi {recipientName}, you have a new message:</Paragraph>
+      <Paragraph>
+        <em style={{ color: '#5C4033' }}>“{snippet}”</em>
+      </Paragraph>
+      <Paragraph>Reply directly in your Truffl messages to keep everything in one place.</Paragraph>
+    </TrufflEmailLayout>
+  );
+}

--- a/emails/emails/walk-completed.tsx
+++ b/emails/emails/walk-completed.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { TrufflEmailLayout, Heading, Paragraph, Details } from '../components/TrufflEmailLayout';
+
+// Trigger: a carer ends a walk → sent to BOTH the customer and the carer.
+// `forCarer` switches the wording for the carer's copy.
+interface Props {
+  recipientName?: string;
+  otherName?: string; // the carer (for the owner) or the owner (for the carer)
+  petName?: string;
+  distanceText?: string;
+  durationText?: string;
+  summaryUrl?: string;
+  forCarer?: boolean;
+}
+
+export default function WalkCompleted({
+  recipientName = 'Sarah',
+  otherName = 'Olivia',
+  petName = 'Biscuit',
+  distanceText = '2.4 km',
+  durationText = '32 min',
+  summaryUrl = 'https://trufflpets.com/track/',
+  forCarer = false,
+}: Props) {
+  return (
+    <TrufflEmailLayout
+      preview={`${petName}'s walk is complete`}
+      cta={{ label: 'See the walk', href: summaryUrl }}
+      footnote="You're receiving this because a walk on your booking has finished."
+    >
+      <Heading>{petName}'s walk is complete</Heading>
+      <Paragraph>
+        Hi {recipientName},{' '}
+        {forCarer
+          ? `nice work — you've wrapped up ${petName}'s walk. Here's the summary the owner sees:`
+          : `${otherName} has brought ${petName} home safe and sound. Here's how the walk went:`}
+      </Paragraph>
+      <Details
+        rows={[
+          ['Pet', petName],
+          [forCarer ? 'Owner' : 'Carer', otherName],
+          ['Distance', distanceText],
+          ['Duration', durationText],
+        ]}
+      />
+      <Paragraph>
+        {forCarer
+          ? 'Thanks for the great care.'
+          : 'You can view the full route and any photos from the walk anytime.'}
+      </Paragraph>
+    </TrufflEmailLayout>
+  );
+}

--- a/emails/emails/walk-started.tsx
+++ b/emails/emails/walk-started.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { TrufflEmailLayout, Heading, Paragraph } from '../components/TrufflEmailLayout';
+
+// Trigger: a carer starts a walk → sent to the customer.
+interface Props {
+  customerName?: string;
+  carerName?: string;
+  petName?: string;
+  trackUrl?: string;
+}
+
+export default function WalkStarted({
+  customerName = 'Sarah',
+  carerName = 'Olivia',
+  petName = 'Biscuit',
+  trackUrl = 'https://trufflpets.com/track/',
+}: Props) {
+  return (
+    <TrufflEmailLayout
+      preview={`${carerName} has started ${petName}'s walk`}
+      cta={{ label: 'Follow along live', href: trackUrl }}
+      footnote="You're receiving this because a walk is in progress for your booking."
+    >
+      <Heading>{petName}'s walk has started</Heading>
+      <Paragraph>
+        Hi {customerName}, {carerName} has just set off with {petName}. You can watch the route
+        live on the map and you'll see photo updates along the way.
+      </Paragraph>
+      <Paragraph>We'll send a summary once they're safely home.</Paragraph>
+    </TrufflEmailLayout>
+  );
+}

--- a/emails/send.mjs
+++ b/emails/send.mjs
@@ -1,20 +1,23 @@
 /**
- * Send a rendered Truffl email to one or more inboxes via the Resend API.
+ * Send rendered Truffl email(s) to one or more inboxes via the Resend API.
  *
- *   RESEND_API_KEY=re_xxx npm run send
+ *   RESEND_API_KEY=re_xxx npm run send                      # the layout preview
+ *   EMAIL_TEMPLATE=booking-confirmed ... npm run send       # one template
+ *   EMAIL_TEMPLATE=all ... npm run send                     # every exported template
+ *   node send.mjs booking-confirmed                         # one template (arg form)
  *
- * `npm run send` runs `email export` first, so out/layout-preview.html is fresh.
- * Override the sender or recipients with env vars if needed:
- *   EMAIL_FROM="Truffl Pets <hello@trufflpets.com>"
- *   EMAIL_TO="a@x.com,b@y.com"
+ * `npm run send` runs `email export` first so out/*.html is fresh.
+ * Override sender/recipients:
+ *   EMAIL_FROM="Truffl Pets <hello@trufflpets.com>"   EMAIL_TO="a@x.com,b@y.com"
  *
  * Sender must be on the Resend-verified domain (trufflpets.com — TRU-113).
  */
-import { readFile } from 'node:fs/promises';
+import { readFile, readdir } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = join(__dirname, 'out');
 
 const API_KEY = process.env.RESEND_API_KEY;
 if (!API_KEY) {
@@ -26,24 +29,41 @@ const FROM = process.env.EMAIL_FROM || 'Truffl Pets <hello@trufflpets.com>';
 const RECIPIENTS = (process.env.EMAIL_TO ||
   'tom_farmery@hotmail.co.uk,tomfarmery17@googlemail.com')
   .split(',').map(s => s.trim()).filter(Boolean);
-const SUBJECT = process.env.EMAIL_SUBJECT || 'Truffl email test';
 
-// Which exported template to send, e.g. EMAIL_TEMPLATE=booking-confirmed npm run send
-// (or `node send.mjs booking-confirmed`). Defaults to the layout preview.
-const TEMPLATE = process.env.EMAIL_TEMPLATE || process.argv[2] || 'layout-preview';
-const html = await readFile(join(__dirname, 'out', `${TEMPLATE}.html`), 'utf8');
-console.log(`Sending template: ${TEMPLATE}`);
+// Per-template subject lines (falls back to a generic one).
+const SUBJECTS = {
+  'booking-request': 'New booking request (Truffl test)',
+  'booking-confirmed': 'Your booking is confirmed (Truffl test)',
+  'walk-started': "Your dog's walk has started (Truffl test)",
+  'walk-completed': "Your dog's walk is complete (Truffl test)",
+  'new-message': 'New message (Truffl test)',
+  'layout-preview': 'Truffl email test',
+};
 
-let ok = 0;
-for (const to of RECIPIENTS) {
-  const res = await fetch('https://api.resend.com/emails', {
-    method: 'POST',
-    headers: { Authorization: `Bearer ${API_KEY}`, 'Content-Type': 'application/json' },
-    body: JSON.stringify({ from: FROM, to, subject: SUBJECT, html }),
-  });
-  const data = await res.json().catch(() => ({}));
-  if (res.ok) { console.log(`✓ sent to ${to}  (id ${data.id})`); ok++; }
-  else console.error(`✗ failed for ${to}: ${res.status} ${JSON.stringify(data)}`);
+const selected = process.env.EMAIL_TEMPLATE || process.argv[2] || 'layout-preview';
+let templates;
+if (selected === 'all') {
+  templates = (await readdir(OUT_DIR)).filter(f => f.endsWith('.html')).map(f => f.replace(/\.html$/, ''));
+} else {
+  templates = [selected];
 }
-console.log(`\nDone — ${ok}/${RECIPIENTS.length} sent.`);
-process.exit(ok === RECIPIENTS.length ? 0 : 1);
+
+let ok = 0, total = 0;
+for (const tpl of templates) {
+  const html = await readFile(join(OUT_DIR, `${tpl}.html`), 'utf8');
+  const subject = process.env.EMAIL_SUBJECT || SUBJECTS[tpl] || `Truffl: ${tpl}`;
+  console.log(`\n● ${tpl}`);
+  for (const to of RECIPIENTS) {
+    total++;
+    const res = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${API_KEY}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ from: FROM, to, subject, html }),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (res.ok) { console.log(`  ✓ ${to}  (id ${data.id})`); ok++; }
+    else console.error(`  ✗ ${to}: ${res.status} ${JSON.stringify(data)}`);
+  }
+}
+console.log(`\nDone — ${ok}/${total} sent across ${templates.length} template(s).`);
+process.exit(ok === total ? 0 : 1);

--- a/emails/send.mjs
+++ b/emails/send.mjs
@@ -26,9 +26,13 @@ const FROM = process.env.EMAIL_FROM || 'Truffl Pets <hello@trufflpets.com>';
 const RECIPIENTS = (process.env.EMAIL_TO ||
   'tom_farmery@hotmail.co.uk,tomfarmery17@googlemail.com')
   .split(',').map(s => s.trim()).filter(Boolean);
-const SUBJECT = process.env.EMAIL_SUBJECT || 'Your booking is confirmed (Truffl email test)';
+const SUBJECT = process.env.EMAIL_SUBJECT || 'Truffl email test';
 
-const html = await readFile(join(__dirname, 'out', 'layout-preview.html'), 'utf8');
+// Which exported template to send, e.g. EMAIL_TEMPLATE=booking-confirmed npm run send
+// (or `node send.mjs booking-confirmed`). Defaults to the layout preview.
+const TEMPLATE = process.env.EMAIL_TEMPLATE || process.argv[2] || 'layout-preview';
+const html = await readFile(join(__dirname, 'out', `${TEMPLATE}.html`), 'utf8');
+console.log(`Sending template: ${TEMPLATE}`);
 
 let ok = 0;
 for (const to of RECIPIENTS) {

--- a/emails/send.mjs
+++ b/emails/send.mjs
@@ -48,6 +48,22 @@ if (selected === 'all') {
   templates = [selected];
 }
 
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+// Resend free tier allows 2 requests/sec, so pace sends and retry on 429.
+async function sendOne(payload) {
+  for (let attempt = 0; attempt < 4; attempt++) {
+    const res = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${API_KEY}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (res.status !== 429) return res;
+    await sleep(1200 * (attempt + 1)); // back off, then retry
+  }
+  return null;
+}
+
 let ok = 0, total = 0;
 for (const tpl of templates) {
   const html = await readFile(join(OUT_DIR, `${tpl}.html`), 'utf8');
@@ -55,14 +71,11 @@ for (const tpl of templates) {
   console.log(`\n● ${tpl}`);
   for (const to of RECIPIENTS) {
     total++;
-    const res = await fetch('https://api.resend.com/emails', {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${API_KEY}`, 'Content-Type': 'application/json' },
-      body: JSON.stringify({ from: FROM, to, subject, html }),
-    });
-    const data = await res.json().catch(() => ({}));
-    if (res.ok) { console.log(`  ✓ ${to}  (id ${data.id})`); ok++; }
-    else console.error(`  ✗ ${to}: ${res.status} ${JSON.stringify(data)}`);
+    const res = await sendOne({ from: FROM, to, subject, html });
+    const data = res ? await res.json().catch(() => ({})) : {};
+    if (res && res.ok) { console.log(`  ✓ ${to}  (id ${data.id})`); ok++; }
+    else console.error(`  ✗ ${to}: ${res ? res.status : 'rate-limited'} ${JSON.stringify(data)}`);
+    await sleep(600); // stay under 2 req/sec
   }
 }
 console.log(`\nDone — ${ok}/${total} sent across ${templates.length} template(s).`);


### PR DESCRIPTION
## What

The five transactional notification templates, built on the shared `TrufflEmailLayout` (TRU-116). Each is a thin, typed component with sensible default props so it renders a realistic example in the preview/export.

| Template | Trigger → recipient |
|---|---|
| `booking-request` | customer requests → **provider** |
| `booking-confirmed` | provider accepts → **customer** |
| `walk-started` | carer starts walk → **customer** |
| `walk-completed` | carer ends walk → **customer + carer** (`forCarer` copy switch; distance/duration) |
| `new-message` | message sent → **recipient** (snippet + reply CTA) |

Plain transactional copy in the Truffl voice; dynamic data (names, pet, times, links) via props; rendered to HTML through the shared `renderEmail` helper for the eventual send.

## Testing helper

`send.mjs` is now **template-aware** — fire any template to a real inbox for cross-client checks:

```bash
cd emails
EMAIL_TEMPLATE=booking-confirmed RESEND_API_KEY=re_xxx npm run send
```

(Defaults still go to your two test addresses; override with `EMAIL_TO`.)

## Verification

`npx email export` renders all five to HTML with no errors; visual check confirms on-brand rendering (Georgia fallback, terracotta CTA, details table) — see screenshot.

## Note

There's a stray empty `emails/avoids/` directory already on `main` (not from this PR) — harmless, but worth removing in a tidy-up.

## Next

- TRU-118 — sending pipeline (Supabase trigger → Edge Function → Resend) calling `renderEmail` on these.
- TRU-119 — auth email rebrand on the same layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)