### PR TITLE
TRU-147: fix M&G payment modal overflow on small screens

### DIFF
--- a/profile/index.html
+++ b/profile/index.html
@@ -1039,8 +1039,12 @@ function mgOverlay(html) {
   closeMgOverlay();
   const o = document.createElement('div');
   o.id = 'mgOverlay';
-  o.style.cssText = 'position:fixed;inset:0;background:rgba(40,30,25,.55);display:flex;align-items:center;justify-content:center;padding:1rem;z-index:1000;';
-  o.innerHTML = `<div class="form-card fade-in" style="max-width:460px;width:100%;margin:0;background:#fff;border-radius:14px;padding:1.5rem;">${html}</div>`;
+  // display:flex + child margin:auto centres the card when it fits; overflow-y:auto lets a
+  // tall modal (e.g. the Stripe Payment Element) scroll so its buttons stay reachable on
+  // short screens / the app WebView (TRU-147). Don't use align/justify centre here — that
+  // clips an overflowing card at top and bottom with no way to scroll to it.
+  o.style.cssText = 'position:fixed;inset:0;background:rgba(40,30,25,.55);display:flex;padding:1rem;z-index:1000;overflow-y:auto;';
+  o.innerHTML = `<div class="form-card fade-in" style="max-width:460px;width:100%;margin:auto;background:#fff;border-radius:14px;padding:1.5rem;">${html}</div>`;
   document.body.appendChild(o);
 }
 function closeMgOverlay() { const o = document.getElementById('mgOverlay'); if (o) o.remove(); }


### PR DESCRIPTION
**Bug** (found testing the Stripe payment flow on mobile/in-app): the customer meet & greet overlays (`profile/index.html` `mgOverlay`) centred content with flexbox (`align-items/justify-content:center`) and the container had no scroll. On short viewports — notably the native app WebView — a tall modal like the Stripe **Payment Element** became taller than the viewport, so the card was clipped at top and bottom and the action buttons (**"Save card & go ahead" / "Not now"**) rendered **off-screen and unreachable**. This blocked the customer payment flow.

## Fix
`mgOverlay`: `display:flex; overflow-y:auto; padding:1rem` (drop the hard `align-items/justify-content:center`) + card `margin:auto`. It still centres when the modal fits, and scrolls — keeping the card top and the buttons reachable — when it doesn't. One change covers every customer overlay routed through `mgOverlay` (payment, success, decline, education).

## Verified (Preview MCP)
| Viewport | Before | After |
|---|---|---|
| 375×600 | Save button at 638px, below the 600 fold; overlay `overflow-y:visible`, card top clipped at −62 | overlay `overflow-y:auto`; button reachable |
| 375×400 | button at 717px, off-screen | scroll → card top at 16px and Save button at 360px, both on-screen ✅ |

Screenshot confirms both buttons fully visible/selectable after scroll. No JS changes — pure layout fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)