### PR TITLE
TRU-119: branded Supabase auth email templates

### DIFF
--- a/emails/emails/auth-change-email.tsx
+++ b/emails/emails/auth-change-email.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { TrufflEmailLayout, Heading, Paragraph } from '../components/TrufflEmailLayout';
+
+// Supabase auth template: "Change Email Address". {{ .Email }} / {{ .NewEmail }} /
+// {{ .ConfirmationURL }} substituted at send time.
+export default function AuthChangeEmail() {
+  return (
+    <TrufflEmailLayout
+      preview="Confirm your new Truffl Pets email address"
+      cta={{ label: 'Confirm new email', href: '{{ .ConfirmationURL }}' }}
+      footnote="If you didn't request this change, please contact us at support@trufflpets.com straight away."
+    >
+      <Heading>Confirm your new email</Heading>
+      <Paragraph>
+        Tap below to confirm changing your Truffl Pets email from {'{{ .Email }}'} to{' '}
+        {'{{ .NewEmail }}'}.
+      </Paragraph>
+      <Paragraph>Until you confirm, your account keeps using your current email.</Paragraph>
+    </TrufflEmailLayout>
+  );
+}

--- a/emails/emails/auth-confirm-signup.tsx
+++ b/emails/emails/auth-confirm-signup.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { TrufflEmailLayout, Heading, Paragraph } from '../components/TrufflEmailLayout';
+
+// Supabase auth template: "Confirm signup". Paste rendered HTML into
+// Authentication → Email Templates → Confirm signup. {{ .ConfirmationURL }} is
+// substituted by Supabase at send time.
+export default function AuthConfirmSignup() {
+  return (
+    <TrufflEmailLayout
+      preview="Confirm your email to finish setting up your Truffl account"
+      cta={{ label: 'Confirm email', href: '{{ .ConfirmationURL }}' }}
+      footnote="If you didn't create a Truffl Pets account, you can safely ignore this email."
+    >
+      <Heading>Confirm your email</Heading>
+      <Paragraph>
+        Welcome to Truffl Pets! Tap the button below to confirm your email address and finish
+        setting up your account.
+      </Paragraph>
+      <Paragraph>This link will expire shortly, so it's best to confirm now.</Paragraph>
+    </TrufflEmailLayout>
+  );
+}

--- a/emails/emails/auth-invite.tsx
+++ b/emails/emails/auth-invite.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { TrufflEmailLayout, Heading, Paragraph } from '../components/TrufflEmailLayout';
+
+// Supabase auth template: "Invite user". {{ .ConfirmationURL }} substituted at send time.
+export default function AuthInvite() {
+  return (
+    <TrufflEmailLayout
+      preview="You've been invited to Truffl Pets"
+      cta={{ label: 'Accept invitation', href: '{{ .ConfirmationURL }}' }}
+      footnote="If you weren't expecting this invitation, you can ignore this email."
+    >
+      <Heading>You've been invited to Truffl Pets</Heading>
+      <Paragraph>
+        You've been invited to join Truffl Pets — Sydney's trusted pet care. Tap below to accept
+        and set up your account.
+      </Paragraph>
+    </TrufflEmailLayout>
+  );
+}

--- a/emails/emails/auth-magic-link.tsx
+++ b/emails/emails/auth-magic-link.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { TrufflEmailLayout, Heading, Paragraph } from '../components/TrufflEmailLayout';
+
+// Supabase auth template: "Magic Link". {{ .ConfirmationURL }} substituted at send time.
+export default function AuthMagicLink() {
+  return (
+    <TrufflEmailLayout
+      preview="Your Truffl Pets sign-in link"
+      cta={{ label: 'Sign in to Truffl', href: '{{ .ConfirmationURL }}' }}
+      footnote="If you didn't request this link, you can safely ignore this email — no one can sign in without it."
+    >
+      <Heading>Your sign-in link</Heading>
+      <Paragraph>Tap the button below to sign in to Truffl Pets. For your security, this link expires shortly and can only be used once.</Paragraph>
+    </TrufflEmailLayout>
+  );
+}

--- a/emails/emails/auth-reset-password.tsx
+++ b/emails/emails/auth-reset-password.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { TrufflEmailLayout, Heading, Paragraph } from '../components/TrufflEmailLayout';
+
+// Supabase auth template: "Reset Password". {{ .ConfirmationURL }} substituted at send time.
+export default function AuthResetPassword() {
+  return (
+    <TrufflEmailLayout
+      preview="Reset your Truffl Pets password"
+      cta={{ label: 'Reset password', href: '{{ .ConfirmationURL }}' }}
+      footnote="If you didn't request a password reset, you can safely ignore this email — your password won't change."
+    >
+      <Heading>Reset your password</Heading>
+      <Paragraph>
+        We received a request to reset the password for your Truffl Pets account. Tap the button
+        below to choose a new one.
+      </Paragraph>
+      <Paragraph>This link will expire shortly.</Paragraph>
+    </TrufflEmailLayout>
+  );
+}


### PR DESCRIPTION
## What

Branded versions of the five Supabase **auth** emails, built on the shared `TrufflEmailLayout` (TRU-116), with Supabase's Go-template variables embedded so they substitute at send time.

| Supabase template | File | Variables |
|---|---|---|
| Confirm signup | `auth-confirm-signup.tsx` | `{{ .ConfirmationURL }}` |
| Magic Link | `auth-magic-link.tsx` | `{{ .ConfirmationURL }}` |
| Reset Password | `auth-reset-password.tsx` | `{{ .ConfirmationURL }}` |
| Change Email Address | `auth-change-email.tsx` | `{{ .Email }}` → `{{ .NewEmail }}`, `{{ .ConfirmationURL }}` |
| Invite user | `auth-invite.tsx` | `{{ .ConfirmationURL }}` |

Verified on export that the `{{ }}` variables survive intact (e.g. `href="{{ .ConfirmationURL }}"`).

## How to apply (dashboard paste — the ticket's "easy path")

```bash
cd emails && npx email export
```
Then in Supabase → **Authentication → Email Templates**, for each type paste `emails/out/auth-*.html` into the message body and set the subject:

| Template | Subject |
|---|---|
| Confirm signup | Confirm your email — Truffl Pets |
| Magic Link | Your Truffl Pets sign-in link |
| Reset Password | Reset your Truffl Pets password |
| Change Email Address | Confirm your new Truffl Pets email |
| Invite user | You're invited to Truffl Pets |

## Dependency

These render branded whenever auth emails send, but **production auth sending still needs TRU-115** (point Supabase custom SMTP at Resend) — the default mailer only does ~2/hour to team addresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)