### PR TITLE
TRU-149: failed-charge handling — notify customer + retry

### DIFF
--- a/profile/index.html
+++ b/profile/index.html
@@ -427,13 +427,25 @@ function actionButtons(b) {
     return `<button class="btn-ghost danger" onclick="showCancelConfirm('${b.id}')">Cancel</button>`;
   }
   if (b.status === 'completed') {
+    const retryBtn = b.payment_status === 'failed'
+      ? `<button class="btn-track" onclick="retryPayment('${b.id}')">Retry payment</button>` : '';
     const reviewBtn = b._has_review
       ? `<a href="/review/?booking=${b.id}" class="btn-ghost">Edit review</a>`
-      : `<a href="/review/?booking=${b.id}" class="btn-track">Leave a review</a>`;
+      : `<a href="/review/?booking=${b.id}" class="${retryBtn ? 'btn-ghost' : 'btn-track'}">Leave a review</a>`;
     const viewWalk = `<a href="/track/?booking=${b.id}" class="btn-ghost">View walk</a>`;
     const bookAgain = b._provider_user_id ? `<a href="/book/?provider=${b._provider_user_id}" class="btn-ghost">Book again</a>` : '';
-    return [reviewBtn, viewWalk, bookAgain].filter(Boolean).join('');
+    return [retryBtn, reviewBtn, viewWalk, bookAgain].filter(Boolean).join('');
   }
+  return '';
+}
+// Per-booking payment state shown on completed bookings (TRU-149).
+function paymentNotice(b) {
+  if (b.status !== 'completed' || !b.payment_status) return '';
+  if (b.payment_status === 'failed') {
+    return `<div style="margin-bottom:10px;background:#fdeeee;border:1px solid #f3c9c9;border-radius:8px;padding:8px 12px;font-size:0.82rem;color:#9a3b3b;">Payment didn't go through — retry below to complete it.</div>`;
+  }
+  if (b.payment_status === 'refunded') return `<div style="margin-bottom:10px;font-size:0.8rem;color:var(--text-muted);">Refunded</div>`;
+  if (b.payment_status === 'paid') return `<div style="margin-bottom:10px;font-size:0.8rem;color:var(--success,#5B8C5A);">Paid ✓</div>`;
   return '';
 }
 function cancelConfirmHtml(b) {
@@ -569,6 +581,7 @@ function bookingCardHtml(b) {
       <div class="bc-meta">${serviceLabel} · ${provLabel}</div>
       <div class="bc-time">${esc(dateStr)}</div>
       ${statusBadge(b.status)}
+      ${paymentNotice(b)}
       <div class="bc-actions">${actions}${msgLink}</div>
     </div>
   `;
@@ -1107,6 +1120,56 @@ async function confirmProceedMg(seriesId) {
   } catch(e) {
     if (m) { m.textContent = e.message; m.className = 'msg error'; }
     if (btn) { btn.disabled = false; btn.textContent = 'Save card & go ahead'; }
+  }
+}
+
+// Retry a failed charge on-session (TRU-149) — reuses the Stripe Payment Element plumbing.
+async function retryPayment(bookingId) {
+  mgOverlay(`
+    <h2 style="margin-top:0;">Retry payment</h2>
+    <p style="font-size:0.9rem;">Your last payment didn't go through. Pop your card in to complete it — your carer's already done the work.</p>
+    <div id="mgPaymentElement" style="margin:1rem 0;min-height:40px;"></div>
+    <div id="mgOverlayMsg" class="msg" style="font-size:0.84rem;color:var(--text-muted);">Loading secure card form…</div>
+    <div style="display:flex;gap:10px;justify-content:flex-end;flex-wrap:wrap;">
+      <button class="btn-ghost" onclick="closeMgOverlay()">Not now</button>
+      <button class="btn-track" id="mgPayConfirm" onclick="confirmRetryPayment('${bookingId}')" disabled>Pay now</button>
+    </div>`);
+  try {
+    if (!window.Stripe) throw new Error('Could not load the secure card form. Please refresh and try again.');
+    const { client_secret } = await sbFn('stripe-api', { action: 'retry_charge', booking_id: bookingId });
+    mgStripe = mgStripe || Stripe(STRIPE_PK);
+    mgElements = mgStripe.elements({ clientSecret: client_secret, appearance: { theme: 'flat', variables: { colorPrimary: '#C4866A' } } });
+    const pe = mgElements.create('payment');
+    pe.mount('#mgPaymentElement');
+    pe.on('ready', () => {
+      const b = document.getElementById('mgPayConfirm'); if (b) b.disabled = false;
+      const m = document.getElementById('mgOverlayMsg'); if (m) { m.textContent = ''; m.className = 'msg'; }
+    });
+  } catch (e) {
+    const m = document.getElementById('mgOverlayMsg'); if (m) { m.textContent = e.message; m.className = 'msg error'; }
+  }
+}
+async function confirmRetryPayment(bookingId) {
+  const btn = document.getElementById('mgPayConfirm');
+  const m = document.getElementById('mgOverlayMsg');
+  if (btn) { btn.disabled = true; btn.textContent = 'Paying…'; }
+  if (m) { m.textContent = ''; m.className = 'msg'; }
+  try {
+    if (!mgStripe || !mgElements) throw new Error('Card form not ready — please try again.');
+    const { error } = await mgStripe.confirmPayment({ elements: mgElements, redirect: 'if_required' });
+    if (error) throw new Error(error.message || 'Payment failed.');
+    const res = await sbFn('stripe-api', { action: 'sync_payment', booking_id: bookingId });
+    if (res.payment_status === 'paid') {
+      mgOverlay(`
+        <h2 style="margin-top:0;">Payment complete</h2>
+        <p>Thank you — that's all sorted, and your carer has been paid.</p>
+        <div style="display:flex;justify-content:flex-end;"><button class="btn-track" onclick="closeMgOverlay();reloadBookings()">Done</button></div>`);
+    } else {
+      throw new Error("That payment didn't go through either — try a different card.");
+    }
+  } catch (e) {
+    if (m) { m.textContent = e.message; m.className = 'msg error'; }
+    if (btn) { btn.disabled = false; btn.textContent = 'Pay now'; }
   }
 }
 

--- a/supabase/functions/send-notification/index.ts
+++ b/supabase/functions/send-notification/index.ts
@@ -146,6 +146,22 @@ async function buildMessages(type: string, payload: Record<string, unknown>) {
         footnote: "You're receiving this because you have a booking with Truffl Pets.",
       }),
     });
+  } else if (type === 'payment_failed') {
+    const d = await loadBooking(payload.booking_id as string);
+    if (!d.customer?.email) return out;
+    const amount = d.booking.total_cents ? `$${(d.booking.total_cents / 100).toFixed(2)}` : 'the amount due';
+    out.push({
+      to: d.customer.email,
+      subject: `Payment didn't go through for ${d.petName}'s ${d.serviceLabel.toLowerCase()}`,
+      html: layout({
+        preview: "We couldn't process your payment",
+        heading: "We couldn't process your payment",
+        body: p(`Hi ${esc(d.customer.first_name || 'there')}, we tried to charge ${amount} for ${esc(d.petName)}'s ${esc(d.serviceLabel.toLowerCase())} with ${esc(d.provider?.first_name || 'your carer')}, but it didn't go through — usually a small card issue.`) +
+          p('Pop back in and retry whenever you’re ready — it only takes a moment.'),
+        cta: { label: 'Retry payment', href: `${SITE}/profile/` },
+        footnote: 'Your carer has already provided the service, so please retry soon.',
+      }),
+    });
   } else if (type === 'walk_started') {
     const { data: ws } = await sb.from('walk_sessions').select('booking_id').eq('id', payload.walk_session_id as string).single();
     if (!ws) return out;

--- a/supabase/functions/stripe-api/index.ts
+++ b/supabase/functions/stripe-api/index.ts
@@ -10,6 +10,8 @@
 //   connect_status  - retrieve the account, persist payouts/charges readiness, return it
 //   setup_intent    - get/create the customer's Stripe Customer, return a SetupIntent secret
 //   set_default_pm  - set the just-saved card as the customer's default payment method
+//   retry_charge    - recover a failed charge on-session (returns a PaymentIntent secret)
+//   sync_payment    - reconcile a booking's payment_status from its PaymentIntent
 //
 // Required function secrets (Supabase → Edge Functions → Secrets):
 //   STRIPE_SECRET_KEY   - sk_test_… (platform secret key)
@@ -21,6 +23,8 @@ const STRIPE_SECRET_KEY = Deno.env.get('STRIPE_SECRET_KEY')!;
 const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
 const SERVICE_ROLE = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
 const SITE = 'https://trufflpets.com';
+// Platform take rate in basis points (matches charge-booking). 1500 = 15%; set 0 at launch.
+const PLATFORM_FEE_BPS = 1500;
 
 const sb = createClient(SUPABASE_URL, SERVICE_ROLE);
 
@@ -174,6 +178,67 @@ Deno.serve(async (req) => {
         'invoice_settings[default_payment_method]': pm,
       });
       return json({ ok: true });
+    }
+
+    if (action === 'retry_charge') {
+      // Customer recovers a failed off-session charge on-session (can fix/replace the card).
+      const customer = await getCustomer(user.id);
+      if (!customer) return json({ error: 'Not a customer account' }, 403);
+      const bookingId = String(payload.booking_id || '');
+      const { data: b } = await sb.from('bookings')
+        .select('id,total_cents,provider_id,is_meet_and_greet,payment_status')
+        .eq('id', bookingId).eq('customer_id', customer.id).single();
+      if (!b) return json({ error: 'Booking not found' }, 404);
+      if (b.is_meet_and_greet || (b.total_cents || 0) <= 0) return json({ error: 'Nothing to pay' }, 400);
+      if (b.payment_status !== 'failed') return json({ error: 'This booking is not awaiting payment' }, 400);
+      if (!customer.stripe_customer_id) return json({ error: 'No payment profile on file' }, 400);
+      const { data: pp } = await sb.from('provider_profiles').select('stripe_account_id').eq('id', b.provider_id).single();
+      if (!pp?.stripe_account_id) return json({ error: 'Carer has no payout account' }, 400);
+
+      const fee = Math.round((b.total_cents * PLATFORM_FEE_BPS) / 10000);
+      const piBody: Record<string, unknown> = {
+        amount: b.total_cents,
+        currency: 'aud',
+        customer: customer.stripe_customer_id,
+        'transfer_data[destination]': pp.stripe_account_id,
+        'payment_method_types[]': 'card',
+        setup_future_usage: 'off_session', // save the working card for future charges
+        'metadata[booking_id]': bookingId,
+      };
+      if (fee > 0) piBody['application_fee_amount'] = fee;
+      // No confirm — the client confirms with the Payment Element so a new card / 3DS works.
+      const pi = await stripe('payment_intents', 'POST', piBody);
+      await sb.from('bookings').update({ stripe_payment_intent_id: pi.id, application_fee_cents: fee }).eq('id', bookingId);
+      return json({ client_secret: pi.client_secret });
+    }
+
+    if (action === 'sync_payment') {
+      // Reconcile a booking's payment from its PaymentIntent after the client confirms
+      // (webhook-independent). Used by the retry flow.
+      const customer = await getCustomer(user.id);
+      if (!customer) return json({ error: 'Not a customer account' }, 403);
+      const bookingId = String(payload.booking_id || '');
+      const { data: b } = await sb.from('bookings')
+        .select('id,stripe_payment_intent_id,payment_status')
+        .eq('id', bookingId).eq('customer_id', customer.id).single();
+      if (!b) return json({ error: 'Booking not found' }, 404);
+      if (!b.stripe_payment_intent_id) return json({ payment_status: b.payment_status });
+      const pi = await stripe(`payment_intents/${b.stripe_payment_intent_id}`, 'GET');
+      if (pi.status === 'succeeded') {
+        await sb.from('bookings')
+          .update({ payment_status: 'paid', charged_at: new Date().toISOString() })
+          .eq('id', bookingId).neq('payment_status', 'paid');
+        // Make the card that worked the customer's default for future off-session charges.
+        if (pi.payment_method && customer.stripe_customer_id) {
+          try { await stripe(`customers/${customer.stripe_customer_id}`, 'POST', { 'invoice_settings[default_payment_method]': pi.payment_method }); } catch (_e) { /* non-fatal */ }
+        }
+        return json({ payment_status: 'paid' });
+      }
+      if (pi.status === 'requires_payment_method' || pi.status === 'canceled') {
+        await sb.from('bookings').update({ payment_status: 'failed' }).eq('id', bookingId).neq('payment_status', 'paid');
+        return json({ payment_status: 'failed' });
+      }
+      return json({ payment_status: b.payment_status, pi_status: pi.status });
     }
 
     return json({ error: `Unknown action: ${action}` }, 400);

--- a/supabase/migrations/20260629_tru149_payment_failed_email.sql
+++ b/supabase/migrations/20260629_tru149_payment_failed_email.sql
@@ -1,0 +1,18 @@
+-- TRU-149: notify the customer when an off-session charge fails on completion.
+-- Mirrors the email pipeline (private.notify_email → send-notification). Exception-wrapped so
+-- an email hiccup can never roll back the booking write.
+--
+-- Applied to the live DB via apply_migration (Supabase branching is broken on this repo);
+-- committed here for version control. The "Supabase Preview" check on the PR is expected to
+-- fail and is non-blocking (see TRU-145).
+create or replace function private.tg_payment_failed() returns trigger language plpgsql security definer set search_path = '' as $$
+begin
+  if NEW.payment_status = 'failed' and OLD.payment_status is distinct from 'failed' then
+    begin perform private.notify_email(jsonb_build_object('type','payment_failed','booking_id',NEW.id));
+    exception when others then null; end;
+  end if;
+  return NEW;
+end; $$;
+
+drop trigger if exists trg_email_payment_failed on public.bookings;
+create trigger trg_email_payment_failed after update on public.bookings for each row execute function private.tg_payment_failed();


### PR DESCRIPTION
Phase A of payment hardening (epic TRU-22), follows TRU-146. A failed off-session charge on completion previously just set `payment_status='failed'` **silently** — the customer wasn't told, the carer worked unpaid, and there was no recovery path. Now the customer is emailed and can retry on-session.

## What's here
- **Migration** `20260629_tru149_payment_failed_email.sql` — AFTER UPDATE trigger on `bookings` when `payment_status`→`failed` → `private.notify_email({type:'payment_failed'})` (mirrors the email pipeline; exception-wrapped). **Applied live** (Supabase Preview check expected red, non-blocking — TRU-145).
- **`send-notification`** — `payment_failed` customer email ("we couldn't process your payment — retry"), CTA to `/profile/`. **Deployed.**
- **`stripe-api`** — `retry_charge` (on-session PaymentIntent for the failed booking → returns a `client_secret`; `setup_future_usage:off_session` so the fixed card is saved) + `sync_payment` (reconcile `paid`/`failed` from the PI after the client confirms — webhook-independent; promotes the working card to the customer's default). **Deployed (v6).**
- **`profile/index.html`** — a "Payment didn't go through — retry below" notice + **Retry payment** button on failed completed bookings (plus a subtle `Paid ✓` / `Refunded` indicator). Retry reuses the scrollable Payment Element overlay (`confirmPayment` → `sync_payment`).

## Verified (live, test mode, as Sarah)
- Failed-state UI renders: notice + Retry button; `Paid ✓` on a paid booking; no console errors.
- `retry_charge` creates a PaymentIntent and returns a `client_secret`.
- `sync_payment` reads the live (unconfirmed) PI and correctly keeps it `failed` — no false "paid".
- `payment_failed` email renders + sends (`sent:1, allOk:true`, accepted by Resend).
- The card-entry→`paid` step is the cross-origin Stripe iframe (can't be automated) — it reuses the exact Payment Element + confirm plumbing already proven by the live $25 charge.

Next (Phase B, TRU-150-ish): refunds + the founder admin page. 🤖 Generated with [Claude Code](https://claude.com/claude-code)