### PR TITLE
TRU-137/138: walker cancellation flow, min-notice + real-time founder cover alert

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -49,6 +49,10 @@
   .cancel-inline span { font-size: 0.82rem; color: var(--text-secondary); }
   .cancel-inline.series { flex-direction: column; align-items: flex-start; }
   .cancel-inline-btns { display: flex; gap: 8px; flex-wrap: wrap; }
+  /* TRU-137: cancellation reason capture */
+  .cancel-reason { display: flex; flex-direction: column; gap: 6px; width: 100%; margin: 6px 0; }
+  .cancel-reason select, .cancel-reason input { font: inherit; font-size: 0.85rem; padding: 8px 10px; border: 1px solid var(--border); border-radius: 8px; background: #fff; color: var(--text); }
+  .cancel-notice { font-size: 0.76rem; color: var(--text-muted); width: 100%; }
   .nav-avatar {
     width: 32px; height: 32px; border-radius: 50%; background: var(--blush);
     display: flex; align-items: center; justify-content: center;
@@ -741,36 +745,80 @@ async function declineSeries(id) {
 }
 
 /* ── Cancelling an upcoming walk (and, for series walks, the whole series) ── */
+/* TRU-137: every walker cancellation records a reason; cancelling a confirmed
+   walk with under 3 hours' notice is flagged on the walker's record (server-side
+   trigger). If the owner has backup cover, cancelling also pages Truffl. */
+const CANCEL_REASONS = ['Feeling unwell', 'Personal emergency', 'Schedule conflict', 'Weather', 'Other'];
 function dashShowCancel(id) { dashCancelId = id; renderBookingsTab(); }
 function dashDismissCancel() { dashCancelId = null; renderBookingsTab(); }
+function cancelReasonUi(b) {
+  const hoursAway = (new Date(b.scheduled_at).getTime() - Date.now()) / 3600000;
+  const lateNote = (b.status === 'confirmed' && hoursAway < 3)
+    ? `<span class="cancel-notice">Heads up — this is under 3 hours' notice, which counts as a late cancellation on your record.</span>` : '';
+  return `<div class="cancel-reason">
+      <select id="cxl-reason-${b.id}">
+        <option value="">Why are you cancelling?</option>
+        ${CANCEL_REASONS.map(r => `<option>${r}</option>`).join('')}
+      </select>
+      <input type="text" id="cxl-note-${b.id}" maxlength="200" placeholder="Add a short note (optional)">
+    </div>${lateNote}`;
+}
 function dashCancelConfirm(b) {
   if (b.series_id) {
     return `<div class="cancel-inline series">
       <span>Recurring walk — cancel what?</span>
+      ${cancelReasonUi(b)}
       <div class="cancel-inline-btns">
         <button class="bc-btn decline" onclick="cancelWalk('${b.id}')">Just this walk</button>
-        <button class="bc-btn decline" onclick="cancelSeriesWalks('${b.series_id}')">All future walks</button>
+        <button class="bc-btn decline" onclick="cancelSeriesWalks('${b.series_id}', '${b.id}')">All future walks</button>
         <button class="bc-btn" style="border:1px solid var(--border);color:var(--text-muted);" onclick="dashDismissCancel()">Keep</button>
       </div>
     </div>`;
   }
-  return `<div class="cancel-inline">
+  return `<div class="cancel-inline series">
     <span>Cancel this walk?</span>
-    <button class="bc-btn decline" onclick="cancelWalk('${b.id}')">Yes, cancel</button>
-    <button class="bc-btn" style="border:1px solid var(--border);color:var(--text-muted);" onclick="dashDismissCancel()">Keep</button>
+    ${cancelReasonUi(b)}
+    <div class="cancel-inline-btns">
+      <button class="bc-btn decline" onclick="cancelWalk('${b.id}')">Yes, cancel</button>
+      <button class="bc-btn" style="border:1px solid var(--border);color:var(--text-muted);" onclick="dashDismissCancel()">Keep</button>
+    </div>
   </div>`;
 }
+function collectCancelReason(bookingId) {
+  const sel = document.getElementById('cxl-reason-' + bookingId);
+  const reason = sel ? sel.value : '';
+  if (!reason) {
+    showMsg('Please pick a reason for cancelling — the owner will want to know.', 'error');
+    return null;
+  }
+  const noteEl = document.getElementById('cxl-note-' + bookingId);
+  const note = noteEl && noteEl.value.trim() ? ': ' + noteEl.value.trim() : '';
+  return reason + note;
+}
 async function cancelWalk(id) {
+  const reason = collectCancelReason(id);
+  if (reason === null) return;
   try {
-    await sbPatch('bookings', 'id', id, { status: 'cancelled' });
+    await sbPatch('bookings', 'id', id, { status: 'cancelled', cancel_reason: reason });
     const b = bookings.find(x => x.id === id);
     if (b) b.status = 'cancelled';
     dashCancelId = null;
     renderBookingsTab();
   } catch(e) { showMsg(e.message, 'error'); }
 }
-async function cancelSeriesWalks(seriesId) {
+async function cancelSeriesWalks(seriesId, promptBookingId) {
+  // The booking the carer is looking at gets their chosen reason directly (so a
+  // covered-walk alert carries it); the series cascade then stamps the rest with
+  // "Recurring schedule cancelled" and skips this already-cancelled row.
+  const reason = promptBookingId ? collectCancelReason(promptBookingId) : null;
+  if (promptBookingId && reason === null) return;
   try {
+    if (promptBookingId) {
+      const pb = bookings.find(x => x.id === promptBookingId);
+      if (pb && (pb.status === 'pending' || pb.status === 'confirmed')) {
+        await sbPatch('bookings', 'id', promptBookingId, { status: 'cancelled', cancel_reason: reason });
+      }
+    }
     await sbPatch('booking_series', 'id', seriesId, { status: 'cancelled' });
     const now = Date.now();
     bookings.forEach(b => {
@@ -778,6 +826,8 @@ async function cancelSeriesWalks(seriesId) {
         b.status = 'cancelled';
       }
     });
+    const pb = bookings.find(x => x.id === promptBookingId);
+    if (pb) pb.status = 'cancelled';
     dashCancelId = null;
     renderBookingsTab();
     showMsg('Recurring schedule cancelled — upcoming walks were cancelled. Past walks are unchanged.', 'success');

--- a/supabase/functions/send-notification/index.ts
+++ b/supabase/functions/send-notification/index.ts
@@ -162,6 +162,75 @@ async function buildMessages(type: string, payload: Record<string, unknown>) {
         footnote: 'Your carer has already provided the service, so please retry soon.',
       }),
     });
+  } else if (type === 'cover_cancellation') {
+    // TRU-138: a covered walk was cancelled by its walker — page every admin
+    // immediately with everything needed to act. This is the ONE operational
+    // surface where stored access detail (TRU-135) appears; the footnote asks
+    // for the email to be deleted once the walk is covered.
+    const d = await loadBooking(payload.booking_id as string);
+    const { data: admins } = await sb.from('users').select('email,first_name').eq('is_admin', true);
+    if (!admins?.length) return out;
+    const { data: cover } = await sb.rpc('get_cover_details', { p_booking_id: d.booking.id });
+    const c = (cover ?? {}) as Record<string, string | null>;
+
+    // Per-dog handling notes, linked from the pet profile (booking_pets with the
+    // legacy single-pet fallback). The service client bypasses RLS.
+    const { data: bps } = await sb.from('booking_pets').select('pet_id').eq('booking_id', d.booking.id);
+    const petIds = (bps?.length ? bps.map((r: { pet_id: string }) => r.pet_id) : [d.booking.pet_id]).filter(Boolean);
+    const { data: petRows } = petIds.length
+      ? await sb.from('pets').select('name,breed,behaviour_notes,medical_notes,vet_name,vet_phone').in('id', petIds)
+      : { data: [] as never[] };
+    const dogs = (petRows ?? []) as { name: string; breed: string | null; behaviour_notes: string | null; medical_notes: string | null; vet_name: string | null; vet_phone: string | null }[];
+    const dogNames = dogs.map((p) => p.name).join(' & ') || d.petName;
+
+    const windowStr = d.booking.window_end_at
+      ? `${fmtWhen(d.booking.scheduled_at, null)}–${new Date(d.booking.window_end_at).toLocaleTimeString('en-AU', { hour: 'numeric', minute: '2-digit', timeZone: 'Australia/Sydney' })}${d.durationMins ? ` · ${d.durationMins} min` : ''}`
+      : fmtWhen(d.booking.scheduled_at, d.durationMins);
+
+    const rows: [string, string][] = [
+      ['Dog', dogs.map((p) => p.breed ? `${p.name} (${p.breed})` : p.name).join(' & ') || d.petName],
+      ['Window', windowStr],
+      ['Address', [c.address, c.suburb, c.postcode].filter(Boolean).join(', ') || '⚠ missing'],
+      ['Lockbox', c.access_location || '⚠ missing — contact owner'],
+      ['Code', c.access_code || '⚠ missing'],
+    ];
+    if (c.access_notes) rows.push(['Access notes', c.access_notes]);
+    rows.push(
+      ['Owner', c.owner_name || 'Owner'],
+      ['Owner phone', c.owner_phone || '—'],
+      ['Owner email', c.owner_email || '—'],
+      ['Original walker', d.provider?.first_name || '—'],
+      ['Reason', d.booking.cancel_reason || '—'],
+      ['Late (<3h notice)', d.booking.late_cancellation ? 'YES' : 'no'],
+    );
+
+    const notesHtml = dogs
+      .map((pet) => {
+        const bits = [];
+        if (pet.behaviour_notes) bits.push(`Behaviour: ${esc(pet.behaviour_notes)}`);
+        if (pet.medical_notes) bits.push(`Medical: ${esc(pet.medical_notes)}`);
+        if (pet.vet_name || pet.vet_phone) bits.push(`Vet: ${esc([pet.vet_name, pet.vet_phone].filter(Boolean).join(' · '))}`);
+        return bits.length ? p(`<b>${esc(pet.name)}</b> — ${bits.join(' · ')}`) : '';
+      })
+      .filter(Boolean)
+      .join('');
+
+    for (const admin of admins) {
+      if (!admin.email) continue;
+      out.push({
+        to: admin.email,
+        subject: `🚨 Cover needed — ${dogNames} · ${fmtWhen(d.booking.scheduled_at, null)}`,
+        html: layout({
+          preview: `Covered walk cancelled — ${dogNames} needs cover`,
+          heading: 'A covered walk needs you',
+          body: p(`${esc(d.provider?.first_name || 'The walker')} cancelled a covered ${esc(d.serviceLabel.toLowerCase())}. Everything you need is below.`) +
+            detailsTable(rows) +
+            (notesHtml || p('No handling notes on file.')),
+          cta: { label: 'Open the admin console', href: `${SITE}/admin/` },
+          footnote: 'This email contains entry access details — delete it once the walk is covered.',
+        }),
+      });
+    }
   } else if (type === 'walk_started') {
     const { data: ws } = await sb.from('walk_sessions').select('booking_id').eq('id', payload.walk_session_id as string).single();
     if (!ws) return out;

--- a/supabase/migrations/20260703000001_tru137_138_cancellation_flow.sql
+++ b/supabase/migrations/20260703000001_tru137_138_cancellation_flow.sql
@@ -1,0 +1,187 @@
+-- TRU-137: walker cancellation flow + minimum-notice policy.
+-- TRU-138: covered-cancellation founder alert (the event fires here; the email is
+-- rendered/sent by the send-notification edge function, type 'cover_cancellation').
+--
+-- Policy constants (MVP, founder-changeable by editing the trigger fn):
+--   * minimum notice window = 3 hours (cancelling a confirmed walk with less
+--     notice — or after its start — is a "late cancellation", treated like a
+--     no-show on the walker's record);
+--   * cover trigger horizon = 48 hours (a covered walk only pages the founder
+--     when it's actually imminent; further-out walks can simply be rebooked).
+--
+-- Scope decisions (per ticket): cancellations only, no no-show detection; cover
+-- applies to walks and drop-ins only; declining a *pending* request is not a
+-- cancellation (counters and cover fire only when a CONFIRMED booking is
+-- cancelled by its walker). Series cascades cancel each future booking, so each
+-- confirmed one counts individually and each covered one within the horizon
+-- alerts individually.
+--
+-- Applied to the live DB via apply_migration; committed for version control.
+
+alter table public.bookings
+  add column if not exists cancel_reason text,
+  add column if not exists cancelled_by text
+    check (cancelled_by in ('customer','provider','admin')),
+  add column if not exists cancelled_at timestamptz,
+  add column if not exists late_cancellation boolean,
+  add column if not exists cover_status text not null default 'none'
+    check (cover_status in ('none','triggered','reassigned','fell_through'));
+
+alter table public.provider_profiles
+  add column if not exists cancellation_count integer not null default 0,
+  add column if not exists late_cancellation_count integer not null default 0;
+
+-- ── Stamp pass (BEFORE): who cancelled, when, late?, covered? ────────────────
+create or replace function public.trg_booking_cancel_stamp()
+returns trigger
+language plpgsql security definer set search_path = public
+as $$
+declare
+  v_service_type text;
+begin
+  if NEW.status = 'cancelled' and OLD.status is distinct from 'cancelled' then
+    NEW.cancelled_at := coalesce(NEW.cancelled_at, now());
+
+    if NEW.cancelled_by is null then
+      if exists (select 1 from provider_profiles pp
+                 where pp.id = NEW.provider_id and pp.user_id = auth.uid()) then
+        NEW.cancelled_by := 'provider';
+      elsif exists (select 1 from customer_profiles cp
+                    where cp.id = NEW.customer_id and cp.user_id = auth.uid()) then
+        NEW.cancelled_by := 'customer';
+      elsif exists (select 1 from users u
+                    where u.id = auth.uid() and u.is_admin) then
+        NEW.cancelled_by := 'admin';
+      end if;
+    end if;
+
+    -- Reliability + cover only apply when a walker cancels a CONFIRMED booking.
+    if NEW.cancelled_by = 'provider' and OLD.status = 'confirmed' then
+      -- Late = inside the 3-hour minimum-notice window (or after the start).
+      NEW.late_cancellation := (NEW.scheduled_at - now()) < interval '3 hours';
+
+      select ps.service_type into v_service_type
+        from provider_services ps where ps.id = NEW.service_id;
+
+      if v_service_type in ('dog_walking', 'drop_in')
+         and not coalesce(NEW.is_meet_and_greet, false)
+         and NEW.scheduled_at > now()
+         and NEW.scheduled_at < now() + interval '48 hours'
+         and exists (
+           select 1
+             from customer_profiles cp
+             join private.backup_access ba on ba.customer_id = cp.id
+            where cp.id = NEW.customer_id
+              and cp.backup_cover_enabled
+         ) then
+        NEW.cover_status := 'triggered';
+      end if;
+    end if;
+  end if;
+  return NEW;
+end;
+$$;
+
+drop trigger if exists booking_cancel_stamp on public.bookings;
+create trigger booking_cancel_stamp
+  before update of status on public.bookings
+  for each row execute function public.trg_booking_cancel_stamp();
+
+-- ── Effects pass (AFTER): reliability counters + founder alert ───────────────
+create or replace function public.trg_booking_cancel_effects()
+returns trigger
+language plpgsql security definer set search_path = public
+as $$
+begin
+  if NEW.status = 'cancelled' and OLD.status is distinct from 'cancelled'
+     and NEW.cancelled_by = 'provider' and OLD.status = 'confirmed' then
+    update provider_profiles
+       set cancellation_count = cancellation_count + 1,
+           late_cancellation_count = late_cancellation_count
+             + (case when coalesce(NEW.late_cancellation, false) then 1 else 0 end)
+     where id = NEW.provider_id;
+
+    if NEW.cover_status = 'triggered' then
+      -- Same fire-and-forget pg_net path as the email pipeline; an alert hiccup
+      -- must never roll back the cancellation write.
+      begin
+        perform private.notify_email(
+          jsonb_build_object('type', 'cover_cancellation', 'booking_id', NEW.id));
+      exception when others then null;
+      end;
+    end if;
+  end if;
+  return NEW;
+end;
+$$;
+
+drop trigger if exists booking_cancel_effects on public.bookings;
+create trigger booking_cancel_effects
+  after update of status on public.bookings
+  for each row execute function public.trg_booking_cancel_effects();
+
+-- Internal trigger functions — not RPC-callable (TRU-153 pattern).
+revoke execute on function public.trg_booking_cancel_stamp() from public, anon, authenticated;
+revoke execute on function public.trg_booking_cancel_effects() from public, anon, authenticated;
+
+-- ── Series cascade: record a reason on the cancelled rows ────────────────────
+-- Same body as the TRU-14 version, plus cancel_reason so cascaded cancellations
+-- always carry a reason (AC: "walker cancellation always records a reason").
+create or replace function public.trg_series_cancelled()
+returns trigger
+language plpgsql security definer set search_path = public
+as $$
+begin
+  if NEW.status = 'cancelled' and (OLD.status is distinct from 'cancelled') then
+    update public.bookings
+       set status = 'cancelled',
+           cancel_reason = coalesce(cancel_reason, 'Recurring schedule cancelled'),
+           updated_at = now()
+     where series_id = NEW.id
+       and not coalesce(is_meet_and_greet, false)
+       and status in ('pending', 'confirmed')
+       and scheduled_at > now();
+  end if;
+  return NEW;
+end;
+$$;
+
+-- ── Founder-alert data (TRU-138) ─────────────────────────────────────────────
+-- The ONE operational surface where stored access detail is exposed. The private
+-- schema isn't reachable over the API, so send-notification (service role) reads
+-- through this definer fn. service_role only — not callable by users.
+create or replace function public.get_cover_details(p_booking_id uuid)
+returns jsonb
+language plpgsql security definer stable set search_path = public
+as $$
+declare
+  b public.bookings%rowtype;
+  result jsonb;
+begin
+  select * into b from bookings where id = p_booking_id;
+  if not found then return null; end if;
+
+  select jsonb_build_object(
+    'access_location', ba.access_location,
+    'access_code',     ba.access_code,
+    'access_notes',    ba.access_notes,
+    'consent_at',      ba.consent_at,
+    'consent_version', ba.consent_version,
+    'address',         cp.address,
+    'suburb',          cp.suburb,
+    'postcode',        cp.postcode,
+    'owner_name',      trim(coalesce(u.first_name,'') || ' ' || coalesce(u.last_name,'')),
+    'owner_phone',     u.phone,
+    'owner_email',     u.email
+  ) into result
+  from customer_profiles cp
+  join users u on u.id = cp.user_id
+  left join private.backup_access ba on ba.customer_id = cp.id
+  where cp.id = b.customer_id;
+
+  return result;
+end;
+$$;
+
+revoke all on function public.get_cover_details(uuid) from public, anon, authenticated;
+grant execute on function public.get_cover_details(uuid) to service_role;


### PR DESCRIPTION
## What

Second slice of the **Backup Cover MVP** — stacked on #74 (merge that first; this PR's base is that branch).

### TRU-137 — cancellation flow + minimum-notice policy
- Every walker cancellation now records **who / when / why** (`cancelled_by`, `cancelled_at`, `cancel_reason` on `bookings`) — stamped by a server-side trigger, so the policy can't be bypassed by a raw PATCH.
- **Late cancellation** = a confirmed booking cancelled with **< 3 hours' notice** (or after its start) — flagged distinctly (`late_cancellation`) and counted separately (`late_cancellation_count` alongside `cancellation_count` on `provider_profiles`) to feed trust & safety / a future "reliable walker" tier. The 3h window is a constant in the trigger fn (ticket suggested 2–3h, configurable).
- Declining a **pending** request is *not* a reliability event: recorded, but no counter, no cover.
- **Dashboard**: cancelling now requires a reason (select + optional note) and shows a heads-up when inside the 3h window. A series cancel puts the picked reason on the walk being viewed, then the cascade stamps the rest with "Recurring schedule cancelled".
- Scope per ticket: walks + drop-ins only; no no-show detection.

### TRU-138 — real-time founder alert (critical path)
- A covered confirmed walk cancelled by its walker → `cover_status='triggered'` → **immediate 🚨 email to every admin** via the existing pg_net → send-notification → Resend pipeline (exception-wrapped: an alert hiccup can never roll back the cancellation).
- **Covered** = owner opted in with access captured (#74) + walk/drop-in + not M&G + **scheduled within 48h** (an imminent walk pages you; one three weeks out just needs rebooking — judgement call, easy to change).
- Alert contains everything needed to act without digging: dog(s) + per-dog behaviour/medical/vet notes, address, lockbox location + code + notes, time window, owner contact, original walker, reason, late flag. Footnote asks you to delete the email once covered.
- `get_cover_details()` is the **single** operational read of `private.backup_access` — definer fn, EXECUTE granted to `service_role` only.

## Verified live (real data, real email)

1. Created a confirmed test walk (Sarah × Max, 2h out) and cancelled it as the walker: stamps ✓, `late_cancellation=true` ✓, `cover_status='triggered'` ✓, counters 1/1 ✓.
2. The 🚨 alert **actually delivered** (Resend `allOk:true`) — **check your admin inbox**: that's the real thing, with Sarah's dummy lockbox details. Judge the format there.
3. Negative path: pending-request decline → recorded, but no counter / no cover / no alert ✓.
4. Dashboard JS passes `node --check`; deployed edge fn source (v7) diffed back against the repo copy ✓.

The covered cancelled test booking (`09d96638…`) is deliberately left in place as the reassignment fixture for the TRU-139 PR.

Migration applied via `apply_migration`; the committed `.sql` is the record.

Closes TRU-137. Closes TRU-138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)