### PR TITLE
TRU-140: carer visibility into M&G status (waiting on customer)

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1016,6 +1016,9 @@ function mgCarerCardHtml(b) {
   const dog = esc(s._pet_names || b._pet_label || 'their dog');
   const serviceLabel = SERVICE_LABELS[s._service_type || b._service_type] || 'Service';
   const priceLine = s.locked_price_cents != null ? `<div class="bc-time">$${priceToDollars(s.locked_price_cents)} per service · locked</div>` : '';
+  // Customer marks the M&G complete (status -> completed); the series stays
+  // pending_meet_greet until they proceed. So a completed M&G = "met, waiting on the owner".
+  const met = b.status === 'completed';
 
   let actions;
   if (mgBowOutSel[b.series_id]) {
@@ -1026,6 +1029,13 @@ function mgCarerCardHtml(b) {
       <button class="bc-btn decline" onclick="carerBowOutStart('${b.series_id}')">This one isn't the right fit for me</button>`;
   }
 
+  const statusBlock = met
+    ? `<div class="checkin-prompt ok">✓ Meet &amp; greet complete — waiting for ${owner} to confirm and go ahead</div>`
+    : '';
+  const blurb = met
+    ? `<p class="bc-notes" style="font-style:normal;">Nice — you've met ${owner} and ${dog}. They just need to confirm to start the bookings; we'll let you know as soon as they do. Nothing more for you to do right now.</p>`
+    : `<p class="bc-notes" style="font-style:normal;">A free, no-commitment hello before the first paid ${esc(SERVICE_NATURAL[s._service_type || b._service_type] || 'visit')}. Arrange a time in your messages — ${owner} marks it complete once you've met.</p>`;
+
   return `
     <div class="booking-card">
       <div class="bc-info">
@@ -1034,8 +1044,9 @@ function mgCarerCardHtml(b) {
         <span class="bc-service">${serviceLabel}</span>
         <div class="bc-time">Proposed: ${esc(mgProposedText(s))}</div>
         ${priceLine}
+        ${statusBlock}
         ${bookingDetailsHtml(b)}
-        <p class="bc-notes" style="font-style:normal;">A free, no-commitment hello before the first paid ${esc(SERVICE_NATURAL[s._service_type || b._service_type] || 'visit')}. Arrange a time in your messages — ${owner} marks it complete once you've met.</p>
+        ${blurb}
       </div>
       <div class="bc-actions">${actions}</div>
     </div>`;


### PR DESCRIPTION
## Bug

After the **customer** marks a meet & greet complete (`mark_meet_greet_complete` → M&G `bookings.status = completed`, while the series stays `pending_meet_greet` until they *proceed*), the carer's dashboard card was unchanged — still showing "arrange a time / owner marks it complete". The carer couldn't tell the M&G was done and the ball was now in the owner's court. (Hit in real testing.)

## Fix (`dashboard/index.html`, `mgCarerCardHtml`)

Key off the M&G booking status:
- **Met** (`status === 'completed'`): green badge **"✓ Meet & greet complete — waiting for {owner} to confirm and go ahead"** + a reassuring "nothing more to do right now" blurb.
- **Not yet met**: unchanged "arrange a time in messages" copy.

So the carer always knows the current stage. Front-end only — uses the existing `bookings.status` and the `.checkin-prompt.ok` style; no schema change.

## Verification

Rendered both states with the real `mgCarerCardHtml` function (screenshot): met → green waiting-on-owner badge; not-met → arrange copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)