### PR TITLE
TRU-56: native Android walk tracking (background-proof GPS upload)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -33,6 +33,12 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths"></meta-data>
         </provider>
+
+        <!-- Native walk-tracking foreground service (TRU-56) -->
+        <service
+            android:name=".WalkTrackingService"
+            android:exported="false"
+            android:foregroundServiceType="location" />
     </application>
 
     <!-- Permissions -->

--- a/android/app/src/main/java/com/trufflpets/app/MainActivity.java
+++ b/android/app/src/main/java/com/trufflpets/app/MainActivity.java
@@ -1,5 +1,13 @@
 package com.trufflpets.app;
 
+import android.os.Bundle;
+
 import com.getcapacitor.BridgeActivity;
 
-public class MainActivity extends BridgeActivity {}
+public class MainActivity extends BridgeActivity {
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    registerPlugin(WalkTrackerPlugin.class);
+    super.onCreate(savedInstanceState);
+  }
+}

--- a/android/app/src/main/java/com/trufflpets/app/WalkTrackerPlugin.java
+++ b/android/app/src/main/java/com/trufflpets/app/WalkTrackerPlugin.java
@@ -1,0 +1,55 @@
+package com.trufflpets.app;
+
+import android.content.Intent;
+import android.os.Build;
+
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+/**
+ * TRU-56: native background walk tracking.
+ *
+ * The web page's JS is throttled/suspended when the screen is off or the app is
+ * backgrounded, so persisting GPS pings from JS is unreliable. This plugin runs a
+ * foreground service that collects locations and POSTs them to Supabase from native
+ * code, independent of the WebView — so tracking continues with the app off-screen.
+ */
+@CapacitorPlugin(name = "TrufflWalkTracker")
+public class WalkTrackerPlugin extends Plugin {
+
+  @PluginMethod
+  public void start(PluginCall call) {
+    String supabaseUrl = call.getString("supabaseUrl");
+    String anonKey = call.getString("anonKey");
+    String accessToken = call.getString("accessToken");
+    String walkSessionId = call.getString("walkSessionId");
+    Integer intervalMs = call.getInt("intervalMs", 10000);
+
+    if (supabaseUrl == null || anonKey == null || accessToken == null || walkSessionId == null) {
+      call.reject("Missing required tracking config (supabaseUrl, anonKey, accessToken, walkSessionId)");
+      return;
+    }
+
+    Intent intent = new Intent(getContext(), WalkTrackingService.class);
+    intent.putExtra("supabaseUrl", supabaseUrl);
+    intent.putExtra("anonKey", anonKey);
+    intent.putExtra("accessToken", accessToken);
+    intent.putExtra("walkSessionId", walkSessionId);
+    intent.putExtra("intervalMs", intervalMs);
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      getContext().startForegroundService(intent);
+    } else {
+      getContext().startService(intent);
+    }
+    call.resolve();
+  }
+
+  @PluginMethod
+  public void stop(PluginCall call) {
+    getContext().stopService(new Intent(getContext(), WalkTrackingService.class));
+    call.resolve();
+  }
+}

--- a/android/app/src/main/java/com/trufflpets/app/WalkTrackingService.java
+++ b/android/app/src/main/java/com/trufflpets/app/WalkTrackingService.java
@@ -1,0 +1,168 @@
+package com.trufflpets.app;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.ServiceInfo;
+import android.location.Location;
+import android.location.LocationListener;
+import android.location.LocationManager;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.IBinder;
+import android.os.Looper;
+
+import androidx.annotation.Nullable;
+import androidx.core.app.NotificationCompat;
+
+import org.json.JSONObject;
+
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Foreground service that collects GPS fixes and uploads each as a gps_pings row to
+ * Supabase from native code, so tracking survives the screen being off / the app
+ * being backgrounded (where the WebView's JS is suspended). See WalkTrackerPlugin.
+ */
+public class WalkTrackingService extends Service implements LocationListener {
+
+  private static final String CHANNEL_ID = "truffl_walk_tracking";
+  private static final int NOTIF_ID = 4201;
+
+  private LocationManager locationManager;
+  private ExecutorService executor;
+  private String supabaseUrl, anonKey, accessToken, walkSessionId;
+  private long intervalMs = 10000;
+  private long lastSent = 0;
+
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    executor = Executors.newSingleThreadExecutor();
+    locationManager = (LocationManager) getSystemService(Context.LOCATION_SERVICE);
+  }
+
+  @Override
+  public int onStartCommand(Intent intent, int flags, int startId) {
+    if (intent != null) {
+      supabaseUrl = intent.getStringExtra("supabaseUrl");
+      anonKey = intent.getStringExtra("anonKey");
+      accessToken = intent.getStringExtra("accessToken");
+      walkSessionId = intent.getStringExtra("walkSessionId");
+      intervalMs = intent.getIntExtra("intervalMs", 10000);
+    }
+    startForegroundWithNotification();
+    requestLocationUpdates();
+    return START_STICKY;
+  }
+
+  private void startForegroundWithNotification() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      NotificationChannel channel = new NotificationChannel(
+        CHANNEL_ID, "Walk tracking", NotificationManager.IMPORTANCE_LOW);
+      NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+      if (nm != null) nm.createNotificationChannel(channel);
+    }
+    Notification notification = new NotificationCompat.Builder(this, CHANNEL_ID)
+      .setContentTitle("Truffl — walk in progress")
+      .setContentText("Tracking the walk so the owner can follow along live.")
+      .setSmallIcon(android.R.drawable.ic_menu_mylocation)
+      .setOngoing(true)
+      .build();
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) { // API 34+
+      startForeground(NOTIF_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION);
+    } else {
+      startForeground(NOTIF_ID, notification);
+    }
+  }
+
+  private void requestLocationUpdates() {
+    try {
+      if (locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)) {
+        locationManager.requestLocationUpdates(
+          LocationManager.GPS_PROVIDER, intervalMs, 0, this, Looper.getMainLooper());
+      }
+      if (locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER)) {
+        locationManager.requestLocationUpdates(
+          LocationManager.NETWORK_PROVIDER, intervalMs, 0, this, Looper.getMainLooper());
+      }
+    } catch (SecurityException e) {
+      // Location permission not granted — nothing we can do here.
+    }
+  }
+
+  @Override
+  public void onLocationChanged(Location location) {
+    long now = System.currentTimeMillis();
+    if (now - lastSent < intervalMs) return; // throttle to the configured cadence
+    lastSent = now;
+    postPing(location.getLatitude(), location.getLongitude(), location.getAccuracy());
+  }
+
+  private void postPing(final double lat, final double lng, final float accuracy) {
+    executor.execute(() -> {
+      HttpURLConnection conn = null;
+      try {
+        URL url = new URL(supabaseUrl + "/rest/v1/gps_pings");
+        conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("POST");
+        conn.setRequestProperty("Content-Type", "application/json");
+        conn.setRequestProperty("apikey", anonKey);
+        conn.setRequestProperty("Authorization", "Bearer " + accessToken);
+        conn.setRequestProperty("Prefer", "return=minimal");
+        conn.setConnectTimeout(15000);
+        conn.setReadTimeout(15000);
+        conn.setDoOutput(true);
+
+        SimpleDateFormat iso = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
+        iso.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        JSONObject body = new JSONObject();
+        body.put("walk_session_id", walkSessionId);
+        body.put("lat", lat);
+        body.put("lng", lng);
+        body.put("accuracy_metres", Math.round(accuracy));
+        body.put("recorded_at", iso.format(new Date()));
+
+        OutputStream os = conn.getOutputStream();
+        os.write(body.toString().getBytes("UTF-8"));
+        os.flush();
+        os.close();
+
+        conn.getResponseCode(); // execute the request
+      } catch (Exception e) {
+        // Swallow — the next fix will produce another ping; we don't crash the service.
+      } finally {
+        if (conn != null) conn.disconnect();
+      }
+    });
+  }
+
+  @Override
+  public void onDestroy() {
+    try { if (locationManager != null) locationManager.removeUpdates(this); } catch (Exception e) {}
+    if (executor != null) executor.shutdown();
+    super.onDestroy();
+  }
+
+  @Nullable
+  @Override
+  public IBinder onBind(Intent intent) { return null; }
+
+  // Required for older LocationListener signatures.
+  @Override public void onStatusChanged(String provider, int status, Bundle extras) {}
+  @Override public void onProviderEnabled(String provider) {}
+  @Override public void onProviderDisabled(String provider) {}
+}

--- a/walk/index.html
+++ b/walk/index.html
@@ -181,7 +181,7 @@ const UPDATE_ICONS = {
 let authToken=null, authUid=null;
 let booking=null, walkSession=null, map=null, polyline=null;
 let gpsPoints=[], watchId=null, timerInterval=null, wakeLock=null;
-let bgWatcherId=null, lastPingTs=0;
+let bgWatcherId=null, lastPingTs=0, nativeTracking=false;
 const PING_INTERVAL_MS=10000; // native: persist a ping at most every 10s
 let hasComment=false, hasPhoto=false;
 let updates=[];
@@ -298,6 +298,9 @@ async function recordPing(lat,lng,accuracy){
   gpsPoints.push(pt);
   updateMap(pt.lat,pt.lng);
   updateStats();
+  // When the native service is tracking, it persists pings from native code (survives
+  // backgrounding) — JS here only drives the live map, so skip the DB write to avoid dupes.
+  if(nativeTracking) return;
   try{
     await sbInsert('gps_pings',{walk_session_id:walkSession.id,lat:pt.lat,lng:pt.lng,accuracy_metres:pt.acc,recorded_at:new Date().toISOString()});
   }catch(e){}
@@ -314,35 +317,34 @@ async function startGpsTracking(){
   );
 }
 
-// Native: keeps tracking with the screen locked / app backgrounded. The plugin streams
-// continuously (distance-filtered), so throttle persisted pings to PING_INTERVAL_MS.
+// Native: a foreground service (TrufflWalkTracker) uploads pings to Supabase from native
+// code, so tracking continues with the screen off / app backgrounded — where the WebView's
+// JS is suspended and can't be relied on. The JS watchPosition below only drives the live
+// map while the app is on-screen (recordPing skips the DB write when nativeTracking is on).
 async function startNativeGpsTracking(){
-  const BG=window.Capacitor.Plugins&&window.Capacitor.Plugins.BackgroundGeolocation;
-  if(!BG){showMsg('GPS not available on this device.','error');return;}
-  try{
-    bgWatcherId=await BG.addWatcher(
-      {
-        backgroundMessage:'Tracking your walk so the owner can follow along live.',
-        backgroundTitle:'Truffl — walk in progress',
-        requestPermissions:true,
-        stale:false,
-        distanceFilter:5
-      },
-      (location,error)=>{
-        if(error){
-          if(error.code==='NOT_AUTHORIZED'){
-            showMsg('Location permission is needed to track the walk. Enable “Always” for Truffl in Settings.','error');
-          }
-          return;
-        }
-        if(!location) return;
-        const now=Date.now();
-        if(now-lastPingTs < PING_INTERVAL_MS) return;
-        lastPingTs=now;
-        recordPing(location.latitude,location.longitude,location.accuracy);
-      }
+  const T = window.Capacitor.Plugins && window.Capacitor.Plugins.TrufflWalkTracker;
+  if(T){
+    try{
+      await T.start({
+        supabaseUrl: SUPABASE_URL,
+        anonKey: SUPABASE_ANON_KEY,
+        accessToken: authToken,
+        walkSessionId: walkSession.id,
+        intervalMs: PING_INTERVAL_MS
+      });
+      nativeTracking = true;
+    }catch(e){ showMsg('Could not start background tracking: '+((e&&e.message)||e),'error'); }
+  }
+  // Live map while on-screen. If the native plugin isn't available (e.g. iOS or an
+  // un-synced build), nativeTracking stays false and recordPing persists from JS as a
+  // foreground-only fallback so the walk still works.
+  if(navigator.geolocation){
+    watchId=navigator.geolocation.watchPosition(
+      (pos)=>recordPing(pos.coords.latitude,pos.coords.longitude,pos.coords.accuracy),
+      ()=>{},
+      {enableHighAccuracy:true,maximumAge:5000,timeout:15000}
     );
-  }catch(e){showMsg('Could not start GPS: '+((e&&e.message)||e),'error');}
+  }
 }
 
 async function startWalk(){
@@ -434,7 +436,8 @@ async function endWalk(){
   clearMsg();
   if(!hasComment||!hasPhoto){showMsg('Please add at least one comment/mood and one photo before ending the walk.','error');return;}
   try{
-    if(bgWatcherId!==null){ try{ await window.Capacitor.Plugins.BackgroundGeolocation.removeWatcher({id:bgWatcherId}); }catch(e){} bgWatcherId=null; }
+    try{ const T=window.Capacitor&&window.Capacitor.Plugins&&window.Capacitor.Plugins.TrufflWalkTracker; if(T) await T.stop(); }catch(e){}
+    nativeTracking=false;
     if(watchId!==null) navigator.geolocation.clearWatch(watchId);
     if(timerInterval) clearInterval(timerInterval);
     if(wakeLock){try{wakeLock.release();}catch(e){}}


### PR DESCRIPTION
## Why

On-device testing (see TRU-56 thread) showed JS-based ping upload **stops when the screen is off or the app is backgrounded** — Android suspends the WebView's JS, so the `fetch()` that saved pings never ran. Result: sparse pings + half the route missing. Fix: **upload from native code** (Option B).

## What

- **`WalkTrackerPlugin` (Java)** + **`WalkTrackingService`** — a custom Capacitor plugin running a **foreground service** that gets GPS fixes via `LocationManager` and **POSTs each to the Supabase `gps_pings` REST endpoint via `HttpURLConnection`**, entirely in native code. Independent of the WebView, so it keeps tracking with the app off-screen. Throttled to the configured interval (10s).
- Registered in `MainActivity`; `<service android:foregroundServiceType="location">` added to the manifest (location permissions already present from earlier).
- **`walk/index.html`** — the native path now calls `TrufflWalkTracker.start/stop` for persistence. The JS `watchPosition` is kept **only to drive the live map while on-screen**; `recordPing` skips the DB write when `nativeTracking` is on (no duplicate pings). If the plugin isn't present (iOS, or an un-synced build), it falls back to JS foreground-only so nothing breaks.

## Scope / honesty

- **Android only.** iOS still uses the JS foreground-only fallback — iOS background upload is a follow-up (iOS is more forgiving, and may be served by a native `CLLocationManager` equivalent or the community plugin).
- **Not testable in CI / by me** — this is native Kotlin/Java that needs a real device. Expect a possible iteration pass.

## How to test (Android device)

1. **Merge this PR** (the `walk/` change must be live, since the app loads the remote site) → wait for Pages deploy.
2. **Rebuild the app from `main`:** `npm install` (no-op) → `npx cap sync android` → run from Android Studio (this compiles the new Java + registers the plugin).
3. Start a walk → grant **Allow all the time** → confirm the persistent "walk in progress" notification appears.
4. **Lock the phone AND background the app** (press home), walk 3–5 min.
5. Check `gps_pings` for the session — pings should keep landing ~every 10s **through the locked/backgrounded window**.

## Follow-up

- The old `@capacitor-community/background-geolocation` dep is now unused (left in `package.json`; can be removed in a tidy-up).
- iOS background upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)