### PR TITLE
TRU-151: self-contained admin console with its own login

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -3,17 +3,27 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Admin · Refunds — Truffl Pets</title>
+<title>Admin — Truffl Pets</title>
 <meta name="robots" content="noindex,nofollow">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@500;600&display=swap" rel="stylesheet">
 <style>
-  :root{--cream:#F7F3EE;--brown:#5C4033;--terracotta:#C4866A;--border:#E7DFD6;--text:#3A2E28;--muted:#7A6860;--success:#5B8C5A;--error:#b3261e;}
+  :root{--cream:#F7F3EE;--brown:#5C4033;--terracotta:#C4866A;--terracottaDark:#B8795C;--border:#E7DFD6;--text:#3A2E28;--muted:#7A6860;--success:#5B8C5A;--error:#b3261e;}
   *{box-sizing:border-box;}
   body{margin:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;background:var(--cream);color:var(--text);}
-  .wrap{max-width:820px;margin:0 auto;padding:24px 16px 64px;}
-  h1{font-family:'Cormorant Garamond',Georgia,serif;font-weight:500;color:var(--brown);font-size:1.9rem;margin:0 0 4px;}
-  .sub{color:var(--muted);font-size:0.9rem;margin:0 0 24px;line-height:1.5;}
+  a{color:var(--terracottaDark);}
+  .wrap{max-width:840px;margin:0 auto;padding:20px 16px 64px;}
+  h1{font-family:'Cormorant Garamond',Georgia,serif;font-weight:500;color:var(--brown);font-size:1.7rem;margin:0;}
+  .sub{color:var(--muted);font-size:0.88rem;margin:4px 0 0;line-height:1.5;}
+  /* header + nav */
+  .topbar{display:flex;justify-content:space-between;align-items:center;gap:12px;border-bottom:1px solid var(--border);padding-bottom:12px;margin-bottom:16px;}
+  .brand{font-family:'Cormorant Garamond',Georgia,serif;font-style:italic;font-size:1.5rem;color:var(--brown);}
+  .brand b{font-style:normal;font-size:0.62rem;font-weight:700;letter-spacing:3px;color:var(--muted);vertical-align:middle;margin-left:6px;}
+  .signout{font-size:0.82rem;background:none;border:none;color:var(--muted);cursor:pointer;text-decoration:underline;}
+  .nav{display:flex;gap:6px;margin-bottom:18px;flex-wrap:wrap;}
+  .nav a{font-size:0.86rem;padding:6px 14px;border-radius:20px;text-decoration:none;color:var(--brown);border:1px solid var(--border);cursor:pointer;}
+  .nav a.active{background:var(--brown);color:#fff;border-color:var(--brown);}
+  /* cards */
   .card{background:#fff;border:1px solid var(--border);border-radius:12px;padding:14px 16px;margin-bottom:10px;}
   .row-top{display:flex;justify-content:space-between;gap:12px;align-items:baseline;flex-wrap:wrap;}
   .amount{font-weight:600;color:var(--brown);}
@@ -22,29 +32,30 @@
   .b-paid{background:#e7f1e6;color:var(--success);}
   .b-failed{background:#fdeeee;color:#9a3b3b;}
   .b-refunded{background:#f0ebe4;color:var(--muted);}
-  button{font:inherit;cursor:pointer;border-radius:8px;padding:8px 14px;border:1px solid var(--terracotta);background:var(--terracotta);color:#fff;font-size:0.86rem;}
-  button:disabled{opacity:.55;cursor:default;}
+  button.btn{font:inherit;cursor:pointer;border-radius:8px;padding:8px 14px;border:1px solid var(--terracotta);background:var(--terracotta);color:#fff;font-size:0.86rem;}
+  button.btn:disabled{opacity:.55;cursor:default;}
   .actions{margin-top:10px;display:flex;gap:8px;align-items:center;flex-wrap:wrap;}
+  input.fld{font:inherit;padding:9px 11px;border:1px solid var(--border);border-radius:8px;width:100%;}
   input.reason{font:inherit;padding:7px 10px;border:1px solid var(--border);border-radius:8px;flex:1;min-width:160px;}
   .msg{font-size:0.85rem;margin:8px 0;min-height:1em;}
   .msg.error{color:var(--error);}
   .msg.ok{color:var(--success);}
   .empty{color:var(--muted);text-align:center;padding:40px 0;}
-  .empty a{color:var(--terracotta);}
+  /* login */
+  .login{max-width:360px;margin:8vh auto 0;background:#fff;border:1px solid var(--border);border-radius:16px;padding:28px 24px;}
+  .login h1{margin-bottom:4px;}
+  .login .field{margin:14px 0;}
+  .login label{display:block;font-size:0.82rem;color:var(--muted);margin-bottom:5px;}
+  .login button{width:100%;margin-top:6px;}
 </style>
 </head>
 <body>
-<div class="wrap">
-  <h1>Refunds</h1>
-  <p class="sub">Recent charges. Refunding returns the full amount to the customer and reverses the carer's payout (including the platform fee).</p>
-  <div id="msg" class="msg"></div>
-  <div id="list"><p class="empty">Loading…</p></div>
-</div>
+<div id="app"><p class="empty" style="padding-top:12vh;">Loading…</p></div>
 <script>
 const SUPABASE_URL = 'https://gadflsntbnbnnxbpiral.supabase.co';
 const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdhZGZsc250Ym5ibm54YnBpcmFsIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzUwNjcwNTcsImV4cCI6MjA5MDY0MzA1N30.g5ZrqeAX9U5l7oDZEbQFrU5j10828dUF0QuJ0ZlHXK8';
-let authToken = null;
-try { const s = JSON.parse(localStorage.getItem('truffl_session') || 'null'); if (s) authToken = s.access_token; } catch (e) {}
+let authToken = null, authUid = null, currentSection = 'refunds';
+try { const s = JSON.parse(localStorage.getItem('truffl_session') || 'null'); if (s) { authToken = s.access_token; authUid = s.user_id; } } catch (e) {}
 
 function h(t) { const o = { 'Content-Type':'application/json', 'apikey':SUPABASE_ANON_KEY, 'Authorization':'Bearer ' + SUPABASE_ANON_KEY }; if (t) o['Authorization'] = 'Bearer ' + t; return o; }
 async function sbFn(name, body) {
@@ -56,34 +67,120 @@ async function sbFn(name, body) {
 function esc(s) { return (s || '').toString().replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
 function money(c) { return '$' + ((c || 0) / 100).toFixed(2); }
 function when(iso) { if (!iso) return ''; try { return new Date(iso).toLocaleDateString('en-AU', { day:'numeric', month:'short', year:'numeric' }); } catch (e) { return ''; } }
-function showMsg(t, type) { const m = document.getElementById('msg'); m.textContent = t || ''; m.className = 'msg' + (type ? ' ' + type : ''); }
 
-function cardHtml(c) {
-  const cls = c.payment_status === 'paid' ? 'b-paid' : c.payment_status === 'failed' ? 'b-failed' : 'b-refunded';
-  const dateStr = c.charged_at ? when(c.charged_at) : when(c.scheduled_at);
-  const ctl = c.payment_status === 'paid'
-    ? `<div class="actions"><input class="reason" id="reason-${c.id}" placeholder="Reason (optional)"><button onclick="refund('${c.id}')">Refund ${money(c.total_cents)}</button></div>`
-    : c.payment_status === 'refunded'
-      ? `<div class="meta">Refunded${c.refunded_at ? ' · ' + when(c.refunded_at) : ''}</div>`
-      : `<div class="meta">Charge failed — awaiting customer retry</div>`;
-  return `<div class="card" id="card-${c.id}">
-    <div class="row-top"><div><span class="amount">${money(c.total_cents)}</span><span class="badge ${cls}">${c.payment_status}</span></div><div class="meta">${dateStr}</div></div>
-    <div class="meta">${esc(c.customer)} &rarr; ${esc(c.carer)}</div>
-    ${ctl}
-  </div>`;
+const app = () => document.getElementById('app');
+
+// ── Auth ──
+async function checkAdmin() {
+  // True only if the stored token is valid AND the user is an admin.
+  const r = await fetch(`${SUPABASE_URL}/rest/v1/users?id=eq.${authUid}&select=is_admin`, { headers:h(authToken) });
+  if (!r.ok) return false;
+  const d = await r.json().catch(() => []);
+  return !!(d[0] && d[0].is_admin);
+}
+function signOut() { localStorage.removeItem('truffl_session'); authToken = null; authUid = null; render(); }
+
+async function render() {
+  if (authToken && authUid) {
+    let ok = false;
+    try { ok = await checkAdmin(); } catch (e) { ok = false; }
+    if (ok) return showConsole();
+    // token expired or not an admin — fall through to login
+    if (!authToken) {/* cleared */}
+  }
+  showLogin();
 }
 
-async function load() {
-  const list = document.getElementById('list');
-  if (!authToken) { list.innerHTML = '<p class="empty">Please <a href="/login/?redirect=/admin/">sign in</a> as an admin.</p>'; return; }
+function showLogin(msg) {
+  app().innerHTML = `
+    <div class="login">
+      <h1>Truffl Admin</h1>
+      <p class="sub">Sign in with your admin account.</p>
+      <form id="loginForm">
+        <div class="field"><label for="al-email">Email</label><input class="fld" id="al-email" type="email" autocomplete="username" required></div>
+        <div class="field"><label for="al-pw">Password</label><input class="fld" id="al-pw" type="password" autocomplete="current-password" required></div>
+        <div id="al-msg" class="msg ${msg ? 'error' : ''}">${msg ? esc(msg) : ''}</div>
+        <button class="btn" id="al-btn" type="submit">Sign in</button>
+      </form>
+    </div>`;
+  document.getElementById('loginForm').addEventListener('submit', onLogin);
+}
+
+async function onLogin(e) {
+  e.preventDefault();
+  const email = document.getElementById('al-email').value.trim();
+  const pw = document.getElementById('al-pw').value;
+  const btn = document.getElementById('al-btn'); const msg = document.getElementById('al-msg');
+  btn.disabled = true; btn.textContent = 'Signing in…'; msg.textContent = ''; msg.className = 'msg';
   try {
-    const { charges } = await sbFn('stripe-api', { action:'list_recent_charges' });
-    list.innerHTML = (charges && charges.length) ? charges.map(cardHtml).join('') : '<p class="empty">No charges yet.</p>';
-  } catch (e) {
-    list.innerHTML = `<p class="empty">${e.message === 'Not authorised' ? "You don't have access to this page." : esc(e.message)}</p>`;
+    const r = await fetch(`${SUPABASE_URL}/auth/v1/token?grant_type=password`, { method:'POST', headers:{ 'Content-Type':'application/json', 'apikey':SUPABASE_ANON_KEY }, body:JSON.stringify({ email, password:pw }) });
+    const d = await r.json();
+    if (!d.access_token) throw new Error(d.error_description || d.msg || 'Wrong email or password.');
+    authToken = d.access_token; authUid = d.user.id;
+    const ur = await fetch(`${SUPABASE_URL}/rest/v1/users?id=eq.${authUid}&select=role,is_admin`, { headers:h(authToken) });
+    const us = await ur.json().catch(() => []);
+    if (!us[0] || !us[0].is_admin) { authToken = null; authUid = null; throw new Error("This account doesn't have admin access."); }
+    localStorage.setItem('truffl_session', JSON.stringify({ access_token:authToken, user_id:authUid, role:us[0].role }));
+    showConsole();
+  } catch (err) {
+    msg.textContent = err.message; msg.className = 'msg error';
+    btn.disabled = false; btn.textContent = 'Sign in';
   }
 }
 
+// ── Console shell ──
+const SECTIONS = [ { id:'refunds', label:'Refunds' } ];
+function showConsole() {
+  currentSection = SECTIONS.some(s => s.id === currentSection) ? currentSection : 'refunds';
+  app().innerHTML = `
+    <div class="wrap">
+      <div class="topbar">
+        <span class="brand">truffl<b>ADMIN</b></span>
+        <button class="signout" onclick="signOut()">Sign out</button>
+      </div>
+      <div class="nav">${SECTIONS.map(s => `<a data-s="${s.id}" class="${s.id === currentSection ? 'active' : ''}" onclick="switchSection('${s.id}')">${s.label}</a>`).join('')}</div>
+      <div id="adm-content"></div>
+    </div>`;
+  renderSection(currentSection);
+}
+function switchSection(name) {
+  currentSection = name;
+  document.querySelectorAll('.nav a').forEach(a => a.classList.toggle('active', a.dataset.s === name));
+  renderSection(name);
+}
+function renderSection(name) {
+  const c = document.getElementById('adm-content');
+  if (name === 'refunds') return renderRefunds(c);
+  c.innerHTML = '<p class="empty">Coming soon.</p>';
+}
+
+// ── Refunds section ──
+function chargeCard(ch) {
+  const cls = ch.payment_status === 'paid' ? 'b-paid' : ch.payment_status === 'failed' ? 'b-failed' : 'b-refunded';
+  const dateStr = ch.charged_at ? when(ch.charged_at) : when(ch.scheduled_at);
+  const ctl = ch.payment_status === 'paid'
+    ? `<div class="actions"><input class="reason" id="reason-${ch.id}" placeholder="Reason (optional)"><button class="btn" onclick="refund('${ch.id}')">Refund ${money(ch.total_cents)}</button></div>`
+    : ch.payment_status === 'refunded'
+      ? `<div class="meta">Refunded${ch.refunded_at ? ' · ' + when(ch.refunded_at) : ''}</div>`
+      : `<div class="meta">Charge failed — awaiting customer retry</div>`;
+  return `<div class="card" id="card-${ch.id}">
+    <div class="row-top"><div><span class="amount">${money(ch.total_cents)}</span><span class="badge ${cls}">${ch.payment_status}</span></div><div class="meta">${dateStr}</div></div>
+    <div class="meta">${esc(ch.customer)} &rarr; ${esc(ch.carer)}</div>
+    ${ctl}
+  </div>`;
+}
+async function renderRefunds(c) {
+  c.innerHTML = '<div id="adm-msg" class="msg"></div><p class="empty">Loading…</p>';
+  try {
+    const { charges } = await sbFn('stripe-api', { action:'list_recent_charges' });
+    const list = (charges && charges.length) ? charges.map(chargeCard).join('') : '<p class="empty">No charges yet.</p>';
+    c.innerHTML = `<p class="sub" style="margin-bottom:14px;">Recent charges. Refunding returns the full amount to the customer and reverses the carer's payout (including the platform fee).</p><div id="adm-msg" class="msg"></div>${list}`;
+  } catch (e) {
+    if (e.message === 'Not authenticated') return signOut(); // expired mid-session
+    c.innerHTML = `<p class="empty">${esc(e.message)}</p>`;
+  }
+}
+function admMsg(t, type) { const m = document.getElementById('adm-msg'); if (m) { m.textContent = t || ''; m.className = 'msg' + (type ? ' ' + type : ''); } }
 async function refund(id) {
   if (!confirm("Refund this booking in full? This returns the money to the customer and reverses the carer's payout.")) return;
   const reasonEl = document.getElementById('reason-' + id);
@@ -91,17 +188,18 @@ async function refund(id) {
   const card = document.getElementById('card-' + id);
   const btn = card ? card.querySelector('button') : null;
   if (btn) { btn.disabled = true; btn.textContent = 'Refunding…'; }
-  showMsg('');
+  admMsg('');
   try {
     await sbFn('stripe-api', { action:'refund_booking', booking_id:id, reason });
-    showMsg('Refunded ✓', 'ok');
-    await load();
+    admMsg('Refunded ✓', 'ok');
+    renderRefunds(document.getElementById('adm-content'));
   } catch (e) {
-    showMsg(e.message, 'error');
+    admMsg(e.message, 'error');
     if (btn) { btn.disabled = false; btn.textContent = 'Refund'; }
   }
 }
-load();
+
+render();
 </script>
 </body>
 </html>


### PR DESCRIPTION
Fixes the "can't log in to /admin/" problem and restructures it per Tom's suggestion: a proper admin landing with its own login + sections underneath.

**Problem:** the first `/admin/` page had no login — it relied on whatever session was in the browser from the main site. A missing/expired token surfaced a raw "Not authenticated" with no way in.

**Now:** `/admin/` is a self-contained console:
- **Own email + password login**, gated on `users.is_admin`. Non-admins are rejected (and the underlying `list_recent_charges` / `refund_booking` actions enforce `is_admin` server-side regardless).
- **Console shell** — header + section nav + content. **Refunds** is the first section (existing list/refund behaviour); the nav is structured so more sections (bookings, etc.) drop in.
- An **expired token** mid-session bounces back to the login instead of erroring.

Single-file change (`admin/index.html`); no backend change (reuses the deployed admin-gated actions).

## Verified (Preview MCP)
- Logged-out / expired → login form (not the raw error).
- Admin login → console + Refunds list renders (showed the Sarah→Olivia charge, now `refunded`).
- **Non-admin login → rejected** ("doesn't have admin access"), no session stored.

(Tested by temporarily flagging a test user admin, then restoring; the real admin `tom_farmery@hotmail.co.uk` is unaffected.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)