### PR TITLE
TRU-143: Stripe Connect Express onboarding for carers

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -426,6 +426,15 @@ async function sbInsertQuiet(table, row) {
   });
   if (!r.ok) { const e = await r.json().catch(() => ({})); throw new Error(e.message || 'Insert failed'); }
 }
+// Call a Supabase Edge Function (e.g. Stripe actions) as the logged-in user.
+async function sbFn(name, body) {
+  const r = await fetch(`${SUPABASE_URL}/functions/v1/${name}`, {
+    method: 'POST', headers: headers(authToken), body: JSON.stringify(body || {})
+  });
+  const data = await r.json().catch(() => ({}));
+  if (!r.ok) throw new Error(data.error || `Request failed (${r.status})`);
+  return data;
+}
 
 function esc(s) {
   return (s == null ? '' : s.toString()).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
@@ -527,6 +536,60 @@ function ackGateBannerHtml() {
       ${item(s, '/carer-guidelines/emergencies-and-safety/', 'Emergencies and safety')}
     </div>
   </div>`;
+}
+
+/* ── TRU-143: Stripe Connect payouts ── */
+function payoutsEnabled() { return !!(providerProfile && providerProfile.payouts_enabled); }
+// Slim top-of-dashboard nudge once the carer is past the guidelines gate but hasn't set up payouts.
+function payoutBannerHtml() {
+  if (payoutsEnabled() || !guidelinesAcknowledged()) return '';
+  return `<div class="ack-gate" style="cursor:pointer;" onclick="switchTab('earnings')">
+    <div class="ack-gate-title">Set up payouts to get paid</div>
+    <p>Add your bank details with Stripe so we can pay you after each booking — see the Earnings tab.</p>
+  </div>`;
+}
+// Payout status card shown in the Earnings tab.
+function payoutCardHtml() {
+  if (payoutsEnabled()) {
+    return `<div class="card" style="border-color:var(--success);">
+      <div class="card-title" style="display:flex;align-items:center;gap:8px;">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--success)" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg>
+        Payouts active
+      </div>
+      <p style="font-size:0.88rem;color:var(--text-secondary);line-height:1.55;margin:0;">Your bank details are verified with Stripe. You'll be paid automatically after each completed booking.</p>
+    </div>`;
+  }
+  const started = !!(providerProfile && providerProfile.stripe_account_id);
+  return `<div class="card">
+    <div class="card-title">${started ? 'Finish setting up payouts' : 'Set up payouts'}</div>
+    <p style="font-size:0.88rem;color:var(--text-secondary);line-height:1.55;margin-bottom:1rem;">${started
+      ? 'You started setting up payouts but a few details are still needed before you can be paid. Pick up where you left off.'
+      : 'Add your bank details with Stripe so you can be paid for your bookings. It takes a couple of minutes, and your details are handled securely by Stripe — Truffl never sees them.'}</p>
+    <button class="bc-btn start-walk" id="payoutBtn" onclick="startPayoutOnboarding()" style="border:none;cursor:pointer;">${started ? 'Continue setup' : 'Set up payouts'}</button>
+  </div>`;
+}
+async function startPayoutOnboarding() {
+  const btn = document.getElementById('payoutBtn');
+  if (btn) { btn.disabled = true; btn.textContent = 'Opening Stripe…'; }
+  try {
+    const r = await sbFn('stripe-api', { action: 'connect_onboard' });
+    if (r.url) { window.location.href = r.url; return; }
+    throw new Error('Could not start payout setup.');
+  } catch (e) {
+    showMsg(e.message, 'error');
+    if (btn) { btn.disabled = false; btn.textContent = 'Set up payouts'; }
+  }
+}
+// Pull the latest payout readiness from Stripe (called on return from onboarding).
+async function refreshPayoutStatus() {
+  try {
+    const r = await sbFn('stripe-api', { action: 'connect_status' });
+    if (providerProfile) {
+      providerProfile.payouts_enabled = r.payouts_enabled;
+      providerProfile.charges_enabled = r.charges_enabled;
+      if (r.stripe_account_id) providerProfile.stripe_account_id = r.stripe_account_id;
+    }
+  } catch (e) { /* non-fatal — card just shows the pre-return state */ }
 }
 
 async function acceptBooking(bookingId) {
@@ -1183,6 +1246,8 @@ function renderDashboard() {
 
     ${ackGateBannerHtml()}
 
+    ${payoutBannerHtml()}
+
     <div class="tabs">
       <button class="tab active" data-tab="bookings" onclick="switchTab('bookings')">Bookings${pending.length > 0 ? ` (${pending.length})` : ''}</button>
       <button class="tab" data-tab="services" onclick="switchTab('services')">My services</button>
@@ -1230,6 +1295,7 @@ function renderDashboard() {
 
     <!-- Earnings placeholder -->
     <div class="tab-content" id="tab-earnings">
+      ${payoutCardHtml()}
       <div class="placeholder-card">
         <div class="ph-icon"><svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 20h18M6 20v-6M11 20V8M16 20v-9"/></svg></div>
         <h3>Earnings tracker coming soon</h3>
@@ -1487,6 +1553,13 @@ async function init() {
     await loadBookings();
     await loadSeries();
     await loadMgSeries();
+
+    // Returning from Stripe Connect onboarding? refresh payout readiness before first paint.
+    const payoutsParam = new URLSearchParams(location.search).get('payouts');
+    if (payoutsParam === 'return' || payoutsParam === 'refresh') {
+      await refreshPayoutStatus();
+      history.replaceState(null, '', location.pathname);
+    }
 
     renderDashboard();
     refreshMsgBadge();

--- a/supabase/functions/stripe-api/index.ts
+++ b/supabase/functions/stripe-api/index.ts
@@ -1,0 +1,141 @@
+// TRU-143 (+ later phases): authenticated client-facing Stripe actions.
+// verify_jwt is DISABLED: the browser CORS preflight (OPTIONS) carries no JWT, so the
+// platform gate would reject it and the call would never reach us. Instead we authenticate
+// in-function by validating the caller's Supabase JWT via auth.getUser (a request with no
+// valid user is rejected 401 below). We talk to Stripe's REST API directly (no SDK — most
+// reliable in the Deno edge runtime, same fetch style as send-notification).
+//
+// Actions:
+//   connect_onboard - get/create the carer's Express account, return a Stripe onboarding URL
+//   connect_status  - retrieve the account, persist payouts/charges readiness, return it
+//   setup_intent    - (Phase 2) save a customer card off-session
+//
+// Required function secrets (Supabase → Edge Functions → Secrets):
+//   STRIPE_SECRET_KEY   - sk_test_… (platform secret key)
+//   (SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY are injected automatically)
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const STRIPE_SECRET_KEY = Deno.env.get('STRIPE_SECRET_KEY')!;
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
+const SERVICE_ROLE = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+const SITE = 'https://trufflpets.com';
+
+const sb = createClient(SUPABASE_URL, SERVICE_ROLE);
+
+const CORS: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, content-type, apikey',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { ...CORS, 'Content-Type': 'application/json' } });
+}
+
+// Form-encode with Stripe's nested-bracket convention (e.g. capabilities[transfers][requested]).
+function encode(obj: Record<string, unknown>, prefix = ''): string {
+  const parts: string[] = [];
+  for (const [k, v] of Object.entries(obj)) {
+    if (v === undefined || v === null) continue;
+    const key = prefix ? `${prefix}[${k}]` : k;
+    if (typeof v === 'object') parts.push(encode(v as Record<string, unknown>, key));
+    else parts.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(v))}`);
+  }
+  return parts.filter(Boolean).join('&');
+}
+
+async function stripe(path: string, method: 'GET' | 'POST', body?: Record<string, unknown>) {
+  const res = await fetch(`https://api.stripe.com/v1/${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${STRIPE_SECRET_KEY}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: body ? encode(body) : undefined,
+  });
+  const data = await res.json();
+  if (!res.ok) throw new Error(data?.error?.message || `Stripe ${path} failed (${res.status})`);
+  return data;
+}
+
+async function getProvider(userId: string) {
+  const { data } = await sb
+    .from('provider_profiles')
+    .select('id,user_id,stripe_account_id,payouts_enabled,charges_enabled')
+    .eq('user_id', userId)
+    .single();
+  return data;
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: CORS });
+  if (req.method !== 'POST') return json({ error: 'Method not allowed' }, 405);
+
+  // Identify the caller from their Supabase JWT (users.id === auth.uid()).
+  const jwt = (req.headers.get('Authorization') || '').replace(/^Bearer\s+/i, '');
+  const { data: { user }, error: uerr } = await sb.auth.getUser(jwt);
+  if (uerr || !user) return json({ error: 'Not authenticated' }, 401);
+
+  let payload: Record<string, unknown> = {};
+  try { payload = await req.json(); } catch { /* empty body ok */ }
+  const action = String(payload.action || '');
+
+  try {
+    if (action === 'connect_onboard') {
+      const provider = await getProvider(user.id);
+      if (!provider) return json({ error: 'Not a carer account' }, 403);
+
+      let acctId = provider.stripe_account_id as string | null;
+      if (!acctId) {
+        const acct = await stripe('accounts', 'POST', {
+          type: 'express',
+          country: 'AU',
+          email: user.email,
+          business_type: 'individual',
+          // Destination charges settle on the platform and transfer to the carer, so the
+          // connected account only needs the transfers capability.
+          capabilities: { transfers: { requested: true } },
+          business_profile: { product_description: 'Pet care services via Truffl Pets' },
+          metadata: { provider_profile_id: provider.id, user_id: user.id },
+        });
+        acctId = acct.id as string;
+        await sb.from('provider_profiles').update({ stripe_account_id: acctId }).eq('id', provider.id);
+      }
+
+      const link = await stripe('account_links', 'POST', {
+        account: acctId,
+        type: 'account_onboarding',
+        refresh_url: `${SITE}/dashboard/?payouts=refresh`,
+        return_url: `${SITE}/dashboard/?payouts=return`,
+      });
+      return json({ url: link.url });
+    }
+
+    if (action === 'connect_status') {
+      const provider = await getProvider(user.id);
+      if (!provider) return json({ error: 'Not a carer account' }, 403);
+      if (!provider.stripe_account_id) {
+        return json({ connected: false, payouts_enabled: false, charges_enabled: false });
+      }
+      const acct = await stripe(`accounts/${provider.stripe_account_id}`, 'GET');
+      const payouts_enabled = !!acct.payouts_enabled;
+      const charges_enabled = !!acct.charges_enabled;
+      await sb.from('provider_profiles')
+        .update({ payouts_enabled, charges_enabled })
+        .eq('id', provider.id);
+      return json({
+        connected: true,
+        payouts_enabled,
+        charges_enabled,
+        details_submitted: !!acct.details_submitted,
+        stripe_account_id: provider.stripe_account_id,
+      });
+    }
+
+    return json({ error: `Unknown action: ${action}` }, 400);
+  } catch (e) {
+    console.error('stripe-api error', action, e);
+    return json({ error: String((e as Error)?.message || e) }, 500);
+  }
+});

--- a/supabase/migrations/20260628_tru143_stripe_connect_onboarding.sql
+++ b/supabase/migrations/20260628_tru143_stripe_connect_onboarding.sql
@@ -1,0 +1,30 @@
+-- TRU-143: Stripe Connect Express onboarding for carers (Phase 1 of Stripe payments).
+-- Track each provider's connected account + payout readiness, and add a private single-row
+-- config table (mirrors private.email_config) the Phase-3 charge pipeline uses to POST to the
+-- charge Edge Function via pg_net.
+--
+-- Applied to the live DB via apply_migration (Supabase branching is broken on this repo);
+-- committed here for version control. The "Supabase Preview" check on the PR is expected to
+-- fail and is non-blocking.
+
+alter table public.provider_profiles
+  add column if not exists stripe_account_id text,
+  add column if not exists payouts_enabled boolean not null default false,
+  add column if not exists charges_enabled boolean not null default false;
+
+-- Single-row config for the Stripe charge pipeline (Phase 3). Mirrors private.email_config:
+-- populated OUT OF BAND (not in git) so the shared secret never lands in source control:
+--   insert into private.stripe_config (id, function_base_url, webhook_secret, enabled)
+--   values (1, 'https://<project>.supabase.co/functions/v1', '<secret>', true)
+--   on conflict (id) do update set function_base_url=excluded.function_base_url,
+--     webhook_secret=excluded.webhook_secret, enabled=excluded.enabled;
+create schema if not exists private;
+create table if not exists private.stripe_config (
+  id int primary key default 1,
+  function_base_url text not null,
+  webhook_secret text not null,
+  enabled boolean not null default true,
+  constraint stripe_config_single_row check (id = 1)
+);
+alter table private.stripe_config enable row level security;
+-- no policies: only the table owner / SECURITY DEFINER functions can read it.


### PR DESCRIPTION
Phase 1 of the Stripe payments integration (epic TRU-22). Carers set up payouts via a Stripe Connect **Express** account before any charges run. Test mode (sandbox `acct_1TlHff1Sh4qkQvUZ`) — live cutover is later.

## What's here
- **Migration** `20260628_tru143_stripe_connect_onboarding.sql` — `provider_profiles.stripe_account_id` / `payouts_enabled` / `charges_enabled`, plus a `private.stripe_config` single-row table (mirrors `private.email_config`) for the Phase-3 charge pipeline. **Already applied to the live DB** via `apply_migration` (committed for version control; the Supabase Preview check is expected to fail, non-blocking).
- **Edge function** `supabase/functions/stripe-api/` — `verify_jwt` off; authenticates in-function via the caller's Supabase JWT (so the browser CORS preflight isn't blocked by the platform gate). Actions: `connect_onboard` (create Express account + onboarding AccountLink) and `connect_status` (retrieve account, persist payout readiness). Calls Stripe's REST API directly (no SDK), same fetch style as `send-notification`. **Deployed (v2).**
- **Client** `dashboard/index.html` — payout-status card in the Earnings tab + a slim top banner once past the guidelines gate, with return-from-onboarding handling. Adds a small `sbFn()` edge-function helper.

## Decisions resolved
- Connect account type: **Express** (TRU-46).
- Fee model: **15% deducted from carer**, destination charges — implemented in Phase 3 (TRU-47).

## ⚠️ Required before this works end-to-end
Set **`STRIPE_SECRET_KEY`** (sk_test) as a Supabase Edge Function secret (Dashboard → Edge Functions → Secrets). Until then `connect_onboard` returns `Invalid API Key provided: undefined` (verified). `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` are injected automatically.

## Verification done (Preview MCP, as Olivia / walk1)
- Payout banner + Earnings card render correctly, no console errors.
- Full client→function→DB path verified: `connect_status` returns `{connected:false, payouts_enabled:false}` (early return, no Stripe call needed).
- `connect_onboard` reaches Stripe and fails only on the missing secret — confirming the wiring is complete.

Once the secret is set I'll complete real test-mode onboarding (Express test flow) and confirm `payouts_enabled` flips true, then move to Phase 2 (customer SetupIntent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)