### PR TITLE
TRU-144: customer SetupIntent at the meet & greet proceed step

### DIFF
--- a/profile/index.html
+++ b/profile/index.html
@@ -10,6 +10,8 @@
 
   gtag('config', 'G-T2CPSDBJ1L');
 </script>
+<!-- Stripe.js for the meet & greet card form (TRU-144) -->
+<script src="https://js.stripe.com/v3/"></script>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="robots" content="noindex,nofollow">
@@ -225,6 +227,9 @@
 const SUPABASE_URL = 'https://gadflsntbnbnnxbpiral.supabase.co';
 const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdhZGZsc250Ym5ibm54YnBpcmFsIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzUwNjcwNTcsImV4cCI6MjA5MDY0MzA1N30.g5ZrqeAX9U5l7oDZEbQFrU5j10828dUF0QuJ0ZlHXK8';
 
+// Stripe publishable (test) key — public by design, safe to ship client-side (TRU-144).
+const STRIPE_PK = 'pk_test_51TlHff1Sh4qkQvUZOXzfEFJzZcGilXp5JjaDQc3ksDFiF7iJSYSmanteWT9nDpVFiLtshU92hFucVAZzNyFvXgPX00z34gWOQA';
+
 const SERVICE_LABELS = {
   dog_walking:'Dog walking', dog_sitting:'Dog sitting', dog_boarding:'Dog boarding',
   pet_sitting:'Other pet sitting'
@@ -286,6 +291,13 @@ async function sbInsert(t, row) {
   const r = await fetch(`${SUPABASE_URL}/rest/v1/${t}`, { method: 'POST', headers: { ...h(authToken), 'Prefer': 'return=representation' }, body: JSON.stringify(row) });
   if (!r.ok) { const e = await r.json(); throw new Error(e.message); }
   return await r.json();
+}
+// Call a Supabase Edge Function (Stripe actions) as the logged-in user.
+async function sbFn(name, body) {
+  const r = await fetch(`${SUPABASE_URL}/functions/v1/${name}`, { method: 'POST', headers: h(authToken), body: JSON.stringify(body || {}) });
+  const data = await r.json().catch(() => ({}));
+  if (!r.ok) throw new Error(data.error || `Request failed (${r.status})`);
+  return data;
 }
 
 function esc(s) {
@@ -1033,23 +1045,50 @@ function mgOverlay(html) {
 }
 function closeMgOverlay() { const o = document.getElementById('mgOverlay'); if (o) o.remove(); }
 
-// Proceed: stubbed payment-method step (no card stored — Stripe Connect lands later),
-// then activate the series. The DB gate requires a completed M&G to allow this.
-function proceedMg(seriesId) {
+// Proceed: collect & save the customer's card via a Stripe SetupIntent (off-session, no
+// charge), then activate the series. The DB gate requires a completed M&G to allow this.
+// Each booking is charged on completion (Phase 3), off the saved card.
+let mgStripe = null, mgElements = null;
+async function proceedMg(seriesId) {
   mgOverlay(`
     <h2 style="margin-top:0;">Add a payment method</h2>
     <p style="font-size:0.9rem;">You're only ever charged after a service is finished — never before, and never for the meet &amp; greet.</p>
-    <div style="background:var(--cream,#fbf6ef);border:1px dashed var(--border);border-radius:10px;padding:1rem;margin:1rem 0;font-size:0.84rem;color:var(--text-muted);">Card payments are coming soon. During launch there's nothing to add — just confirm to go ahead.</div>
-    <div id="mgOverlayMsg" class="msg"></div>
+    <div id="mgPaymentElement" style="margin:1rem 0;min-height:40px;"></div>
+    <div id="mgOverlayMsg" class="msg" style="font-size:0.84rem;color:var(--text-muted);">Loading secure card form…</div>
     <div style="display:flex;gap:10px;justify-content:flex-end;flex-wrap:wrap;">
       <button class="btn-ghost" onclick="closeMgOverlay()">Not now</button>
-      <button class="btn-track" id="mgProceedConfirm" onclick="confirmProceedMg('${seriesId}')">Confirm and go ahead</button>
+      <button class="btn-track" id="mgProceedConfirm" onclick="confirmProceedMg('${seriesId}')" disabled>Save card &amp; go ahead</button>
     </div>`);
+  try {
+    if (!window.Stripe) throw new Error('Could not load the secure card form. Please refresh and try again.');
+    const { client_secret } = await sbFn('stripe-api', { action: 'setup_intent' });
+    mgStripe = mgStripe || Stripe(STRIPE_PK);
+    mgElements = mgStripe.elements({ clientSecret: client_secret, appearance: { theme: 'flat', variables: { colorPrimary: '#C4866A' } } });
+    const pe = mgElements.create('payment');
+    pe.mount('#mgPaymentElement');
+    pe.on('ready', () => {
+      const b = document.getElementById('mgProceedConfirm'); if (b) b.disabled = false;
+      const m = document.getElementById('mgOverlayMsg'); if (m) { m.textContent = ''; m.className = 'msg'; }
+    });
+  } catch (e) {
+    const m = document.getElementById('mgOverlayMsg'); if (m) { m.textContent = e.message; m.className = 'msg error'; }
+  }
 }
 async function confirmProceedMg(seriesId) {
   const btn = document.getElementById('mgProceedConfirm');
-  if (btn) { btn.disabled = true; btn.textContent = 'Confirming…'; }
+  const m = document.getElementById('mgOverlayMsg');
+  if (btn) { btn.disabled = true; btn.textContent = 'Saving…'; }
+  if (m) { m.textContent = ''; m.className = 'msg'; }
   try {
+    if (!mgStripe || !mgElements) throw new Error('Card form not ready — please try again.');
+    // Save the card, no charge. redirect:'if_required' keeps card flows in-page.
+    const { error, setupIntent } = await mgStripe.confirmSetup({ elements: mgElements, redirect: 'if_required' });
+    if (error) throw new Error(error.message || 'Could not save your card.');
+    // Make it the default so the per-booking charge on completion can use it off-session.
+    if (setupIntent && setupIntent.payment_method) {
+      try { await sbFn('stripe-api', { action: 'set_default_pm', payment_method: setupIntent.payment_method }); } catch (e) { /* non-fatal */ }
+    }
+    // Activate the series — the server-side M&G gate is still enforced.
     await sbPatch('booking_series', 'id', seriesId, { status: 'active' });
     const s = seriesById[seriesId];
     if (s) s.status = 'active';
@@ -1062,9 +1101,8 @@ async function confirmProceedMg(seriesId) {
       <p>Wonderful. ${carer} can't wait to spend time with ${dog}. Your ${esc(svcNat)} starts ${startTxt}, and you're only ever charged once a service is done, never a moment before.</p>
       <div style="display:flex;justify-content:flex-end;"><button class="btn-track" onclick="closeMgOverlay();reloadBookings()">Done</button></div>`);
   } catch(e) {
-    const m = document.getElementById('mgOverlayMsg');
     if (m) { m.textContent = e.message; m.className = 'msg error'; }
-    if (btn) { btn.disabled = false; btn.textContent = 'Confirm and go ahead'; }
+    if (btn) { btn.disabled = false; btn.textContent = 'Save card & go ahead'; }
   }
 }
 

--- a/supabase/functions/stripe-api/index.ts
+++ b/supabase/functions/stripe-api/index.ts
@@ -8,7 +8,8 @@
 // Actions:
 //   connect_onboard - get/create the carer's Express account, return a Stripe onboarding URL
 //   connect_status  - retrieve the account, persist payouts/charges readiness, return it
-//   setup_intent    - (Phase 2) save a customer card off-session
+//   setup_intent    - get/create the customer's Stripe Customer, return a SetupIntent secret
+//   set_default_pm  - set the just-saved card as the customer's default payment method
 //
 // Required function secrets (Supabase → Edge Functions → Secrets):
 //   STRIPE_SECRET_KEY   - sk_test_… (platform secret key)
@@ -63,6 +64,15 @@ async function getProvider(userId: string) {
   const { data } = await sb
     .from('provider_profiles')
     .select('id,user_id,stripe_account_id,payouts_enabled,charges_enabled')
+    .eq('user_id', userId)
+    .single();
+  return data;
+}
+
+async function getCustomer(userId: string) {
+  const { data } = await sb
+    .from('customer_profiles')
+    .select('id,user_id,stripe_customer_id')
     .eq('user_id', userId)
     .single();
   return data;
@@ -131,6 +141,39 @@ Deno.serve(async (req) => {
         details_submitted: !!acct.details_submitted,
         stripe_account_id: provider.stripe_account_id,
       });
+    }
+
+    if (action === 'setup_intent') {
+      // Save a customer's card off-session at the M&G proceed step (no charge here).
+      const customer = await getCustomer(user.id);
+      if (!customer) return json({ error: 'Not a customer account' }, 403);
+      let custId = customer.stripe_customer_id as string | null;
+      if (!custId) {
+        const c = await stripe('customers', 'POST', {
+          email: user.email,
+          metadata: { customer_profile_id: customer.id, user_id: user.id },
+        });
+        custId = c.id as string;
+        await sb.from('customer_profiles').update({ stripe_customer_id: custId }).eq('id', customer.id);
+      }
+      const si = await stripe('setup_intents', 'POST', {
+        customer: custId,
+        usage: 'off_session',
+        'payment_method_types[]': 'card',
+      });
+      return json({ client_secret: si.client_secret, customer_id: custId });
+    }
+
+    if (action === 'set_default_pm') {
+      // Make the just-saved card the customer's default so Phase 3 can charge it off-session.
+      const customer = await getCustomer(user.id);
+      if (!customer?.stripe_customer_id) return json({ error: 'No Stripe customer on file' }, 400);
+      const pm = String(payload.payment_method || '');
+      if (!pm) return json({ error: 'Missing payment_method' }, 400);
+      await stripe(`customers/${customer.stripe_customer_id}`, 'POST', {
+        'invoice_settings[default_payment_method]': pm,
+      });
+      return json({ ok: true });
     }
 
     return json({ error: `Unknown action: ${action}` }, 400);

--- a/supabase/migrations/20260628_tru144_customer_stripe_customer_id.sql
+++ b/supabase/migrations/20260628_tru144_customer_stripe_customer_id.sql
@@ -1,0 +1,9 @@
+-- TRU-144: Customer SetupIntent (Phase 2 of Stripe payments).
+-- Save a customer's card off-session at the meet & greet proceed step. Store the Stripe
+-- Customer id so the saved card can be charged on service completion (Phase 3).
+--
+-- Applied to the live DB via apply_migration (Supabase branching is broken on this repo);
+-- committed here for version control. The "Supabase Preview" check on the PR is expected to
+-- fail and is non-blocking (see TRU-145).
+alter table public.customer_profiles
+  add column if not exists stripe_customer_id text;


### PR DESCRIPTION
Phase 2 of the Stripe payments integration (epic TRU-22), building on TRU-143. Replaces the **stubbed** "Add a payment method" step in the meet & greet proceed flow with a real Stripe **SetupIntent + Payment Element**. The card is saved **off-session, not charged** (per the TRU-14 spec); the booking series activates only after the card is saved. Charging on completion is Phase 3.

## What's here
- **Migration** `20260628_tru144_customer_stripe_customer_id.sql` — `customer_profiles.stripe_customer_id`. **Already applied to the live DB** via `apply_migration` (committed for version control; Supabase Preview check expected to fail, non-blocking — see TRU-145).
- **Edge function** `stripe-api` — two new actions: `setup_intent` (ensure a Stripe Customer for the caller, store the id, return a SetupIntent `client_secret`, `usage: off_session`) and `set_default_pm` (set the saved card as the customer's default so the Phase-3 charge can use it off-session). **Deployed (v4).**
- **Client** `profile/index.html` — loads Stripe.js, mounts the Payment Element in the proceed overlay, `confirmSetup` (redirect: if_required), sets the default PM, then runs the existing series-activation PATCH. Adds the `pk_test` publishable key and a small `sbFn()` edge-function helper.

## Verification done (Preview MCP, as the cust_1dog test user)
- `setup_intent` creates a real Stripe customer (`cus_…`) and **persists** `stripe_customer_id` to the DB (confirmed via SQL); returns a valid `seti_…` secret.
- The Payment Element **mounts** in the proceed overlay, the confirm button enables on `ready`, loading state clears — **no console errors**.
- The literal card entry (typing `4242 4242 4242 4242` into Stripe's card field) + final save can't be automated because Stripe Elements runs in a cross-origin iframe — that's the one human step. The surrounding code (`confirmSetup` → `set_default_pm` → activate → success overlay) is standard.

## Note
- Carer-payout pre-check (block/inform if the carer hasn't finished payout setup) was deliberately **deferred** — charging is Phase 3, where carer-readiness actually matters, and a hard block here could deadlock the flow before a carer completes onboarding.

Next: Phase 3 — charge on completion (off-session destination charge, 15% application fee) + Stripe webhook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)