### PR TITLE
TRU-150: refunds + founder admin page (re-target to main)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Admin · Refunds — Truffl Pets</title>
+<meta name="robots" content="noindex,nofollow">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@500;600&display=swap" rel="stylesheet">
+<style>
+  :root{--cream:#F7F3EE;--brown:#5C4033;--terracotta:#C4866A;--border:#E7DFD6;--text:#3A2E28;--muted:#7A6860;--success:#5B8C5A;--error:#b3261e;}
+  *{box-sizing:border-box;}
+  body{margin:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;background:var(--cream);color:var(--text);}
+  .wrap{max-width:820px;margin:0 auto;padding:24px 16px 64px;}
+  h1{font-family:'Cormorant Garamond',Georgia,serif;font-weight:500;color:var(--brown);font-size:1.9rem;margin:0 0 4px;}
+  .sub{color:var(--muted);font-size:0.9rem;margin:0 0 24px;line-height:1.5;}
+  .card{background:#fff;border:1px solid var(--border);border-radius:12px;padding:14px 16px;margin-bottom:10px;}
+  .row-top{display:flex;justify-content:space-between;gap:12px;align-items:baseline;flex-wrap:wrap;}
+  .amount{font-weight:600;color:var(--brown);}
+  .meta{font-size:0.84rem;color:var(--muted);margin-top:2px;}
+  .badge{display:inline-block;font-size:0.68rem;font-weight:700;text-transform:uppercase;letter-spacing:.04em;padding:2px 8px;border-radius:20px;vertical-align:middle;margin-left:6px;}
+  .b-paid{background:#e7f1e6;color:var(--success);}
+  .b-failed{background:#fdeeee;color:#9a3b3b;}
+  .b-refunded{background:#f0ebe4;color:var(--muted);}
+  button{font:inherit;cursor:pointer;border-radius:8px;padding:8px 14px;border:1px solid var(--terracotta);background:var(--terracotta);color:#fff;font-size:0.86rem;}
+  button:disabled{opacity:.55;cursor:default;}
+  .actions{margin-top:10px;display:flex;gap:8px;align-items:center;flex-wrap:wrap;}
+  input.reason{font:inherit;padding:7px 10px;border:1px solid var(--border);border-radius:8px;flex:1;min-width:160px;}
+  .msg{font-size:0.85rem;margin:8px 0;min-height:1em;}
+  .msg.error{color:var(--error);}
+  .msg.ok{color:var(--success);}
+  .empty{color:var(--muted);text-align:center;padding:40px 0;}
+  .empty a{color:var(--terracotta);}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>Refunds</h1>
+  <p class="sub">Recent charges. Refunding returns the full amount to the customer and reverses the carer's payout (including the platform fee).</p>
+  <div id="msg" class="msg"></div>
+  <div id="list"><p class="empty">Loading…</p></div>
+</div>
+<script>
+const SUPABASE_URL = 'https://gadflsntbnbnnxbpiral.supabase.co';
+const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdhZGZsc250Ym5ibm54YnBpcmFsIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzUwNjcwNTcsImV4cCI6MjA5MDY0MzA1N30.g5ZrqeAX9U5l7oDZEbQFrU5j10828dUF0QuJ0ZlHXK8';
+let authToken = null;
+try { const s = JSON.parse(localStorage.getItem('truffl_session') || 'null'); if (s) authToken = s.access_token; } catch (e) {}
+
+function h(t) { const o = { 'Content-Type':'application/json', 'apikey':SUPABASE_ANON_KEY, 'Authorization':'Bearer ' + SUPABASE_ANON_KEY }; if (t) o['Authorization'] = 'Bearer ' + t; return o; }
+async function sbFn(name, body) {
+  const r = await fetch(`${SUPABASE_URL}/functions/v1/${name}`, { method:'POST', headers:h(authToken), body:JSON.stringify(body || {}) });
+  const d = await r.json().catch(() => ({}));
+  if (!r.ok) throw new Error(d.error || ('Request failed (' + r.status + ')'));
+  return d;
+}
+function esc(s) { return (s || '').toString().replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
+function money(c) { return '$' + ((c || 0) / 100).toFixed(2); }
+function when(iso) { if (!iso) return ''; try { return new Date(iso).toLocaleDateString('en-AU', { day:'numeric', month:'short', year:'numeric' }); } catch (e) { return ''; } }
+function showMsg(t, type) { const m = document.getElementById('msg'); m.textContent = t || ''; m.className = 'msg' + (type ? ' ' + type : ''); }
+
+function cardHtml(c) {
+  const cls = c.payment_status === 'paid' ? 'b-paid' : c.payment_status === 'failed' ? 'b-failed' : 'b-refunded';
+  const dateStr = c.charged_at ? when(c.charged_at) : when(c.scheduled_at);
+  const ctl = c.payment_status === 'paid'
+    ? `<div class="actions"><input class="reason" id="reason-${c.id}" placeholder="Reason (optional)"><button onclick="refund('${c.id}')">Refund ${money(c.total_cents)}</button></div>`
+    : c.payment_status === 'refunded'
+      ? `<div class="meta">Refunded${c.refunded_at ? ' · ' + when(c.refunded_at) : ''}</div>`
+      : `<div class="meta">Charge failed — awaiting customer retry</div>`;
+  return `<div class="card" id="card-${c.id}">
+    <div class="row-top"><div><span class="amount">${money(c.total_cents)}</span><span class="badge ${cls}">${c.payment_status}</span></div><div class="meta">${dateStr}</div></div>
+    <div class="meta">${esc(c.customer)} &rarr; ${esc(c.carer)}</div>
+    ${ctl}
+  </div>`;
+}
+
+async function load() {
+  const list = document.getElementById('list');
+  if (!authToken) { list.innerHTML = '<p class="empty">Please <a href="/login/?redirect=/admin/">sign in</a> as an admin.</p>'; return; }
+  try {
+    const { charges } = await sbFn('stripe-api', { action:'list_recent_charges' });
+    list.innerHTML = (charges && charges.length) ? charges.map(cardHtml).join('') : '<p class="empty">No charges yet.</p>';
+  } catch (e) {
+    list.innerHTML = `<p class="empty">${e.message === 'Not authorised' ? "You don't have access to this page." : esc(e.message)}</p>`;
+  }
+}
+
+async function refund(id) {
+  if (!confirm("Refund this booking in full? This returns the money to the customer and reverses the carer's payout.")) return;
+  const reasonEl = document.getElementById('reason-' + id);
+  const reason = reasonEl ? reasonEl.value : '';
+  const card = document.getElementById('card-' + id);
+  const btn = card ? card.querySelector('button') : null;
+  if (btn) { btn.disabled = true; btn.textContent = 'Refunding…'; }
+  showMsg('');
+  try {
+    await sbFn('stripe-api', { action:'refund_booking', booking_id:id, reason });
+    showMsg('Refunded ✓', 'ok');
+    await load();
+  } catch (e) {
+    showMsg(e.message, 'error');
+    if (btn) { btn.disabled = false; btn.textContent = 'Refund'; }
+  }
+}
+load();
+</script>
+</body>
+</html>

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -824,6 +824,13 @@ function bookingDetailsHtml(b) {
   return rows.length ? `<div class="bc-detail">${rows.join('')}</div>` : '';
 }
 
+// Payment state shown to the carer on completed bookings (TRU-150).
+function carerPayLine(b) {
+  if (b.payment_status === 'paid') return `<div class="bc-time" style="color:var(--success);">Paid ✓</div>`;
+  if (b.payment_status === 'refunded') return `<div class="bc-time" style="color:var(--text-muted);">Refunded</div>`;
+  if (b.payment_status === 'failed') return `<div class="bc-time" style="color:#9a3b3b;">Awaiting payment</div>`;
+  return '';
+}
 function renderBookingsTab() {
   const pending = bookings.filter(b => b.status === 'pending' && !b.is_meet_and_greet);
   const confirmed = bookings.filter(b => b.status === 'confirmed' && !b.is_meet_and_greet);
@@ -924,6 +931,7 @@ function renderBookingsTab() {
           <div class="bc-pet">${b._pet_label || 'Pet'}</div>
           <span class="bc-service">${SERVICE_LABELS[b._service_type] || b._service_type || 'Service'}</span>
           <div class="bc-time">${bookingTimeLine(b)}</div>
+          ${carerPayLine(b)}
         </div>
         <div class="bc-actions">
           <button class="bc-btn message" onclick="window.location.href='/walk/?booking=${b.id}'">View summary</button>

--- a/supabase/functions/stripe-api/index.ts
+++ b/supabase/functions/stripe-api/index.ts
@@ -12,6 +12,8 @@
 //   set_default_pm  - set the just-saved card as the customer's default payment method
 //   retry_charge    - recover a failed charge on-session (returns a PaymentIntent secret)
 //   sync_payment    - reconcile a booking's payment_status from its PaymentIntent
+//   list_recent_charges - (admin) recent paid/failed/refunded bookings for the admin page
+//   refund_booking  - (admin) refund a paid booking + reverse the carer's transfer
 //
 // Required function secrets (Supabase → Edge Functions → Secrets):
 //   STRIPE_SECRET_KEY   - sk_test_… (platform secret key)
@@ -80,6 +82,11 @@ async function getCustomer(userId: string) {
     .eq('user_id', userId)
     .single();
   return data;
+}
+
+async function isAdmin(userId: string) {
+  const { data } = await sb.from('users').select('is_admin').eq('id', userId).single();
+  return !!data?.is_admin;
 }
 
 Deno.serve(async (req) => {
@@ -239,6 +246,64 @@ Deno.serve(async (req) => {
         return json({ payment_status: 'failed' });
       }
       return json({ payment_status: b.payment_status, pi_status: pi.status });
+    }
+
+    if (action === 'list_recent_charges') {
+      if (!(await isAdmin(user.id))) return json({ error: 'Not authorised' }, 403);
+      const { data } = await sb.from('bookings')
+        .select('id,total_cents,payment_status,charged_at,refunded_at,scheduled_at,customer_id,provider_id')
+        .in('payment_status', ['paid', 'failed', 'refunded'])
+        .order('updated_at', { ascending: false })
+        .limit(50);
+      const rows = data || [];
+      const NONE = ['00000000-0000-0000-0000-000000000000'];
+      const custIds = [...new Set(rows.map((r) => r.customer_id))];
+      const provIds = [...new Set(rows.map((r) => r.provider_id))];
+      const [{ data: cps }, { data: pps }] = await Promise.all([
+        sb.from('customer_profiles').select('id,user_id').in('id', custIds.length ? custIds : NONE),
+        sb.from('provider_profiles').select('id,user_id').in('id', provIds.length ? provIds : NONE),
+      ]);
+      const custUser = Object.fromEntries((cps || []).map((c) => [c.id, c.user_id]));
+      const provUser = Object.fromEntries((pps || []).map((p) => [p.id, p.user_id]));
+      const userIds = [...new Set([...Object.values(custUser), ...Object.values(provUser)])] as string[];
+      const { data: us } = await sb.from('users').select('id,first_name,last_name').in('id', userIds.length ? userIds : NONE);
+      const nameBy = Object.fromEntries((us || []).map((u) => [u.id, `${u.first_name || ''} ${u.last_name || ''}`.trim()]));
+      const charges = rows.map((r) => ({
+        id: r.id,
+        total_cents: r.total_cents,
+        payment_status: r.payment_status,
+        charged_at: r.charged_at,
+        refunded_at: r.refunded_at,
+        scheduled_at: r.scheduled_at,
+        customer: nameBy[custUser[r.customer_id]] || 'Customer',
+        carer: nameBy[provUser[r.provider_id]] || 'Carer',
+      }));
+      return json({ charges });
+    }
+
+    if (action === 'refund_booking') {
+      if (!(await isAdmin(user.id))) return json({ error: 'Not authorised' }, 403);
+      const bookingId = String(payload.booking_id || '');
+      const { data: b } = await sb.from('bookings')
+        .select('id,payment_status,stripe_payment_intent_id')
+        .eq('id', bookingId).single();
+      if (!b) return json({ error: 'Booking not found' }, 404);
+      if (b.payment_status !== 'paid' || !b.stripe_payment_intent_id) {
+        return json({ error: 'Only a paid booking can be refunded' }, 400);
+      }
+      // Full refund: customer gets 100% back, the carer's transfer is reversed, and the
+      // platform application fee is returned too.
+      const refundBody: Record<string, unknown> = {
+        payment_intent: b.stripe_payment_intent_id,
+        reverse_transfer: true,
+        refund_application_fee: true,
+      };
+      if (payload.reason) refundBody['metadata[reason]'] = String(payload.reason);
+      const refund = await stripe('refunds', 'POST', refundBody);
+      await sb.from('bookings')
+        .update({ payment_status: 'refunded', refunded_at: new Date().toISOString(), stripe_refund_id: refund.id })
+        .eq('id', bookingId);
+      return json({ ok: true, refund_id: refund.id });
     }
 
     return json({ error: `Unknown action: ${action}` }, 400);

--- a/supabase/migrations/20260629_tru150_refunds_and_admin.sql
+++ b/supabase/migrations/20260629_tru150_refunds_and_admin.sql
@@ -1,0 +1,16 @@
+-- TRU-150: refunds + admin gating.
+-- Admin flag for the founder (gates the refund tools, enforced server-side in stripe-api).
+-- Refund tracking + the 'refunded' payment state.
+--
+-- Applied to the live DB via apply_migration (Supabase branching is broken on this repo);
+-- committed here for version control. The "Supabase Preview" check on the PR is expected to
+-- fail and is non-blocking (see TRU-145).
+alter table public.users add column if not exists is_admin boolean not null default false;
+
+alter table public.bookings
+  add column if not exists refunded_at timestamptz,
+  add column if not exists stripe_refund_id text;
+
+alter table public.bookings drop constraint if exists bookings_payment_status_check;
+alter table public.bookings add constraint bookings_payment_status_check
+  check (payment_status in ('unpaid','processing','paid','failed','refunded'));


### PR DESCRIPTION
Re-targets Phase B to `main`. The original PR #67 accidentally merged into its stacked base (`claude/tru-149-failed-charge-handling`) instead of `main` — because #66 had already merged that base into main first, so #67's changes never reached main. This brings them in cleanly.

Diff is **only** the 4 Phase B files (Phase A is already on main via #66): `admin/index.html`, `dashboard/index.html`, `stripe-api`, and the migration.

Founder can refund a paid booking (full refund + reverse the carer's transfer + return the platform fee) via `/admin/`, gated by `users.is_admin` (server-enforced). Functions + migration are already live; this just lands the source + the `/admin/` page on the site. Already verified end-to-end in test mode (see TRU-150). 

Supabase Preview check will be red — non-blocking (TRU-145).

🤖 Generated with [Claude Code](https://claude.com/claude-code)