### PR TITLE
TRU-152: app-wide token refresh (no more 1h logout)

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -418,6 +418,7 @@
       .cta-section { padding: 48px 20px; }
     }
   </style>
+  <script src="/session.js"></script>
 </head>
 <body>
 

--- a/admin/index.html
+++ b/admin/index.html
@@ -48,6 +48,7 @@
   .login label{display:block;font-size:0.82rem;color:var(--muted);margin-bottom:5px;}
   .login button{width:100%;margin-top:6px;}
 </style>
+  <script src="/session.js"></script>
 </head>
 <body>
 <div id="app"><p class="empty" style="padding-top:12vh;">Loading…</p></div>
@@ -120,7 +121,7 @@ async function onLogin(e) {
     const ur = await fetch(`${SUPABASE_URL}/rest/v1/users?id=eq.${authUid}&select=role,is_admin`, { headers:h(authToken) });
     const us = await ur.json().catch(() => []);
     if (!us[0] || !us[0].is_admin) { authToken = null; authUid = null; throw new Error("This account doesn't have admin access."); }
-    localStorage.setItem('truffl_session', JSON.stringify({ access_token:authToken, user_id:authUid, role:us[0].role }));
+    localStorage.setItem('truffl_session', JSON.stringify({ access_token:authToken, refresh_token:d.refresh_token, user_id:authUid, role:us[0].role }));
     showConsole();
   } catch (err) {
     msg.textContent = err.message; msg.className = 'msg error';

--- a/book/index.html
+++ b/book/index.html
@@ -183,6 +183,7 @@
   @keyframes fadeIn { from { opacity:0; transform:translateY(8px); } to { opacity:1; transform:translateY(0); } }
   .fade-in { animation: fadeIn 0.3s ease; }
 </style>
+  <script src="/session.js"></script>
 </head>
 <body>
 

--- a/carer-guidelines/emergencies-and-safety/index.html
+++ b/carer-guidelines/emergencies-and-safety/index.html
@@ -54,6 +54,7 @@
     .footer-nav a{color:var(--terracotta);font-weight:500;}
     @media(max-width:720px){.nav{padding:0 1rem;}}
   </style>
+  <script src="/session.js"></script>
 </head>
 <body>
   <nav class="nav">

--- a/carer-guidelines/your-commitments/index.html
+++ b/carer-guidelines/your-commitments/index.html
@@ -48,6 +48,7 @@
     .footer-nav a{color:var(--terracotta);font-weight:500;}
     @media(max-width:720px){.nav{padding:0 1rem;}}
   </style>
+  <script src="/session.js"></script>
 </head>
 <body>
   <nav class="nav">

--- a/carer/index.html
+++ b/carer/index.html
@@ -257,6 +257,7 @@
   @keyframes fadeIn { from { opacity:0; transform:translateY(8px); } to { opacity:1; transform:translateY(0); } }
   .fade-in { animation: fadeIn 0.3s ease; }
 </style>
+  <script src="/session.js"></script>
 </head>
 <body>
 

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -298,6 +298,7 @@
     .tab { padding: 10px 14px; font-size: 0.8rem; }
   }
 </style>
+  <script src="/session.js"></script>
 </head>
 <body>
 

--- a/index.html
+++ b/index.html
@@ -305,6 +305,7 @@
       .strip-divider { display: none; }
     }
   </style>
+  <script src="/session.js"></script>
 </head>
 <body>
 

--- a/login/index.html
+++ b/login/index.html
@@ -249,6 +249,7 @@
     .page-header h1 { font-size: 1.8rem; }
   }
 </style>
+  <script src="/session.js"></script>
 </head>
 <body>
 
@@ -514,13 +515,13 @@ const sb = {
     const r = await fetch(`${SUPABASE_URL}/auth/v1/signup`, { method: 'POST', headers: { 'Content-Type': 'application/json', 'apikey': SUPABASE_ANON_KEY }, body: JSON.stringify({ email, password: pw, data: meta }) });
     const d = await r.json();
     if (d.error || d.msg) throw new Error(d.error?.message || d.msg || 'Signup failed');
-    this._token = d.access_token; this._uid = d.user?.id; return d;
+    this._token = d.access_token; this._refresh = d.refresh_token; this._uid = d.user?.id; return d;
   },
   async signIn(email, pw) {
     const r = await fetch(`${SUPABASE_URL}/auth/v1/token?grant_type=password`, { method: 'POST', headers: { 'Content-Type': 'application/json', 'apikey': SUPABASE_ANON_KEY }, body: JSON.stringify({ email, password: pw }) });
     const d = await r.json();
     if (d.error || d.msg) throw new Error(d.error_description || d.error?.message || d.msg || 'Login failed');
-    this._token = d.access_token; this._uid = d.user?.id; return d;
+    this._token = d.access_token; this._refresh = d.refresh_token; this._uid = d.user?.id; return d;
   },
   async insert(table, row) {
     const r = await fetch(`${SUPABASE_URL}/rest/v1/${table}`, { method: 'POST', headers: { ...this.headers(), 'Prefer': 'return=representation' }, body: JSON.stringify(row) });
@@ -606,7 +607,7 @@ async function doLogin() {
     await sb.signIn(email, pw);
     const users = await sb.get('users', `id=eq.${sb._uid}&select=role`);
     const role = users[0]?.role || 'customer';
-    localStorage.setItem('truffl_session', JSON.stringify({ access_token: sb._token, user_id: sb._uid, role: role }));
+    localStorage.setItem('truffl_session', JSON.stringify({ access_token: sb._token, refresh_token: sb._refresh, user_id: sb._uid, role: role }));
     const redirectTo = new URLSearchParams(window.location.search).get('redirect');
     if (redirectTo) window.location.href = redirectTo;
     else if (role === 'provider') window.location.href = '/dashboard/';
@@ -629,7 +630,7 @@ async function custStep1() {
   const btn = document.querySelector('#cStep1 .btn-primary'); setLoading(btn, true);
   try {
     await sb.signUp(email, pw, { first_name: fn, last_name: ln, phone, role: 'customer' });
-    localStorage.setItem('truffl_session', JSON.stringify({ access_token: sb._token, user_id: sb._uid }));
+    localStorage.setItem('truffl_session', JSON.stringify({ access_token: sb._token, refresh_token: sb._refresh, user_id: sb._uid }));
     if (sb._uid) { try { await sb.patch('users', 'id', sb._uid, { first_name: fn, last_name: ln, phone, role: 'customer' }); } catch(e){} }
     showStep('c', 2); updateSteps('c', 2, 3);
   } catch(e) { showMsg(e.message, 'error'); } finally { setLoading(btn, false); }

--- a/messages/index.html
+++ b/messages/index.html
@@ -116,6 +116,7 @@
     .thread-back{display:inline-flex;}
   }
 </style>
+  <script src="/session.js"></script>
 </head>
 <body>
 

--- a/my/index.html
+++ b/my/index.html
@@ -18,6 +18,7 @@
 <style>
   body{font-family:system-ui,-apple-system,sans-serif;background:#FAF7F2;color:#9B8B7E;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;font-size:0.9rem;}
 </style>
+  <script src="/session.js"></script>
 </head>
 <body>
 <div>Taking you to your account…</div>

--- a/profile/index.html
+++ b/profile/index.html
@@ -197,6 +197,7 @@
     .row-2{grid-template-columns:1fr;}
   }
 </style>
+  <script src="/session.js"></script>
 </head>
 <body>
 

--- a/register/index.html
+++ b/register/index.html
@@ -415,6 +415,7 @@
   .form-step.active { display: block; animation: fadeIn 0.3s ease; }
   @keyframes fadeIn { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
 </style>
+  <script src="/session.js"></script>
 </head>
 <body>
 

--- a/review/index.html
+++ b/review/index.html
@@ -148,6 +148,7 @@
   @keyframes fadeIn { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
   .fade-in { animation: fadeIn 0.3s ease; }
 </style>
+  <script src="/session.js"></script>
 </head>
 <body>
 

--- a/search/index.html
+++ b/search/index.html
@@ -237,6 +237,7 @@
   @keyframes fadeIn { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
   .fade-in { animation: fadeIn 0.3s ease; }
 </style>
+  <script src="/session.js"></script>
 </head>
 <body>
 

--- a/session.js
+++ b/session.js
@@ -1,0 +1,82 @@
+/* Truffl — app-wide session/token refresh.
+ *
+ * Supabase access tokens expire after ~1h. The app previously discarded the refresh token and
+ * had no refresh logic, so after an hour every authed call 401'd (users effectively logged out)
+ * and native background GPS died. This wraps window.fetch: for Supabase requests carrying a user
+ * token, on a 401 it refreshes the access token (via the stored refresh token) once and retries.
+ *
+ * Include it as a BLOCKING script high in <head> so window.fetch is patched before page scripts
+ * run. Pages need no other change — they keep using their own sb* helpers.
+ */
+(function () {
+  'use strict';
+
+  var SUPABASE_URL = 'https://gadflsntbnbnnxbpiral.supabase.co';
+  var ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdhZGZsc250Ym5ibm54YnBpcmFsIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzUwNjcwNTcsImV4cCI6MjA5MDY0MzA1N30.g5ZrqeAX9U5l7oDZEbQFrU5j10828dUF0QuJ0ZlHXK8';
+  var ANON_BEARER = 'Bearer ' + ANON_KEY;
+  var KEY = 'truffl_session';
+  var origFetch = window.fetch.bind(window);
+  var refreshing = null; // shared in-flight refresh so concurrent 401s trigger one POST
+
+  function session() {
+    try { return JSON.parse(localStorage.getItem(KEY) || 'null'); } catch (e) { return null; }
+  }
+  function store(access, refresh) {
+    var s = session() || {};
+    s.access_token = access;
+    if (refresh) s.refresh_token = refresh; // Supabase rotates the refresh token — keep the newest
+    try { localStorage.setItem(KEY, JSON.stringify(s)); } catch (e) {}
+  }
+  function toLogin() {
+    try { localStorage.removeItem(KEY); } catch (e) {}
+    if (!/^\/login\/?/.test(location.pathname)) {
+      location.href = '/login/?redirect=' + encodeURIComponent(location.pathname + location.search);
+    }
+  }
+  function refresh() {
+    if (refreshing) return refreshing;
+    var s = session();
+    if (!s || !s.refresh_token) return Promise.resolve(false);
+    refreshing = origFetch(SUPABASE_URL + '/auth/v1/token?grant_type=refresh_token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'apikey': ANON_KEY },
+      body: JSON.stringify({ refresh_token: s.refresh_token })
+    })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (d) { if (d && d.access_token) { store(d.access_token, d.refresh_token); return true; } return false; })
+      .catch(function () { return false; })
+      .then(function (ok) { refreshing = null; return ok; });
+    return refreshing;
+  }
+
+  window.fetch = function (input, init) {
+    var url = (typeof input === 'string') ? input : null;
+    // Only manage Supabase requests; never the token endpoint itself (would recurse).
+    if (url === null || url.indexOf(SUPABASE_URL) !== 0 || url.indexOf('/auth/v1/token') !== -1) {
+      return origFetch(input, init);
+    }
+    init = init || {};
+    var auth = new Headers(init.headers || {}).get('Authorization');
+    // Leave anon / unauthed requests alone (a 401 there isn't token expiry).
+    if (!auth || auth === ANON_BEARER) return origFetch(input, init);
+
+    function retry(token) {
+      var h = new Headers(init.headers || {});
+      if (token) h.set('Authorization', 'Bearer ' + token);
+      return origFetch(url, Object.assign({}, init, { headers: h }));
+    }
+
+    return origFetch(input, init).then(function (res) {
+      if (res.status !== 401) return res;
+      var used = auth.replace(/^Bearer\s+/i, '');
+      var cur = session();
+      // Another request already refreshed past this token — just retry with the current one.
+      if (cur && cur.access_token && cur.access_token !== used) return retry(cur.access_token);
+      return refresh().then(function (ok) {
+        if (!ok) { toLogin(); return res; }
+        var s2 = session();
+        return retry(s2 && s2.access_token);
+      });
+    });
+  };
+})();

--- a/track/index.html
+++ b/track/index.html
@@ -104,6 +104,7 @@
     #map{height:220px;}
   }
 </style>
+  <script src="/session.js"></script>
 </head>
 <body>
 

--- a/walk/index.html
+++ b/walk/index.html
@@ -139,6 +139,7 @@
     #map{height:220px;}
   }
 </style>
+  <script src="/session.js"></script>
 </head>
 <body>
 


### PR DESCRIPTION
**Root cause** (found scoping the GPS long-walk token-expiry follow-up): Supabase access tokens live **1h**, but the app **discarded the refresh token and had no refresh logic anywhere**. So after ~1h every authed call 401s — users are effectively logged out app-wide, and long-walk background GPS silently dies. Same root cause; fixing it **app-wide** (Tom's call).

## Approach
17 pages make authed calls, there's no shared JS module, and helpers are inconsistent — so rather than retrofit refresh into every page's helpers, one shared script transparently handles it.

- **`session.js`** (repo root, blocking `<head>` script): wraps `window.fetch`. For requests to Supabase carrying a **user** token, on a **401** it refreshes the access token via the stored refresh token (single in-flight — concurrent 401s share one refresh) and retries once. Leaves non-Supabase (Stripe/Leaflet/gtag) and anon-key requests untouched; never intercepts `/auth/v1/token`. A dead refresh token clears the session and redirects to `/login/?redirect=…`.
- **Persist the refresh token** at login (`login/index.html`) and admin sign-in (`admin/index.html`).
- **Include `session.js`** in the `<head>` of all 17 authed pages (about-us, admin, book, carer, carer-guidelines/*, dashboard, index, login, messages, my, profile, register, review, search, track, walk).

## Verified (Preview MCP)
- Request with an **expired access token + valid refresh** → interceptor 401s → refreshes → retry **succeeds (200)**; stored access token replaced with a fresh JWT, refresh token rotated.
- Request with an **invalid refresh token** → session cleared → **redirect to `/login/?redirect=/profile/…`**.

## Scope
Phase 1 (web) of TRU-152. **Phase 2 (native tracker refresh** — Android/iOS trackers renew on a 401 during long walks) follows once the iOS plugin ([#70](https://github.com/tomfarmery93/truffl/pull/70)) is device-verified. JWT TTL stays 1h (fine now that refresh works). Out of scope: websocket/realtime refresh (the app polls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)