### PR TITLE
TRU-122: SEO / meta optimisation

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -12,6 +12,17 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="canonical" href="https://trufflpets.com/about-us/">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Truffl Pets">
+<meta property="og:title" content="About us — Truffl Pets">
+<meta property="og:description" content="Meet Flick — the Springer Spaniel behind Truffl Pets. Our story, our mission, and how we vet every carer.">
+<meta property="og:url" content="https://trufflpets.com/about-us/">
+<meta property="og:image" content="https://trufflpets.com/dog-hero.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="About us — Truffl Pets">
+<meta name="twitter:description" content="Meet Flick — the Springer Spaniel behind Truffl Pets. Our story, our mission, and how we vet every carer.">
+<meta name="twitter:image" content="https://trufflpets.com/dog-hero.png">
   <title>About us — Truffl Pets</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <meta name="description" content="Meet Flick — the Springer Spaniel behind Truffl Pets. Our story, our mission, and how we vet every carer on our platform.">

--- a/book/index.html
+++ b/book/index.html
@@ -12,6 +12,7 @@
 </script>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
 <title>Book a Carer — Truffl Pets</title>
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/carer/index.html
+++ b/carer/index.html
@@ -12,6 +12,7 @@
 </script>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
 <title>Carer Profile — Truffl Pets</title>
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -12,6 +12,7 @@
 </script>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
 <title>Dashboard — Truffl Pets</title>
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/index.html
+++ b/index.html
@@ -14,6 +14,20 @@
   <title>Truffl Pets — Sydney's trusted pet care</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <meta name="description" content="Vetted, trusted pet care professionals in Sydney. GPS tracked walks, real-time updates, police checked carers.">
+  <link rel="canonical" href="https://trufflpets.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Truffl Pets">
+  <meta property="og:title" content="Truffl Pets — Sydney's trusted pet care">
+  <meta property="og:description" content="Vetted, police-checked pet carers in Sydney. GPS-tracked walks, live updates and photos — book dog walking, boarding, sitting and daycare.">
+  <meta property="og:url" content="https://trufflpets.com/">
+  <meta property="og:image" content="https://trufflpets.com/dog-hero.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Truffl Pets — Sydney's trusted pet care">
+  <meta name="twitter:description" content="Vetted, police-checked pet carers in Sydney. GPS-tracked walks, live updates and photos.">
+  <meta name="twitter:image" content="https://trufflpets.com/dog-hero.png">
+  <script type="application/ld+json">
+  {"@context":"https://schema.org","@type":"LocalBusiness","name":"Truffl Pets","description":"Vetted, police-checked pet carers in Sydney offering GPS-tracked dog walking, boarding, sitting and daycare.","url":"https://trufflpets.com/","image":"https://trufflpets.com/dog-hero.png","areaServed":"Sydney, NSW, Australia","address":{"@type":"PostalAddress","addressLocality":"Sydney","addressRegion":"NSW","addressCountry":"AU"}}
+  </script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500&display=swap" rel="stylesheet">

--- a/login/index.html
+++ b/login/index.html
@@ -12,6 +12,7 @@
 </script>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
 <title>Sign in — Truffl Pets</title>
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/messages/index.html
+++ b/messages/index.html
@@ -12,6 +12,7 @@
 </script>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
 <title>Messages — Truffl Pets</title>
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -11,6 +11,17 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="canonical" href="https://trufflpets.com/privacy/">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Truffl Pets">
+<meta property="og:title" content="Privacy policy — Truffl Pets">
+<meta property="og:description" content="How Truffl Pets collects, uses, stores and protects your personal information.">
+<meta property="og:url" content="https://trufflpets.com/privacy/">
+<meta property="og:image" content="https://trufflpets.com/dog-hero.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Privacy policy — Truffl Pets">
+<meta name="twitter:description" content="How Truffl Pets collects, uses, stores and protects your personal information.">
+<meta name="twitter:image" content="https://trufflpets.com/dog-hero.png">
   <title>Privacy policy — Truffl Pets</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <meta name="description" content="How Truffl Pets collects, uses, stores and protects your personal information.">

--- a/profile/index.html
+++ b/profile/index.html
@@ -12,6 +12,7 @@
 </script>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
 <title>Your Profile — Truffl Pets</title>
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/register/index.html
+++ b/register/index.html
@@ -12,6 +12,18 @@
 </script>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="Become a vetted Truffl Pets carer in Sydney. Set your services, get matched with local owners, and get paid for pet care you love.">
+<link rel="canonical" href="https://trufflpets.com/register/">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Truffl Pets">
+<meta property="og:title" content="Join Truffl Pets — become a trusted carer">
+<meta property="og:description" content="Become a vetted Truffl Pets carer in Sydney. Set your services, get matched with local owners, and get paid for pet care you love.">
+<meta property="og:url" content="https://trufflpets.com/register/">
+<meta property="og:image" content="https://trufflpets.com/dog-hero.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Join Truffl Pets — become a trusted carer">
+<meta name="twitter:description" content="Become a vetted Truffl Pets carer in Sydney. Set your services, get matched with local owners, and get paid for pet care you love.">
+<meta name="twitter:image" content="https://trufflpets.com/dog-hero.png">
 <title>Join Truffl Pets — Become a Trusted Carer</title>
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/review/index.html
+++ b/review/index.html
@@ -12,6 +12,7 @@
 </script>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
 <title>Leave a Review — Truffl Pets</title>
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,16 @@
+User-agent: *
+Allow: /
+
+# Authenticated / app pages — no SEO value, keep out of the index
+Disallow: /dashboard/
+Disallow: /book/
+Disallow: /walk/
+Disallow: /track/
+Disallow: /messages/
+Disallow: /my/
+Disallow: /profile/
+Disallow: /login/
+Disallow: /review/
+Disallow: /www/
+
+Sitemap: https://trufflpets.com/sitemap.xml

--- a/search/index.html
+++ b/search/index.html
@@ -12,6 +12,18 @@
 </script>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="Find vetted, police-checked pet carers near you in Sydney. Book GPS-tracked dog walking, boarding, sitting and daycare.">
+<link rel="canonical" href="https://trufflpets.com/search/">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Truffl Pets">
+<meta property="og:title" content="Find a carer — Truffl Pets">
+<meta property="og:description" content="Find vetted, police-checked pet carers near you in Sydney. Book GPS-tracked dog walking, boarding, sitting and daycare.">
+<meta property="og:url" content="https://trufflpets.com/search/">
+<meta property="og:image" content="https://trufflpets.com/dog-hero.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Find a carer — Truffl Pets">
+<meta name="twitter:description" content="Find vetted, police-checked pet carers near you in Sydney. Book GPS-tracked dog walking, boarding, sitting and daycare.">
+<meta name="twitter:image" content="https://trufflpets.com/dog-hero.png">
 <title>Find a Carer — Truffl Pets</title>
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://trufflpets.com/</loc><changefreq>weekly</changefreq><priority>1.0</priority></url>
+  <url><loc>https://trufflpets.com/about-us/</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://trufflpets.com/register/</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://trufflpets.com/search/</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://trufflpets.com/privacy/</loc><changefreq>yearly</changefreq><priority>0.3</priority></url>
+
+  <url><loc>https://trufflpets.com/trust-and-safety/</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://trufflpets.com/trust-and-safety/choosing-your-carer/</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://trufflpets.com/trust-and-safety/getting-ready/</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://trufflpets.com/trust-and-safety/following-along-with-gps/</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://trufflpets.com/trust-and-safety/if-something-goes-wrong/</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://trufflpets.com/trust-and-safety/keeping-it-on-truffl/</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://trufflpets.com/trust-and-safety/reporting-a-concern/</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
+
+  <url><loc>https://trufflpets.com/carer-guidelines/</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://trufflpets.com/carer-guidelines/your-commitments/</loc><changefreq>monthly</changefreq><priority>0.4</priority></url>
+  <url><loc>https://trufflpets.com/carer-guidelines/meet-and-greets/</loc><changefreq>monthly</changefreq><priority>0.4</priority></url>
+  <url><loc>https://trufflpets.com/carer-guidelines/keeping-owners-in-the-loop/</loc><changefreq>monthly</changefreq><priority>0.4</priority></url>
+  <url><loc>https://trufflpets.com/carer-guidelines/emergencies-and-safety/</loc><changefreq>monthly</changefreq><priority>0.4</priority></url>
+  <url><loc>https://trufflpets.com/carer-guidelines/vetting-and-cover/</loc><changefreq>monthly</changefreq><priority>0.4</priority></url>
+  <url><loc>https://trufflpets.com/carer-guidelines/reporting-a-concern/</loc><changefreq>monthly</changefreq><priority>0.4</priority></url>
+</urlset>

--- a/track/index.html
+++ b/track/index.html
@@ -12,6 +12,7 @@
 </script>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <meta name="robots" content="noindex,nofollow">
 <title>Track Walk — Truffl Pets</title>
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/trust-and-safety/index.html
+++ b/trust-and-safety/index.html
@@ -11,6 +11,17 @@
 </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="canonical" href="https://trufflpets.com/trust-and-safety/">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Truffl Pets">
+<meta property="og:title" content="Trust &amp; safety — Truffl Pets">
+<meta property="og:description" content="How to get the most from Truffl, safely — choosing your carer, GPS tracking, and what to do if something goes wrong.">
+<meta property="og:url" content="https://trufflpets.com/trust-and-safety/">
+<meta property="og:image" content="https://trufflpets.com/dog-hero.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Trust &amp; safety — Truffl Pets">
+<meta name="twitter:description" content="How to get the most from Truffl, safely — choosing your carer, GPS tracking, and what to do if something goes wrong.">
+<meta name="twitter:image" content="https://trufflpets.com/dog-hero.png">
   <title>Trust &amp; safety — Truffl Pets</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <meta name="description" content="How to get the most from Truffl, safely. Choosing your carer, getting ready, following along on GPS, and what to do if something goes wrong.">

--- a/walk/index.html
+++ b/walk/index.html
@@ -12,6 +12,7 @@
 </script>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <meta name="robots" content="noindex,nofollow">
 <title>Walk — Truffl Pets</title>
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/www/index.html
+++ b/www/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="robots" content="noindex,nofollow">
   <title>Truffl Pets</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## What

Site-wide SEO and social-sharing metadata (pure static, no config).

### Added
- **`robots.txt`** — allows crawl, disallows app/account paths, points to the sitemap.
- **`sitemap.xml`** — homepage + marketing + trust-and-safety + carer-guidelines pages.
- **Homepage** — `canonical`, full **Open Graph** + **Twitter card**, and **JSON-LD `LocalBusiness`** (name, area served = Sydney NSW, image).
- **Marketing pages** (about-us, trust-and-safety, privacy, register, search) — `canonical` + OG + Twitter; added missing **meta descriptions** to register & search.

### Hardened
- **App/account pages** (dashboard, book, walk, track, messages, profile, login, review, carer, www) → `noindex,nofollow` so authenticated/utility pages don't get indexed. (`/my/` already had it.)

## Verification
- JSON-LD parses (`LocalBusiness — Truffl Pets`).
- Homepage: 6 OG + 4 Twitter + 1 canonical tag.
- All target pages carry `og:title`; app pages carry the noindex tag.
- Head-only changes — no visual/layout impact.

## Notes
- `og:image` uses the existing `dog-hero.png`. A purpose-built 1200×630 social card would render nicer in link previews — easy follow-up if wanted.
- After deploy: submit the sitemap in Google Search Console and validate the homepage in Google's Rich Results test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)