### PR TITLE
TRU-146: charge on completion — off-session destination charge + webhook

### DIFF
--- a/supabase/functions/charge-booking/index.ts
+++ b/supabase/functions/charge-booking/index.ts
@@ -1,0 +1,131 @@
+// TRU-146: charge a completed booking off-session via a Stripe destination charge.
+// Invoked server-to-server by the DB trigger (pg_net) — authenticates with the shared
+// x-webhook-secret header (verify_jwt off), same pattern as send-notification.
+//
+// Cadence-agnostic engine: charges one booking now (triggered on completion). A later
+// fortnightly per-(customer,carer) batch job can reuse the same Stripe call by summing
+// bookings and stamping the same PaymentIntent id on each.
+//
+// Required function secrets:
+//   STRIPE_SECRET_KEY, WEBHOOK_SECRET  (+ SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY injected)
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const STRIPE_SECRET_KEY = Deno.env.get('STRIPE_SECRET_KEY')!;
+const WEBHOOK_SECRET = Deno.env.get('WEBHOOK_SECRET')!;
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
+const SERVICE_ROLE = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+
+// Platform take rate in basis points. 1500 = 15%. Set to 0 for the 0%-commission launch
+// period — the application fee is then omitted entirely (Stripe requires it to be positive).
+const PLATFORM_FEE_BPS = 1500;
+const CURRENCY = 'aud';
+
+const sb = createClient(SUPABASE_URL, SERVICE_ROLE);
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+}
+
+function encode(obj: Record<string, unknown>, prefix = ''): string {
+  const parts: string[] = [];
+  for (const [k, v] of Object.entries(obj)) {
+    if (v === undefined || v === null) continue;
+    const key = prefix ? `${prefix}[${k}]` : k;
+    if (typeof v === 'object') parts.push(encode(v as Record<string, unknown>, key));
+    else parts.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(v))}`);
+  }
+  return parts.filter(Boolean).join('&');
+}
+
+async function stripe(path: string, method: 'GET' | 'POST', body?: Record<string, unknown>, idempotencyKey?: string) {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${STRIPE_SECRET_KEY}`,
+    'Content-Type': 'application/x-www-form-urlencoded',
+  };
+  if (idempotencyKey) headers['Idempotency-Key'] = idempotencyKey;
+  const res = await fetch(`https://api.stripe.com/v1/${path}`, { method, headers, body: body ? encode(body) : undefined });
+  const data = await res.json();
+  if (!res.ok) throw new Error(data?.error?.message || `Stripe ${path} failed (${res.status})`);
+  return data;
+}
+
+async function markFailed(bookingId: string, piId?: string) {
+  await sb.from('bookings')
+    .update({ payment_status: 'failed', ...(piId ? { stripe_payment_intent_id: piId } : {}) })
+    .eq('id', bookingId);
+}
+
+Deno.serve(async (req) => {
+  if (req.method !== 'POST') return json({ error: 'Method not allowed' }, 405);
+  if (req.headers.get('x-webhook-secret') !== WEBHOOK_SECRET) return json({ error: 'Unauthorized' }, 401);
+
+  let payload: Record<string, unknown>;
+  try { payload = await req.json(); } catch { return json({ error: 'Bad JSON' }, 400); }
+  const bookingId = String(payload.booking_id || '');
+  if (!bookingId) return json({ error: 'Missing booking_id' }, 400);
+
+  try {
+    const { data: b } = await sb.from('bookings')
+      .select('id,total_cents,customer_id,provider_id,is_meet_and_greet,payment_status')
+      .eq('id', bookingId).single();
+    if (!b) return json({ error: 'booking not found' }, 404);
+    if (b.is_meet_and_greet || (b.total_cents || 0) <= 0) return json({ skipped: 'not chargeable' });
+
+    // Atomic claim: only one invocation may move unpaid/failed -> processing.
+    const { data: claimed } = await sb.from('bookings')
+      .update({ payment_status: 'processing' })
+      .eq('id', bookingId).in('payment_status', ['unpaid', 'failed'])
+      .select('id');
+    if (!claimed || !claimed.length) return json({ skipped: 'already processing or paid' });
+
+    const { data: cp } = await sb.from('customer_profiles').select('stripe_customer_id').eq('id', b.customer_id).single();
+    if (!cp?.stripe_customer_id) { await markFailed(bookingId); return json({ error: 'customer has no Stripe customer' }, 400); }
+
+    const cust = await stripe(`customers/${cp.stripe_customer_id}`, 'GET');
+    const pm = cust?.invoice_settings?.default_payment_method;
+    if (!pm) { await markFailed(bookingId); return json({ error: 'no saved card on file' }, 400); }
+
+    const { data: pp } = await sb.from('provider_profiles').select('stripe_account_id').eq('id', b.provider_id).single();
+    if (!pp?.stripe_account_id) { await markFailed(bookingId); return json({ error: 'carer has no payout account' }, 400); }
+
+    const fee = Math.round((b.total_cents * PLATFORM_FEE_BPS) / 10000);
+    const piBody: Record<string, unknown> = {
+      amount: b.total_cents,
+      currency: CURRENCY,
+      customer: cp.stripe_customer_id,
+      payment_method: pm,
+      off_session: true,
+      confirm: true,
+      'transfer_data[destination]': pp.stripe_account_id,
+      'metadata[booking_id]': bookingId,
+    };
+    if (fee > 0) piBody['application_fee_amount'] = fee; // omitted at 0% — Stripe requires it positive
+
+    let pi;
+    try {
+      // Idempotency guard against a pg_net retry double-charging the same booking.
+      pi = await stripe('payment_intents', 'POST', piBody, `charge_${bookingId}`);
+    } catch (e) {
+      await markFailed(bookingId);
+      return json({ ok: false, error: 'charge failed', detail: String((e as Error)?.message || e) }, 402);
+    }
+
+    if (pi.status === 'succeeded') {
+      await sb.from('bookings').update({
+        payment_status: 'paid',
+        stripe_payment_intent_id: pi.id,
+        application_fee_cents: fee,
+        charged_at: new Date().toISOString(),
+      }).eq('id', bookingId);
+      return json({ ok: true, payment_intent: pi.id, amount: b.total_cents, application_fee_cents: fee });
+    }
+
+    // requires_action etc. — an off-session charge can't complete; flag for follow-up.
+    await sb.from('bookings').update({ payment_status: 'failed', stripe_payment_intent_id: pi.id }).eq('id', bookingId);
+    return json({ ok: false, status: pi.status, payment_intent: pi.id });
+  } catch (e) {
+    console.error('charge-booking error', bookingId, e);
+    return json({ error: String((e as Error)?.message || e) }, 500);
+  }
+});

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -1,0 +1,80 @@
+// TRU-146: Stripe webhook — reconcile charge + connected-account outcomes.
+// verify_jwt off; we verify Stripe's signature ourselves (HMAC-SHA256 over `${t}.${rawBody}`)
+// with STRIPE_WEBHOOK_SIGNING_SECRET, so no SDK is needed.
+//
+// Handles:
+//   payment_intent.succeeded       -> booking.payment_status = paid
+//   payment_intent.payment_failed  -> booking.payment_status = failed
+//   account.updated                -> provider_profiles payout/charge readiness (so a carer
+//                                     finishing onboarding flips payouts_enabled automatically)
+//
+// Required function secrets:
+//   STRIPE_WEBHOOK_SIGNING_SECRET  (whsec_…, from the registered webhook endpoint)
+//   (SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY injected automatically)
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const SIGNING_SECRET = Deno.env.get('STRIPE_WEBHOOK_SIGNING_SECRET')!;
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
+const SERVICE_ROLE = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+
+const sb = createClient(SUPABASE_URL, SERVICE_ROLE);
+
+// Verify Stripe's signature header: "t=<ts>,v1=<hex hmac>".
+async function verifySignature(rawBody: string, sigHeader: string | null, secret: string): Promise<boolean> {
+  if (!sigHeader) return false;
+  const parts: Record<string, string> = {};
+  for (const seg of sigHeader.split(',')) {
+    const i = seg.indexOf('=');
+    if (i > 0) parts[seg.slice(0, i)] = seg.slice(i + 1);
+  }
+  const t = parts['t'], v1 = parts['v1'];
+  if (!t || !v1) return false;
+  const key = await crypto.subtle.importKey('raw', new TextEncoder().encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+  const mac = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(`${t}.${rawBody}`));
+  const expected = [...new Uint8Array(mac)].map((b) => b.toString(16).padStart(2, '0')).join('');
+  if (expected.length !== v1.length) return false;
+  let diff = 0;
+  for (let i = 0; i < expected.length; i++) diff |= expected.charCodeAt(i) ^ v1.charCodeAt(i);
+  return diff === 0;
+}
+
+Deno.serve(async (req) => {
+  if (req.method !== 'POST') return new Response('Method not allowed', { status: 405 });
+  const raw = await req.text();
+  if (!(await verifySignature(raw, req.headers.get('Stripe-Signature'), SIGNING_SECRET))) {
+    return new Response('Bad signature', { status: 400 });
+  }
+
+  let evt: Record<string, unknown>;
+  try { evt = JSON.parse(raw); } catch { return new Response('Bad JSON', { status: 400 }); }
+
+  const type = String(evt.type || '');
+  const obj = ((evt.data as Record<string, unknown>)?.object || {}) as Record<string, unknown>;
+
+  try {
+    if (type === 'payment_intent.succeeded') {
+      const bid = (obj.metadata as Record<string, string>)?.booking_id;
+      if (bid) {
+        await sb.from('bookings')
+          .update({ payment_status: 'paid', stripe_payment_intent_id: obj.id as string, charged_at: new Date().toISOString() })
+          .eq('id', bid).neq('payment_status', 'paid');
+      }
+    } else if (type === 'payment_intent.payment_failed') {
+      const bid = (obj.metadata as Record<string, string>)?.booking_id;
+      if (bid) {
+        await sb.from('bookings')
+          .update({ payment_status: 'failed', stripe_payment_intent_id: obj.id as string })
+          .eq('id', bid).neq('payment_status', 'paid');
+      }
+    } else if (type === 'account.updated') {
+      await sb.from('provider_profiles')
+        .update({ payouts_enabled: !!obj.payouts_enabled, charges_enabled: !!obj.charges_enabled })
+        .eq('stripe_account_id', obj.id as string);
+    }
+    return new Response(JSON.stringify({ received: true }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  } catch (e) {
+    console.error('stripe-webhook error', type, e);
+    return new Response(JSON.stringify({ error: String(e) }), { status: 500, headers: { 'Content-Type': 'application/json' } });
+  }
+});

--- a/supabase/migrations/20260628_tru146_charge_on_completion.sql
+++ b/supabase/migrations/20260628_tru146_charge_on_completion.sql
@@ -1,0 +1,50 @@
+-- TRU-146: Charge on completion (Phase 3 of Stripe payments).
+-- When a booking is marked completed, charge the customer's saved card off-session via a
+-- Stripe destination charge to the carer's connected account (15% application fee), recorded
+-- per booking. A DB trigger dispatches the charge asynchronously (pg_net) so a payment hiccup
+-- can never roll back the booking write. Mirrors the email pipeline (private.notify_email).
+--
+-- Applied to the live DB via apply_migration (Supabase branching is broken on this repo);
+-- committed here for version control. The "Supabase Preview" check on the PR is expected to
+-- fail and is non-blocking (see TRU-145).
+
+-- Per-booking payment tracking. A single PaymentIntent may settle multiple bookings, so a
+-- later fortnightly per-(customer,carer) batch job can reuse the same charge engine.
+alter table public.bookings
+  add column if not exists payment_status text not null default 'unpaid'
+    check (payment_status in ('unpaid','processing','paid','failed')),
+  add column if not exists stripe_payment_intent_id text,
+  add column if not exists application_fee_cents integer,
+  add column if not exists charged_at timestamptz;
+
+-- Fire-and-forget POST to the charge-booking Edge Function, reusing private.stripe_config
+-- (function_base_url + shared webhook_secret), inserted out of band so the secret stays out of git.
+create or replace function private.charge_booking(p_booking_id uuid)
+returns void language plpgsql security definer set search_path = '' as $$
+declare cfg private.stripe_config;
+begin
+  select * into cfg from private.stripe_config where id = 1 and enabled = true;
+  if cfg.function_base_url is null then return; end if;
+  perform net.http_post(
+    url := cfg.function_base_url || '/charge-booking',
+    headers := jsonb_build_object('Content-Type','application/json','x-webhook-secret',cfg.webhook_secret),
+    body := jsonb_build_object('booking_id', p_booking_id)
+  );
+end; $$;
+
+-- Charge a booking when it completes. Never the (free) M&G; never a zero-value or
+-- already-charged booking. Wrapped so a charge hiccup can't roll back the completion write.
+create or replace function private.tg_charge_on_completion() returns trigger language plpgsql security definer set search_path = '' as $$
+begin
+  if NEW.status = 'completed' and OLD.status is distinct from 'completed'
+     and not coalesce(NEW.is_meet_and_greet, false)
+     and coalesce(NEW.total_cents, 0) > 0
+     and coalesce(NEW.payment_status, 'unpaid') in ('unpaid','failed') then
+    begin perform private.charge_booking(NEW.id);
+    exception when others then null; end;
+  end if;
+  return NEW;
+end; $$;
+
+drop trigger if exists trg_charge_on_completion on public.bookings;
+create trigger trg_charge_on_completion after update on public.bookings for each row execute function private.tg_charge_on_completion();


### PR DESCRIPTION
Phase 3 (final) of the Stripe payments integration (epic TRU-22), building on TRU-143 + TRU-144. When a booking is marked completed, the customer's saved card is charged **off-session** via a Stripe **destination charge** to the carer's connected account, with a 15% application fee. A webhook reconciles the outcome. Test mode (sandbox).

## What's here
- **Migration** `20260628_tru146_charge_on_completion.sql` — `bookings.payment_status` (unpaid/processing/paid/failed) + `stripe_payment_intent_id` + `application_fee_cents` + `charged_at`; `private.charge_booking()` + an AFTER UPDATE trigger that dispatches the charge via `pg_net` (mirrors the email pipeline; wrapped so a charge hiccup can never roll back the completion write). **Applied to the live DB** (committed for version control; Supabase Preview check expected red, non-blocking — TRU-145).
- **`charge-booking`** edge fn (verify_jwt off, `x-webhook-secret`) — atomic `unpaid→processing` claim, off-session PaymentIntent (`transfer_data[destination]` = carer + `application_fee_amount` = 15%), records the outcome; idempotency-keyed against pg_net retries. **Deployed.**
- **`stripe-webhook`** edge fn (verify_jwt off) — `payment_intent.succeeded/failed` → booking status, `account.updated` → carer payout flags; **Stripe signature verified via HMAC-SHA256** (no SDK). **Deployed.**
- `private.stripe_config` row inserted (out of band).

## Design (from session discussion)
- **Fee = config constant** `PLATFORM_FEE_BPS=1500`; at 0% the application fee is omitted entirely (Stripe requires it positive). So the founder's 0%-for-3–6-months launch is a one-line flip.
- **Cadence-agnostic + batch-ready**: charges per booking now (triggered on completion); a single PaymentIntent can settle many bookings, so a later fortnightly per-(customer,carer) batch job reuses this engine unchanged. (Minimises the fixed A$0.30/charge fee — matters most at 0% commission, where the platform absorbs Stripe fees.)

## Verification done (live, test mode)
- Both functions deployed + correctly gated: `charge-booking` → 401 without the secret, 404 for an unknown booking; `stripe-webhook` → 400 on an unsigned request (signature check active).
- **End-to-end trigger proven:** inserted a real completed booking → `payment_status` moved `unpaid → failed` via the trigger → pg_net → `charge-booking`, which claimed the booking, looked up the customer, found no saved card and correctly declined to charge. (Test booking cleaned up.)

## ⚠️ Remaining for a green `paid` charge (live test, your side)
1. **Register a Stripe webhook endpoint** → `https://gadflsntbnbnnxbpiral.supabase.co/functions/v1/stripe-webhook`, events `payment_intent.succeeded`, `payment_intent.payment_failed`, `account.updated` → set its `whsec_…` as the `STRIPE_WEBHOOK_SIGNING_SECRET` function secret. (Webhook isn't needed for the charge itself — it confirms synchronously — only for reconciliation + auto-flipping carer payout status.)
2. **A carer with completed test onboarding** (transfers active) + **a customer with a saved card** (4242 via the M&G proceed flow). Then complete a booking → expect `payment_status=paid`, a PaymentIntent with `application_fee_amount` = 15% and the carer transfer = 85%.

Happy to drive/verify that final pass once the webhook secret + an onboarded carer are in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)