### PR TITLE
TRU-118: email sending pipeline (DB triggers → Edge Function → Resend)

### DIFF
--- a/supabase/functions/send-notification/index.ts
+++ b/supabase/functions/send-notification/index.ts
@@ -1,0 +1,270 @@
+// TRU-118: transactional email sending pipeline.
+// DB triggers (pg_net) POST an event here; this function resolves the recipients/data,
+// renders the branded HTML, and sends via Resend. Called server-to-server only, so it
+// authenticates with a shared secret header (verify_jwt is disabled for this function).
+//
+// Required function secrets (Supabase → Edge Functions → Secrets):
+//   RESEND_API_KEY     - Resend API key
+//   WEBHOOK_SECRET     - shared secret the triggers send as x-webhook-secret
+//   (SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY are injected automatically)
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const RESEND_API_KEY = Deno.env.get('RESEND_API_KEY')!;
+const WEBHOOK_SECRET = Deno.env.get('WEBHOOK_SECRET')!;
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
+const SERVICE_ROLE = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+
+const FROM = 'Truffl Pets <notifications@trufflpets.com>';
+const REPLY_TO = 'support@trufflpets.com'; // TRU-114 forwarding
+const SITE = 'https://trufflpets.com';
+
+const sb = createClient(SUPABASE_URL, SERVICE_ROLE);
+
+const SERVICE_LABELS: Record<string, string> = {
+  dog_walking: 'Dog walking', dog_boarding: 'Dog boarding', dog_sitting: 'Dog sitting',
+  dog_daycare: 'Dog daycare', drop_in: 'Drop-in visit', pet_sitting: 'Pet sitting',
+};
+
+function esc(s: unknown): string {
+  return String(s ?? '').replace(/[&<>"]/g, (c) =>
+    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]!));
+}
+
+function fmtWhen(iso: string | null, mins?: number | null): string {
+  if (!iso) return 'To be arranged';
+  try {
+    const d = new Date(iso);
+    const base = d.toLocaleString('en-AU', {
+      weekday: 'short', day: 'numeric', month: 'short',
+      hour: 'numeric', minute: '2-digit', timeZone: 'Australia/Sydney',
+    });
+    return mins ? `${base} · ${mins} min` : base;
+  } catch { return iso; }
+}
+
+// ── Branded layout (Deno port of TrufflEmailLayout; keep visually in sync) ──
+function layout(opts: { preview: string; heading: string; body: string; cta?: { label: string; href: string }; footnote?: string }): string {
+  const C = { cream: '#F7F3EE', white: '#FFFFFF', border: '#E7DFD6', brown: '#5C4033', terracotta: '#C4866A', terracottaDark: '#B8795C', text: '#3A2E28', textMid: '#7A6860', textLight: '#A8978E' };
+  const headingFont = "'Cormorant Garamond', Georgia, 'Times New Roman', serif";
+  const bodyFont = "-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif";
+  return `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="margin:0;padding:24px 0;background:${C.cream};font-family:${bodyFont};">
+<div style="display:none;max-height:0;overflow:hidden;opacity:0;">${esc(opts.preview)}</div>
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:560px;margin:0 auto;padding:0 16px;">
+  <tr><td style="text-align:center;padding:8px 0 20px;">
+    <a href="${SITE}" style="text-decoration:none;">
+      <span style="font-family:${headingFont};font-style:italic;font-size:30px;color:${C.brown};letter-spacing:-0.5px;vertical-align:middle;">truffl</span>
+      <span style="font-size:11px;font-weight:600;letter-spacing:4px;color:${C.textLight};margin-left:8px;vertical-align:middle;">PETS</span>
+    </a>
+  </td></tr>
+  <tr><td style="background:${C.white};border:1px solid ${C.border};border-radius:16px;padding:32px 28px;">
+    <h1 style="font-family:${headingFont};font-weight:500;font-size:26px;line-height:1.2;color:${C.brown};margin:0 0 14px;">${opts.heading}</h1>
+    ${opts.body}
+  </td></tr>
+  ${opts.cta ? `<tr><td style="text-align:center;padding:24px 0 4px;">
+    <a href="${esc(opts.cta.href)}" style="background:${C.terracotta};color:${C.white};font-size:15px;font-weight:500;text-decoration:none;padding:14px 32px;border-radius:999px;display:inline-block;">${esc(opts.cta.label)}</a>
+  </td></tr>` : ''}
+  ${opts.footnote ? `<tr><td style="text-align:center;font-size:13px;line-height:1.6;color:${C.textMid};padding:18px 8px 0;">${esc(opts.footnote)}</td></tr>` : ''}
+  <tr><td style="padding:18px 0;"><hr style="border:none;border-top:1px solid ${C.border};margin:0;"></td></tr>
+  <tr><td style="text-align:center;">
+    <p style="font-size:13px;color:${C.textMid};margin:0 0 6px;"><a href="${SITE}" style="color:${C.terracottaDark};text-decoration:none;">Truffl Pets</a> · Sydney's trusted pet care</p>
+    <p style="font-size:12px;color:${C.textLight};margin:0 0 6px;"><a href="${SITE}/trust-and-safety/" style="color:${C.terracottaDark};text-decoration:none;">Trust &amp; safety</a> &nbsp;·&nbsp; <a href="${SITE}/privacy/" style="color:${C.terracottaDark};text-decoration:none;">Privacy</a></p>
+    <p style="font-size:12px;color:${C.textLight};margin:0;">© Truffl Pets · Sydney, NSW</p>
+  </td></tr>
+</table></body></html>`;
+}
+
+function p(text: string): string {
+  return `<p style="font-size:15px;line-height:1.65;color:#3A2E28;margin:0 0 14px;">${text}</p>`;
+}
+function detailsTable(rows: [string, string][]): string {
+  return `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#F7F3EE;border-radius:12px;padding:8px 16px;margin:8px 0 4px;">
+    ${rows.map(([k, v]) => `<tr>
+      <td style="font-size:13px;color:#7A6860;padding:10px 0;border-bottom:1px solid #E7DFD6;">${esc(k)}</td>
+      <td style="font-size:14px;font-weight:500;color:#5C4033;padding:10px 0;border-bottom:1px solid #E7DFD6;text-align:right;">${esc(v)}</td>
+    </tr>`).join('')}
+  </table>`;
+}
+
+// ── Recipient/data resolution ──
+async function loadBooking(bookingId: string) {
+  const { data: b } = await sb.from('bookings').select('*').eq('id', bookingId).single();
+  if (!b) throw new Error('booking not found: ' + bookingId);
+  const [cp, pp, pet, svc] = await Promise.all([
+    sb.from('customer_profiles').select('user_id').eq('id', b.customer_id).single(),
+    sb.from('provider_profiles').select('user_id').eq('id', b.provider_id).single(),
+    b.pet_id ? sb.from('pets').select('name').eq('id', b.pet_id).single() : Promise.resolve({ data: null }),
+    b.service_id ? sb.from('provider_services').select('service_type,duration_mins').eq('id', b.service_id).single() : Promise.resolve({ data: null }),
+  ]);
+  const [customer, provider] = await Promise.all([
+    sb.from('users').select('email,first_name').eq('id', cp.data?.user_id).single(),
+    sb.from('users').select('email,first_name').eq('id', pp.data?.user_id).single(),
+  ]);
+  return {
+    booking: b,
+    customer: customer.data, provider: provider.data,
+    petName: pet.data?.name || 'your pet',
+    serviceLabel: svc.data ? (SERVICE_LABELS[svc.data.service_type] || svc.data.service_type) : 'Service',
+    durationMins: svc.data?.duration_mins ?? null,
+  };
+}
+
+// ── Build the email for an event → { to[], subject, html } messages ──
+async function buildMessages(type: string, payload: Record<string, unknown>) {
+  const out: { to: string; subject: string; html: string }[] = [];
+
+  if (type === 'booking_request') {
+    const d = await loadBooking(payload.booking_id as string);
+    if (!d.provider?.email) return out;
+    out.push({
+      to: d.provider.email,
+      subject: `New booking request from ${d.customer?.first_name || 'a customer'}`,
+      html: layout({
+        preview: `New booking request from ${d.customer?.first_name || 'a customer'}`,
+        heading: 'You have a new booking request',
+        body: p(`Hi ${esc(d.provider.first_name || 'there')}, ${esc(d.customer?.first_name || 'a customer')} would like to book you for ${esc(d.petName)}.`) +
+          detailsTable([['Customer', d.customer?.first_name || 'Customer'], ['Pet', d.petName], ['Service', d.serviceLabel], ['When', fmtWhen(d.booking.scheduled_at, d.durationMins)]]) +
+          p('The sooner you respond, the better the experience for the owner.'),
+        cta: { label: 'Review request', href: `${SITE}/dashboard/` },
+        footnote: "You're receiving this because you're a carer on Truffl Pets.",
+      }),
+    });
+  } else if (type === 'booking_confirmed') {
+    const d = await loadBooking(payload.booking_id as string);
+    if (!d.customer?.email) return out;
+    out.push({
+      to: d.customer.email,
+      subject: `Your booking with ${d.provider?.first_name || 'your carer'} is confirmed`,
+      html: layout({
+        preview: 'Your booking is confirmed',
+        heading: 'Your booking is confirmed',
+        body: p(`Hi ${esc(d.customer.first_name || 'there')}, good news — ${esc(d.provider?.first_name || 'your carer')} has confirmed your booking for ${esc(d.petName)}.`) +
+          detailsTable([['Service', d.serviceLabel], ['Carer', d.provider?.first_name || 'Carer'], ['Pet', d.petName], ['When', fmtWhen(d.booking.scheduled_at, d.durationMins)]]) +
+          p("We'll let you know the moment the walk starts so you can follow along live."),
+        cta: { label: 'View booking', href: `${SITE}/track/?booking=${d.booking.id}` },
+        footnote: "You're receiving this because you have a booking with Truffl Pets.",
+      }),
+    });
+  } else if (type === 'walk_started') {
+    const { data: ws } = await sb.from('walk_sessions').select('booking_id').eq('id', payload.walk_session_id as string).single();
+    if (!ws) return out;
+    const d = await loadBooking(ws.booking_id);
+    if (!d.customer?.email) return out;
+    out.push({
+      to: d.customer.email,
+      subject: `${d.provider?.first_name || 'Your carer'} has started ${d.petName}'s walk`,
+      html: layout({
+        preview: `${d.petName}'s walk has started`,
+        heading: `${esc(d.petName)}'s walk has started`,
+        body: p(`Hi ${esc(d.customer.first_name || 'there')}, ${esc(d.provider?.first_name || 'your carer')} has just set off with ${esc(d.petName)}. You can watch the route live and you'll see photo updates along the way.`),
+        cta: { label: 'Follow along live', href: `${SITE}/track/?booking=${d.booking.id}` },
+        footnote: 'You can stop these notifications in your account settings.',
+      }),
+    });
+  } else if (type === 'walk_completed') {
+    const { data: ws } = await sb.from('walk_sessions').select('booking_id,distance_metres,duration_seconds').eq('id', payload.walk_session_id as string).single();
+    if (!ws) return out;
+    const d = await loadBooking(ws.booking_id);
+    const dist = ws.distance_metres ? (ws.distance_metres >= 1000 ? (ws.distance_metres / 1000).toFixed(1) + ' km' : ws.distance_metres + ' m') : '—';
+    const dur = ws.duration_seconds ? Math.round(ws.duration_seconds / 60) + ' min' : '—';
+    const url = `${SITE}/track/?booking=${d.booking.id}`;
+    if (d.customer?.email) {
+      out.push({
+        to: d.customer.email,
+        subject: `${d.petName}'s walk is complete`,
+        html: layout({
+          preview: `${d.petName}'s walk is complete`,
+          heading: `${esc(d.petName)}'s walk is complete`,
+          body: p(`Hi ${esc(d.customer.first_name || 'there')}, ${esc(d.provider?.first_name || 'your carer')} has brought ${esc(d.petName)} home safe and sound. Here's how the walk went:`) +
+            detailsTable([['Pet', d.petName], ['Carer', d.provider?.first_name || 'Carer'], ['Distance', dist], ['Duration', dur]]) +
+            p('You can view the full route and any photos from the walk anytime.'),
+          cta: { label: 'See the walk', href: url },
+        }),
+      });
+    }
+    if (d.provider?.email) {
+      out.push({
+        to: d.provider.email,
+        subject: `Walk complete — ${d.petName}`,
+        html: layout({
+          preview: `${d.petName}'s walk is complete`,
+          heading: `${esc(d.petName)}'s walk is complete`,
+          body: p(`Hi ${esc(d.provider.first_name || 'there')}, nice work — you've wrapped up ${esc(d.petName)}'s walk.`) +
+            detailsTable([['Pet', d.petName], ['Owner', d.customer?.first_name || 'Owner'], ['Distance', dist], ['Duration', dur]]) +
+            p('Thanks for the great care.'),
+          cta: { label: 'View summary', href: url },
+        }),
+      });
+    }
+  } else if (type === 'new_message') {
+    const { data: m } = await sb.from('messages').select('booking_id,sender_id,body').eq('id', payload.message_id as string).single();
+    if (!m) return out;
+    const d = await loadBooking(m.booking_id);
+    const { data: cp } = await sb.from('customer_profiles').select('user_id').eq('id', d.booking.customer_id).single();
+    const senderIsCustomer = cp?.user_id === m.sender_id;
+    const recipient = senderIsCustomer ? d.provider : d.customer;
+    const sender = senderIsCustomer ? d.customer : d.provider;
+    if (!recipient?.email) return out;
+    const snippet = (m.body || '').slice(0, 140);
+    out.push({
+      to: recipient.email,
+      subject: `New message from ${sender?.first_name || 'Truffl'}`,
+      html: layout({
+        preview: `New message from ${sender?.first_name || 'someone'}`,
+        heading: `New message from ${esc(sender?.first_name || 'Truffl')}`,
+        body: p(`Hi ${esc(recipient.first_name || 'there')}, you have a new message:`) +
+          p(`<em style="color:#5C4033;">“${esc(snippet)}”</em>`) +
+          p('Reply directly in your Truffl messages to keep everything in one place.'),
+        cta: { label: 'Reply in Truffl', href: `${SITE}/messages/?booking=${d.booking.id}` },
+        footnote: 'Please keep messages on Truffl so there is a record.',
+      }),
+    });
+  }
+  return out;
+}
+
+// ── Resend send with retry on 429 ──
+async function sendEmail(msg: { to: string; subject: string; html: string }) {
+  for (let attempt = 0; attempt < 4; attempt++) {
+    const res = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${RESEND_API_KEY}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ from: FROM, reply_to: REPLY_TO, to: msg.to, subject: msg.subject, html: msg.html }),
+    });
+    if (res.status !== 429) {
+      const data = await res.json().catch(() => ({}));
+      return { ok: res.ok, status: res.status, id: (data as { id?: string }).id, error: res.ok ? null : data };
+    }
+    await new Promise((r) => setTimeout(r, 1200 * (attempt + 1)));
+  }
+  return { ok: false, status: 429, error: 'rate limited' };
+}
+
+Deno.serve(async (req) => {
+  if (req.method !== 'POST') return new Response('Method not allowed', { status: 405 });
+  if (req.headers.get('x-webhook-secret') !== WEBHOOK_SECRET) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+  let payload: Record<string, unknown>;
+  try { payload = await req.json(); } catch { return new Response('Bad JSON', { status: 400 }); }
+
+  const type = String(payload.type || '');
+  try {
+    const messages = await buildMessages(type, payload);
+    if (!messages.length) {
+      return new Response(JSON.stringify({ skipped: true, type }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+    const results = [];
+    for (const m of messages) {
+      results.push(await sendEmail(m));
+    }
+    const allOk = results.every((r) => r.ok);
+    return new Response(JSON.stringify({ type, sent: results.length, allOk, results }), {
+      status: allOk ? 200 : 502, headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (e) {
+    console.error('send-notification error', type, e);
+    return new Response(JSON.stringify({ error: String(e) }), { status: 500, headers: { 'Content-Type': 'application/json' } });
+  }
+});

--- a/supabase/migrations/20260626_tru118_email_pipeline.sql
+++ b/supabase/migrations/20260626_tru118_email_pipeline.sql
@@ -1,0 +1,101 @@
+-- TRU-118: transactional email sending pipeline (DB triggers -> Edge Function -> Resend).
+--
+-- DB events POST to the `send-notification` Edge Function via pg_net. The function URL +
+-- shared webhook secret live in private.email_config, which is populated OUT OF BAND (not in
+-- this migration / not in git) so the secret never lands in source control:
+--
+--   insert into private.email_config (id, function_url, webhook_secret, enabled)
+--   values (1, 'https://<project>.supabase.co/functions/v1/send-notification', '<secret>', true)
+--   on conflict (id) do update set function_url=excluded.function_url,
+--     webhook_secret=excluded.webhook_secret, enabled=excluded.enabled;
+--
+-- The same <secret> must be set as the function's WEBHOOK_SECRET env var.
+
+create extension if not exists pg_net;
+
+create schema if not exists private;
+
+create table if not exists private.email_config (
+  id int primary key default 1,
+  function_url text not null,
+  webhook_secret text not null,
+  enabled boolean not null default true,
+  constraint email_config_single_row check (id = 1)
+);
+alter table private.email_config enable row level security;
+-- no policies: only the table owner / SECURITY DEFINER functions below can read it.
+
+-- Fire-and-forget POST of an event payload to the Edge Function.
+create or replace function private.notify_email(payload jsonb)
+returns void language plpgsql security definer set search_path = '' as $$
+declare cfg private.email_config;
+begin
+  select * into cfg from private.email_config where id = 1 and enabled = true;
+  if cfg.function_url is null then return; end if;
+  perform net.http_post(
+    url := cfg.function_url,
+    headers := jsonb_build_object('Content-Type','application/json','x-webhook-secret',cfg.webhook_secret),
+    body := payload
+  );
+end; $$;
+
+-- Each trigger wraps the notify in its own block so an email hiccup can never roll back
+-- or block the underlying booking/walk/message operation.
+
+-- booking request -> provider
+create or replace function private.tg_booking_request() returns trigger language plpgsql security definer set search_path = '' as $$
+begin
+  if NEW.status = 'pending' and coalesce(NEW.is_meet_and_greet,false) = false then
+    begin perform private.notify_email(jsonb_build_object('type','booking_request','booking_id',NEW.id));
+    exception when others then null; end;
+  end if;
+  return NEW;
+end; $$;
+drop trigger if exists trg_email_booking_request on public.bookings;
+create trigger trg_email_booking_request after insert on public.bookings for each row execute function private.tg_booking_request();
+
+-- booking confirmed -> customer
+create or replace function private.tg_booking_confirmed() returns trigger language plpgsql security definer set search_path = '' as $$
+begin
+  if NEW.status = 'confirmed' and OLD.status is distinct from 'confirmed' then
+    begin perform private.notify_email(jsonb_build_object('type','booking_confirmed','booking_id',NEW.id));
+    exception when others then null; end;
+  end if;
+  return NEW;
+end; $$;
+drop trigger if exists trg_email_booking_confirmed on public.bookings;
+create trigger trg_email_booking_confirmed after update on public.bookings for each row execute function private.tg_booking_confirmed();
+
+-- walk started -> customer
+create or replace function private.tg_walk_started() returns trigger language plpgsql security definer set search_path = '' as $$
+begin
+  if NEW.status = 'active' then
+    begin perform private.notify_email(jsonb_build_object('type','walk_started','walk_session_id',NEW.id));
+    exception when others then null; end;
+  end if;
+  return NEW;
+end; $$;
+drop trigger if exists trg_email_walk_started on public.walk_sessions;
+create trigger trg_email_walk_started after insert on public.walk_sessions for each row execute function private.tg_walk_started();
+
+-- walk completed -> customer + carer
+create or replace function private.tg_walk_completed() returns trigger language plpgsql security definer set search_path = '' as $$
+begin
+  if NEW.status = 'completed' and OLD.status is distinct from 'completed' then
+    begin perform private.notify_email(jsonb_build_object('type','walk_completed','walk_session_id',NEW.id));
+    exception when others then null; end;
+  end if;
+  return NEW;
+end; $$;
+drop trigger if exists trg_email_walk_completed on public.walk_sessions;
+create trigger trg_email_walk_completed after update on public.walk_sessions for each row execute function private.tg_walk_completed();
+
+-- new message -> the other party
+create or replace function private.tg_new_message() returns trigger language plpgsql security definer set search_path = '' as $$
+begin
+  begin perform private.notify_email(jsonb_build_object('type','new_message','message_id',NEW.id));
+  exception when others then null; end;
+  return NEW;
+end; $$;
+drop trigger if exists trg_email_new_message on public.messages;
+create trigger trg_email_new_message after insert on public.messages for each row execute function private.tg_new_message();


### PR DESCRIPTION
## What

Wires the five transactional emails to fire automatically on real events, end-to-end: **Postgres trigger → pg_net → `send-notification` Edge Function → Resend.**

## Pieces

- **`supabase/functions/send-notification/index.ts`** — resolves recipients/data for an event, renders branded HTML (Deno port of the TRU-116 layout), and sends via Resend. Covers all 5 events:
  - `booking_request` → provider
  - `booking_confirmed` → customer
  - `walk_started` → customer
  - `walk_completed` → customer **and** carer
  - `new_message` → the other party
  Retries on Resend `429`; authenticates with a shared `x-webhook-secret` header (server-to-server; `verify_jwt` off).
- **`supabase/migrations/20260626_tru118_email_pipeline.sql`** — `pg_net`, a `private.email_config` table (function URL + secret, populated out of band — **not in git**), `private.notify_email()`, and per-event triggers on `bookings` / `walk_sessions` / `messages`. Each notify is wrapped so an email hiccup can never roll back the underlying operation.

## Verified live

- Direct invoke (`booking_confirmed`) → Resend `200`, email delivered.
- Auth gate → `401` on missing/wrong secret.
- **Trigger path:** a booking `status → confirmed` update fired the trigger → `pg_net` → function returned **HTTP 200** → Resend sent. Confirmed via `net._http_response`.

## Deploy notes (already done on live, needed for any rebuild/restore)

- Edge Function deployed (`verify_jwt: false`).
- Function secrets set by Tom: `RESEND_API_KEY`, `WEBHOOK_SECRET`.
- `private.email_config` row inserted out of band (URL + secret) — see the migration header for the exact statement.

## Follow-ups

- TRU-119 (auth email rebrand), TRU-120 (deliverability/rendering QA — incl. the Hotmail-junk reputation work).
- Rate-limit handling is in (retry on 429); batch endpoint optional later for high volume.
- `From` is `notifications@trufflpets.com`, `Reply-To` `support@trufflpets.com` (TRU-114 forwarding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)