### PR TITLE
TRU-153: revoke anon/authenticated EXECUTE on internal SECURITY DEFINER functions

### DIFF
--- a/supabase/migrations/20260702_tru153_revoke_definer_fn_execute.sql
+++ b/supabase/migrations/20260702_tru153_revoke_definer_fn_execute.sql
@@ -1,0 +1,21 @@
+-- TRU-153: revoke public API EXECUTE on internal SECURITY DEFINER functions.
+--
+-- These run only from triggers or the rolling cron, which execute the function in the
+-- definer's context regardless of the session role's EXECUTE grant — so revoking EXECUTE
+-- from anon/authenticated does NOT stop them firing. But they were reachable directly over
+-- PostgREST at /rest/v1/rpc/*, letting an unauthenticated caller e.g. materialise bookings
+-- (generate_series_bookings) or invoke trigger functions. This closes that.
+--
+-- mark_meet_greet_complete stays granted to authenticated (the client calls it intentionally).
+-- Leaves PostGIS st_estimatedextent alone (extension-owned).
+--
+-- Applied to the live DB via apply_migration; committed for version control. Supabase Preview
+-- check is expected to fail and is non-blocking (see TRU-145).
+
+revoke execute on function public.generate_series_bookings(uuid, integer) from public, anon, authenticated;
+revoke execute on function public.roll_all_series_bookings() from public, anon, authenticated;
+revoke execute on function public.trg_series_activated() from public, anon, authenticated;
+revoke execute on function public.trg_series_cancelled() from public, anon, authenticated;
+revoke execute on function public.messages_bump_conversation() from public, anon, authenticated;
+revoke execute on function public.messages_set_conversation() from public, anon, authenticated;
+revoke execute on function public.handle_new_user() from public, anon, authenticated;


### PR DESCRIPTION
Security hardening (surfaced by the security advisor while verifying TRU-134). Several `SECURITY DEFINER` functions were `EXECUTE`-able by `anon`/`authenticated` and exposed over PostgREST at `/rest/v1/rpc/*`, even though they only ever run from triggers or the rolling cron. An unauthenticated caller could e.g. `POST /rest/v1/rpc/generate_series_bookings` to materialise bookings, or invoke trigger functions directly.

## Fix
`REVOKE EXECUTE ... FROM public, anon, authenticated` on:
`generate_series_bookings(uuid,integer)`, `roll_all_series_bookings()`, `trg_series_activated()`, `trg_series_cancelled()`, `messages_bump_conversation()`, `messages_set_conversation()`, `handle_new_user()`.

Kept: `mark_meet_greet_complete(uuid)` (authenticated — the client calls it). Left PostGIS `st_estimatedextent` (extension-owned). **Applied to the live DB** via apply_migration; committed for version control (Supabase Preview check red = non-blocking, TRU-145).

## Why this is safe
Postgres does **not** gate trigger firing on the session role's EXECUTE grant, and these definer functions are called by triggers/cron in the definer's context — so booking generation, series activation/cancellation, messaging, and signup are unaffected. Same pattern the existing `trg_meet_greet_gate` already uses (revoked from all roles, works fine).

## Verified (live)
- `anon` POST → `generate_series_bookings` **401**, `roll_all_series_bookings` **401**, `messages_set_conversation` **404** (were callable before). Hole closed.
- The advisor's `anon_/authenticated_security_definer_function_executable` findings for these clear on its next refresh.

Note: the remaining `security_definer_view` advisor errors (`booking_party_names`, `booking_contact_details`, `booking_pet_care`, `booking_checkin_status`, `conversation_party_names`, `series_party_names`) are **intentional** definer views for cross-RLS provider reads — left as-is by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)