### PR TITLE
TRU-139: reassign covered bookings to the backup + payment handling

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -130,7 +130,7 @@ async function onLogin(e) {
 }
 
 // ── Console shell ──
-const SECTIONS = [ { id:'refunds', label:'Refunds' } ];
+const SECTIONS = [ { id:'refunds', label:'Refunds' }, { id:'cover', label:'Cover' } ];
 function showConsole() {
   currentSection = SECTIONS.some(s => s.id === currentSection) ? currentSection : 'refunds';
   app().innerHTML = `
@@ -152,7 +152,95 @@ function switchSection(name) {
 function renderSection(name) {
   const c = document.getElementById('adm-content');
   if (name === 'refunds') return renderRefunds(c);
+  if (name === 'cover') return renderCover(c);
   c.innerHTML = '<p class="empty">Coming soon.</p>';
+}
+
+// ── Cover section (TRU-139) ──
+function coverWhen(iso) {
+  if (!iso) return '';
+  try { return new Date(iso).toLocaleString('en-AU', { weekday:'short', day:'numeric', month:'short', hour:'numeric', minute:'2-digit' }); } catch (e) { return ''; }
+}
+function coverCard(cv) {
+  const badge = cv.cover_status === 'triggered' ? '<span class="badge b-failed">needs cover</span>'
+    : cv.cover_status === 'reassigned' ? '<span class="badge b-paid">covered</span>'
+    : '<span class="badge b-refunded">fell through</span>';
+  const late = cv.late_cancellation ? ' · <b>late (&lt;3h)</b>' : '';
+  let actions = '';
+  if (cv.cover_status === 'triggered') {
+    actions = `<div class="actions">
+      <button class="btn" onclick="coverReassign('${cv.id}')">I'll cover it</button>
+      <span style="font-size:0.84rem;color:var(--muted);">or credit $</span>
+      <input class="reason" id="cred-${cv.id}" type="number" value="10" min="0" step="1" style="max-width:80px;flex:0 1 auto;">
+      <button class="btn" style="background:#fff;color:var(--terracottaDark);" onclick="coverFellThrough('${cv.id}')">Couldn't cover</button>
+    </div>`;
+  } else if (cv.cover_status === 'reassigned') {
+    actions = `<div class="meta">Assigned to you — run it from the <a href="/dashboard/">dashboard</a> like any walk. Completing it charges the owner in full; Truffl retains the walker share.</div>`;
+  }
+  return `<div class="card">
+    <div class="row-top"><div><b>${esc(cv.pet)}</b> · ${esc(cv.customer)}${badge}</div><div class="meta">${coverWhen(cv.scheduled_at)}</div></div>
+    <div class="meta">Walker: ${esc(cv.walker)} · ${esc(cv.cancel_reason || 'no reason recorded')}${late}</div>
+    <div class="meta">${money(cv.total_cents)} · cancelled ${coverWhen(cv.cancelled_at)}</div>
+    ${actions}
+  </div>`;
+}
+function creditCard(cr) {
+  const state = cr.redeemed_at
+    ? `<div class="meta">Applied ${when(cr.redeemed_at)}${cr.redeemed_note ? ' · ' + esc(cr.redeemed_note) : ''}</div>`
+    : `<div class="actions"><input class="reason" id="crednote-${cr.id}" placeholder="How it was applied (optional)"><button class="btn" onclick="creditRedeem('${cr.id}')">Mark applied</button></div>`;
+  return `<div class="card">
+    <div class="row-top"><div><span class="amount">${money(cr.amount_cents)}</span><span class="badge ${cr.redeemed_at ? 'b-refunded' : 'b-paid'}">${cr.redeemed_at ? 'applied' : 'outstanding'}</span></div><div class="meta">${when(cr.created_at)}</div></div>
+    <div class="meta">${esc(cr.customer)} · ${esc(cr.reason || '')}</div>
+    ${state}
+  </div>`;
+}
+async function renderCover(c) {
+  c.innerHTML = '<div id="adm-msg" class="msg"></div><p class="empty">Loading…</p>';
+  try {
+    const { cover, credits } = await sbFn('stripe-api', { action:'cover_list' });
+    const coverHtml = (cover && cover.length) ? cover.map(coverCard).join('') : '<p class="empty">No covered cancellations yet.</p>';
+    const outstanding = (credits || []).filter(cr => !cr.redeemed_at);
+    const applied = (credits || []).filter(cr => cr.redeemed_at);
+    const creditsHtml = (outstanding.length + applied.length)
+      ? outstanding.map(creditCard).join('') + applied.map(creditCard).join('')
+      : '<p class="empty">No credits issued.</p>';
+    c.innerHTML = `
+      <p class="sub" style="margin-bottom:14px;">Covered cancellations. "I'll cover it" reassigns the walk to you (owner keeps the original price; the walker share is retained). "Couldn't cover" applies the fall-through promise: no charge + a manual credit.</p>
+      <div id="adm-msg" class="msg"></div>
+      ${coverHtml}
+      <h1 style="font-size:1.2rem;margin:22px 0 10px;">Credits (manual)</h1>
+      ${creditsHtml}`;
+  } catch (e) {
+    if (e.message === 'Not authenticated') return signOut();
+    c.innerHTML = `<p class="empty">${esc(e.message)}</p>`;
+  }
+}
+async function coverReassign(id) {
+  if (!confirm('Take this walk? It will be reassigned to you and confirmed for the owner.')) return;
+  admMsg('');
+  try {
+    await sbFn('stripe-api', { action:'cover_reassign', booking_id:id });
+    admMsg('Reassigned to you ✓ — it now shows in your dashboard.', 'ok');
+    renderCover(document.getElementById('adm-content'));
+  } catch (e) { admMsg(e.message, 'error'); }
+}
+async function coverFellThrough(id) {
+  const dollars = parseFloat((document.getElementById('cred-' + id) || {}).value || '10') || 0;
+  if (!confirm(`Mark as couldn't cover? The owner is not charged and gets a $${dollars} credit.`)) return;
+  admMsg('');
+  try {
+    await sbFn('stripe-api', { action:'cover_fell_through', booking_id:id, credit_cents: Math.round(dollars * 100) });
+    admMsg('Recorded — owner messaged and credit issued.', 'ok');
+    renderCover(document.getElementById('adm-content'));
+  } catch (e) { admMsg(e.message, 'error'); }
+}
+async function creditRedeem(id) {
+  const note = (document.getElementById('crednote-' + id) || {}).value || '';
+  try {
+    await sbFn('stripe-api', { action:'credit_redeem', credit_id:id, note });
+    admMsg('Credit marked applied ✓', 'ok');
+    renderCover(document.getElementById('adm-content'));
+  } catch (e) { admMsg(e.message, 'error'); }
 }
 
 // ── Refunds section ──

--- a/profile/index.html
+++ b/profile/index.html
@@ -107,6 +107,9 @@
   .cover-check{display:flex;gap:9px;align-items:flex-start;font-size:0.85rem;line-height:1.55;color:var(--text);margin:12px 0;}
   .cover-check input{margin-top:3px;flex-shrink:0;}
   .cover-meta{font-size:0.82rem;color:var(--text-muted);margin:4px 0 10px;}
+  /* TRU-139: fall-through note + manual credit banner */
+  .cover-note{margin-bottom:10px;background:#fdf3ec;border:1px solid #f0d9c8;border-radius:8px;padding:8px 12px;font-size:0.82rem;color:#8a5a3b;line-height:1.5;}
+  .credit-banner{background:var(--success-bg);border:1px solid #d3e3d2;border-radius:10px;padding:10px 14px;font-size:0.86rem;color:var(--sage-dark);margin-bottom:14px;}
   .btn-cancel-yes{padding:8px 14px;background:var(--error);color:white;border:none;border-radius:8px;font-size:0.82rem;font-weight:500;cursor:pointer;font-family:'DM Sans',sans-serif;}
   .btn-cancel-yes:hover{opacity:0.9;}
   .btn-cancel-keep{padding:8px 14px;background:transparent;border:1px solid var(--border);color:var(--text-muted);border-radius:8px;font-size:0.82rem;cursor:pointer;font-family:'DM Sans',sans-serif;}
@@ -272,6 +275,7 @@ const COVER_CONSENT_VERSION = 'v1-2026-07-03';
 const COVERED_SERVICES = ['dog_walking', 'drop_in'];
 let editingCover = false;     // opt-in/edit form open in the account tab
 let coverPrefill = null;      // row from get_backup_access() when editing
+let myCredits = [];           // outstanding manual credits (TRU-139)
 
 const ALLOWED_PHOTO_TYPES = ['image/png', 'image/jpeg', 'image/webp'];
 const MAX_PHOTO_BYTES = 5 * 1024 * 1024;
@@ -607,6 +611,7 @@ function bookingCardHtml(b) {
       <div class="bc-time">${esc(dateStr)}</div>
       ${statusBadge(b.status)}
       ${paymentNotice(b)}
+      ${b.cover_status === 'fell_through' ? `<div class="cover-note">We're really sorry — we weren't able to cover this walk. You haven't been charged for it, and we've added a credit to your account for next time.</div>` : ''}
       <div class="bc-actions">${actions}${msgLink}</div>
     </div>
   `;
@@ -915,6 +920,10 @@ function renderBookingsTab() {
   }
 
   let html = '';
+  const creditTotal = (myCredits || []).reduce((s, c) => s + (c.amount_cents || 0), 0);
+  if (creditTotal > 0) {
+    html += `<div class="credit-banner">You have a $${(creditTotal / 100).toFixed(0)} credit — we'll apply it to an upcoming walk.</div>`;
+  }
   if (active.length > 0) {
     html += `<div class="section-heading">Active &amp; upcoming</div>`;
     html += active.map(bookingCardHtml).join('');
@@ -1471,6 +1480,9 @@ async function init() {
     }
     customerProfile = profiles[0];
     profileRow = profiles[0];
+
+    // TRU-139: outstanding manual credits (RLS scopes to own rows).
+    try { myCredits = await sbGet('customer_credits', 'select=amount_cents&redeemed_at=is.null'); } catch (e) { myCredits = []; }
 
     const rawBookings = await sbGet('bookings', `customer_id=eq.${customerProfile.id}&select=*&order=scheduled_at.desc`);
 

--- a/supabase/functions/charge-booking/index.ts
+++ b/supabase/functions/charge-booking/index.ts
@@ -67,10 +67,15 @@ Deno.serve(async (req) => {
 
   try {
     const { data: b } = await sb.from('bookings')
-      .select('id,total_cents,customer_id,provider_id,is_meet_and_greet,payment_status')
+      .select('id,total_cents,customer_id,provider_id,is_meet_and_greet,payment_status,cover_status')
       .eq('id', bookingId).single();
     if (!b) return json({ error: 'booking not found' }, 404);
     if (b.is_meet_and_greet || (b.total_cents || 0) <= 0) return json({ skipped: 'not chargeable' });
+    // TRU-139: a covered walk completed by the Truffl backup. Owner pays the full
+    // original price; NO destination transfer and NO application fee — the share
+    // that would have gone to the original walker is retained by the platform
+    // (they cancelled; they are not paid for this booking).
+    const covered = b.cover_status === 'reassigned';
 
     // Atomic claim: only one invocation may move unpaid/failed -> processing.
     const { data: claimed } = await sb.from('bookings')
@@ -86,10 +91,6 @@ Deno.serve(async (req) => {
     const pm = cust?.invoice_settings?.default_payment_method;
     if (!pm) { await markFailed(bookingId); return json({ error: 'no saved card on file' }, 400); }
 
-    const { data: pp } = await sb.from('provider_profiles').select('stripe_account_id').eq('id', b.provider_id).single();
-    if (!pp?.stripe_account_id) { await markFailed(bookingId); return json({ error: 'carer has no payout account' }, 400); }
-
-    const fee = Math.round((b.total_cents * PLATFORM_FEE_BPS) / 10000);
     const piBody: Record<string, unknown> = {
       amount: b.total_cents,
       currency: CURRENCY,
@@ -97,10 +98,16 @@ Deno.serve(async (req) => {
       payment_method: pm,
       off_session: true,
       confirm: true,
-      'transfer_data[destination]': pp.stripe_account_id,
       'metadata[booking_id]': bookingId,
     };
-    if (fee > 0) piBody['application_fee_amount'] = fee; // omitted at 0% — Stripe requires it positive
+    let fee = 0;
+    if (!covered) {
+      const { data: pp } = await sb.from('provider_profiles').select('stripe_account_id').eq('id', b.provider_id).single();
+      if (!pp?.stripe_account_id) { await markFailed(bookingId); return json({ error: 'carer has no payout account' }, 400); }
+      piBody['transfer_data[destination]'] = pp.stripe_account_id;
+      fee = Math.round((b.total_cents * PLATFORM_FEE_BPS) / 10000);
+      if (fee > 0) piBody['application_fee_amount'] = fee; // omitted at 0% — Stripe requires it positive
+    }
 
     let pi;
     try {
@@ -118,7 +125,7 @@ Deno.serve(async (req) => {
         application_fee_cents: fee,
         charged_at: new Date().toISOString(),
       }).eq('id', bookingId);
-      return json({ ok: true, payment_intent: pi.id, amount: b.total_cents, application_fee_cents: fee });
+      return json({ ok: true, payment_intent: pi.id, amount: b.total_cents, application_fee_cents: fee, covered });
     }
 
     // requires_action etc. — an off-session charge can't complete; flag for follow-up.

--- a/supabase/functions/stripe-api/index.ts
+++ b/supabase/functions/stripe-api/index.ts
@@ -14,6 +14,10 @@
 //   sync_payment    - reconcile a booking's payment_status from its PaymentIntent
 //   list_recent_charges - (admin) recent paid/failed/refunded bookings for the admin page
 //   refund_booking  - (admin) refund a paid booking + reverse the carer's transfer
+//   cover_list      - (admin) covered bookings (triggered/reassigned/fell_through) + credits
+//   cover_reassign  - (admin) take over a covered cancelled booking (TRU-139)
+//   cover_fell_through - (admin) mark cover as failed; issue a manual credit + owner message
+//   credit_redeem   - (admin) mark a manual credit as applied
 //
 // Required function secrets (Supabase → Edge Functions → Secrets):
 //   STRIPE_SECRET_KEY   - sk_test_… (platform secret key)
@@ -193,26 +197,31 @@ Deno.serve(async (req) => {
       if (!customer) return json({ error: 'Not a customer account' }, 403);
       const bookingId = String(payload.booking_id || '');
       const { data: b } = await sb.from('bookings')
-        .select('id,total_cents,provider_id,is_meet_and_greet,payment_status')
+        .select('id,total_cents,provider_id,is_meet_and_greet,payment_status,cover_status')
         .eq('id', bookingId).eq('customer_id', customer.id).single();
       if (!b) return json({ error: 'Booking not found' }, 404);
       if (b.is_meet_and_greet || (b.total_cents || 0) <= 0) return json({ error: 'Nothing to pay' }, 400);
       if (b.payment_status !== 'failed') return json({ error: 'This booking is not awaiting payment' }, 400);
       if (!customer.stripe_customer_id) return json({ error: 'No payment profile on file' }, 400);
-      const { data: pp } = await sb.from('provider_profiles').select('stripe_account_id').eq('id', b.provider_id).single();
-      if (!pp?.stripe_account_id) return json({ error: 'Carer has no payout account' }, 400);
-
-      const fee = Math.round((b.total_cents * PLATFORM_FEE_BPS) / 10000);
+      // A covered walk completed by the Truffl backup is retained in full (TRU-139):
+      // no destination transfer, no application fee — mirrors charge-booking.
+      const covered = b.cover_status === 'reassigned';
       const piBody: Record<string, unknown> = {
         amount: b.total_cents,
         currency: 'aud',
         customer: customer.stripe_customer_id,
-        'transfer_data[destination]': pp.stripe_account_id,
         'payment_method_types[]': 'card',
         setup_future_usage: 'off_session', // save the working card for future charges
         'metadata[booking_id]': bookingId,
       };
-      if (fee > 0) piBody['application_fee_amount'] = fee;
+      let fee = 0;
+      if (!covered) {
+        const { data: pp } = await sb.from('provider_profiles').select('stripe_account_id').eq('id', b.provider_id).single();
+        if (!pp?.stripe_account_id) return json({ error: 'Carer has no payout account' }, 400);
+        piBody['transfer_data[destination]'] = pp.stripe_account_id;
+        fee = Math.round((b.total_cents * PLATFORM_FEE_BPS) / 10000);
+        if (fee > 0) piBody['application_fee_amount'] = fee;
+      }
       // No confirm — the client confirms with the Payment Element so a new card / 3DS works.
       const pi = await stripe('payment_intents', 'POST', piBody);
       await sb.from('bookings').update({ stripe_payment_intent_id: pi.id, application_fee_cents: fee }).eq('id', bookingId);
@@ -304,6 +313,140 @@ Deno.serve(async (req) => {
         .update({ payment_status: 'refunded', refunded_at: new Date().toISOString(), stripe_refund_id: refund.id })
         .eq('id', bookingId);
       return json({ ok: true, refund_id: refund.id });
+    }
+
+    // ── Backup cover (TRU-139) — admin actions ──
+
+    if (action === 'cover_list') {
+      if (!(await isAdmin(user.id))) return json({ error: 'Not authorised' }, 403);
+      const { data } = await sb.from('bookings')
+        .select('id,scheduled_at,window_end_at,duration_mins,total_cents,status,payment_status,cover_status,cancel_reason,cancelled_at,late_cancellation,customer_id,provider_id,original_provider_id,pet_id')
+        .neq('cover_status', 'none')
+        .order('scheduled_at', { ascending: false })
+        .limit(30);
+      const rows = data || [];
+      const NONE = ['00000000-0000-0000-0000-000000000000'];
+      const custIds = [...new Set(rows.map((r) => r.customer_id))];
+      const provIds = [...new Set(rows.flatMap((r) => [r.provider_id, r.original_provider_id]).filter(Boolean))] as string[];
+      const petIds = [...new Set(rows.map((r) => r.pet_id).filter(Boolean))] as string[];
+      const [{ data: cps }, { data: pps }, { data: petsData }, { data: credits }] = await Promise.all([
+        sb.from('customer_profiles').select('id,user_id').in('id', custIds.length ? custIds : NONE),
+        sb.from('provider_profiles').select('id,user_id').in('id', provIds.length ? provIds : NONE),
+        sb.from('pets').select('id,name').in('id', petIds.length ? petIds : NONE),
+        sb.from('customer_credits').select('id,customer_id,amount_cents,reason,created_at,redeemed_at,redeemed_note,booking_id')
+          .order('created_at', { ascending: false }).limit(30),
+      ]);
+      const custUser = Object.fromEntries((cps || []).map((c) => [c.id, c.user_id]));
+      const provUser = Object.fromEntries((pps || []).map((p) => [p.id, p.user_id]));
+      const petName = Object.fromEntries((petsData || []).map((p) => [p.id, p.name]));
+      const creditCustIds = [...new Set((credits || []).map((c) => c.customer_id))];
+      const { data: creditCps } = await sb.from('customer_profiles').select('id,user_id').in('id', creditCustIds.length ? creditCustIds : NONE);
+      (creditCps || []).forEach((c) => { custUser[c.id] = c.user_id; });
+      const userIds = [...new Set([...Object.values(custUser), ...Object.values(provUser)])] as string[];
+      const { data: us } = await sb.from('users').select('id,first_name,last_name').in('id', userIds.length ? userIds : NONE);
+      const nameBy = Object.fromEntries((us || []).map((u) => [u.id, `${u.first_name || ''} ${u.last_name || ''}`.trim()]));
+      return json({
+        cover: rows.map((r) => ({
+          ...r,
+          customer: nameBy[custUser[r.customer_id]] || 'Customer',
+          walker: nameBy[provUser[r.original_provider_id || r.provider_id]] || 'Walker',
+          pet: petName[r.pet_id] || 'Dog',
+        })),
+        credits: (credits || []).map((c) => ({ ...c, customer: nameBy[custUser[c.customer_id]] || 'Customer' })),
+      });
+    }
+
+    if (action === 'cover_reassign') {
+      if (!(await isAdmin(user.id))) return json({ error: 'Not authorised' }, 403);
+      const bookingId = String(payload.booking_id || '');
+      const { data: b } = await sb.from('bookings')
+        .select('id,status,cover_status,provider_id,original_provider_id,customer_id,pet_id')
+        .eq('id', bookingId).maybeSingle();
+      if (!b) return json({ error: 'Booking not found' }, 404);
+      if (b.cover_status !== 'triggered' || b.status !== 'cancelled') {
+        return json({ error: 'This booking is not awaiting cover' }, 400);
+      }
+      // The admin doing the reassign becomes the backup walker. Ensure they have a
+      // provider profile — created inactive + unverified so it is never searchable;
+      // it's just the identity the walk hangs off so tracking/completion work
+      // unchanged (records: original_provider_id = booked, provider_id = actual).
+      let { data: mypp } = await sb.from('provider_profiles').select('id').eq('user_id', user.id).maybeSingle();
+      if (!mypp) {
+        const ins = await sb.from('provider_profiles')
+          .insert({ user_id: user.id, is_active: false, is_verified: false, bio: 'Truffl backup' })
+          .select('id').single();
+        if (ins.error || !ins.data) return json({ error: 'Could not create backup profile' }, 500);
+        mypp = ins.data;
+      }
+      if (mypp.id === b.provider_id) return json({ error: 'Booking is already assigned to you' }, 400);
+      const upd = await sb.from('bookings').update({
+        original_provider_id: b.original_provider_id || b.provider_id,
+        provider_id: mypp.id,
+        status: 'confirmed',
+        cover_status: 'reassigned',
+      }).eq('id', bookingId).eq('cover_status', 'triggered').select('id');
+      if (upd.error || !upd.data?.length) return json({ error: 'Reassign failed — booking may already be handled' }, 409);
+      // Tell the owner in-app (one-way Truffl channel; service role writes directly).
+      const { data: cp } = await sb.from('customer_profiles').select('user_id').eq('id', b.customer_id).single();
+      const { data: pet } = b.pet_id ? await sb.from('pets').select('name').eq('id', b.pet_id).single() : { data: null };
+      if (cp?.user_id) {
+        await sb.from('system_messages').insert({
+          recipient_user_id: cp.user_id,
+          body: `Good news — your walker had to cancel, but backup cover kicked in. A Truffl backup will walk ${pet?.name || 'your dog'} as planned.`,
+          link_url: `/track/?booking=${bookingId}`,
+          link_label: 'View booking',
+        });
+      }
+      return json({ ok: true });
+    }
+
+    if (action === 'cover_fell_through') {
+      if (!(await isAdmin(user.id))) return json({ error: 'Not authorised' }, 403);
+      const bookingId = String(payload.booking_id || '');
+      const creditCents = Math.max(0, Math.round(Number(payload.credit_cents ?? 1000)) || 0);
+      const { data: b } = await sb.from('bookings')
+        .select('id,status,cover_status,customer_id,pet_id')
+        .eq('id', bookingId).maybeSingle();
+      if (!b) return json({ error: 'Booking not found' }, 404);
+      if (b.cover_status !== 'triggered' || b.status !== 'cancelled') {
+        return json({ error: 'This booking is not awaiting cover' }, 400);
+      }
+      const upd = await sb.from('bookings').update({ cover_status: 'fell_through' })
+        .eq('id', bookingId).eq('cover_status', 'triggered').select('id');
+      if (upd.error || !upd.data?.length) return json({ error: 'Update failed — booking may already be handled' }, 409);
+      // The walk was never charged (charging happens on completion), so "full
+      // refund" needs no money movement — the credit is the goodwill on top.
+      if (creditCents > 0) {
+        await sb.from('customer_credits').insert({
+          customer_id: b.customer_id,
+          amount_cents: creditCents,
+          reason: 'Backup cover fell through',
+          booking_id: bookingId,
+        });
+      }
+      const { data: cp } = await sb.from('customer_profiles').select('user_id').eq('id', b.customer_id).single();
+      const { data: pet } = b.pet_id ? await sb.from('pets').select('name').eq('id', b.pet_id).single() : { data: null };
+      if (cp?.user_id) {
+        const creditLine = creditCents > 0 ? ` and we've added a $${(creditCents / 100).toFixed(0)} credit to your account for next time` : '';
+        await sb.from('system_messages').insert({
+          recipient_user_id: cp.user_id,
+          body: `We're really sorry — we weren't able to cover ${pet?.name || 'your dog'}'s walk. You haven't been charged for it${creditLine}. No questions asked.`,
+          link_url: '/profile/',
+          link_label: 'View your bookings',
+        });
+      }
+      return json({ ok: true, credit_cents: creditCents });
+    }
+
+    if (action === 'credit_redeem') {
+      if (!(await isAdmin(user.id))) return json({ error: 'Not authorised' }, 403);
+      const creditId = String(payload.credit_id || '');
+      const note = String(payload.note || '').slice(0, 300);
+      const upd = await sb.from('customer_credits')
+        .update({ redeemed_at: new Date().toISOString(), redeemed_note: note || null })
+        .eq('id', creditId).is('redeemed_at', null).select('id');
+      if (upd.error || !upd.data?.length) return json({ error: 'Credit not found or already applied' }, 409);
+      return json({ ok: true });
     }
 
     return json({ error: `Unknown action: ${action}` }, 400);

--- a/supabase/migrations/20260703000002_tru139_reassign_credits.sql
+++ b/supabase/migrations/20260703000002_tru139_reassign_credits.sql
@@ -1,0 +1,48 @@
+-- TRU-139: reassign a covered booking to the backup (founder) + payment handling.
+--
+-- Reassignment model: the booking's provider_id is swapped to the backup's
+-- provider profile (created inactive+unverified on first use, so it is never
+-- searchable) and the originally booked walker is snapshotted in
+-- original_provider_id — records always distinguish booked walker from actual
+-- walker, and walk tracking / RLS / owner UI keep working unchanged for the
+-- covered walk. Payment: charge-booking charges the owner the full original
+-- price but omits the destination transfer for cover_status='reassigned', so
+-- the walker share is retained by the platform and the original walker is not
+-- paid (they cancelled).
+--
+-- Fall-through: cover_status='fell_through' + a customer_credits row. Credits
+-- are MANUAL at MVP (decided with Tom): admin-issued, admin-redeemed, visible
+-- to the owner — the charge engine does NOT auto-apply them.
+--
+-- Applied to the live DB via apply_migration; committed for version control.
+
+alter table public.bookings
+  add column if not exists original_provider_id uuid references public.provider_profiles(id);
+
+create table if not exists public.customer_credits (
+  id            uuid primary key default gen_random_uuid(),
+  customer_id   uuid not null references public.customer_profiles(id) on delete cascade,
+  amount_cents  integer not null check (amount_cents > 0),
+  reason        text,
+  booking_id    uuid references public.bookings(id) on delete set null,
+  created_at    timestamptz not null default now(),
+  redeemed_at   timestamptz,
+  redeemed_note text
+);
+create index if not exists idx_customer_credits_customer
+  on public.customer_credits (customer_id, redeemed_at);
+
+alter table public.customer_credits enable row level security;
+
+-- Owners can see their own credits (profile banner); only the admin console
+-- (service role via stripe-api) writes them.
+drop policy if exists credits_owner_read on public.customer_credits;
+create policy credits_owner_read on public.customer_credits
+  for select to authenticated
+  using (exists (
+    select 1 from public.customer_profiles cp
+    where cp.id = customer_credits.customer_id and cp.user_id = auth.uid()
+  ));
+
+revoke insert, update, delete on public.customer_credits from anon, authenticated;
+grant select on public.customer_credits to authenticated, service_role;


### PR DESCRIPTION
## What

Final slice of the **Backup Cover MVP** — stacked on #75 (merge order: #74 → #75 → this).

### Reassign in one action
Admin console gets a **Cover** section. "I'll cover it" on a triggered booking: snapshots the booked walker into `original_provider_id`, swaps `provider_id` to the backup's provider profile (created **inactive + unverified** on first use — never searchable, it's just the identity the walk hangs off), returns the booking to `confirmed`, and sends the owner an in-app "backup cover kicked in" message. Because the covered walk is now a normal booking of the backup's, **walk tracking, completion, RLS and the owner UI all work unchanged** — and records always distinguish booked walker from actual walker.

### Payment split (the TRU-139 ask, exactly)
`charge-booking` (and the customer `retry_charge` path) fork on `cover_status='reassigned'`: the PaymentIntent has **no destination transfer and no application fee** — owner pays the full original price, the platform retains the walker share, the original walker is not paid.

### Fall-through = the TRU-136 promise
"Couldn't cover" marks `fell_through`, messages the owner, and issues a **manual credit** (per Tom's decision): a `customer_credits` row the admin applies by hand — the charge engine does not auto-apply. Owners see the credit as a banner in their profile (RLS-scoped) plus a note on the booking card; the admin console lists credits with mark-applied + note. One copy adjustment for reality: with charge-on-completion the fallen-through walk was **never charged**, so the message says "you haven't been charged for it" instead of "you've been refunded" — same promise, honest mechanics.

## Verified live, end-to-end, with real (test-mode) money

Using a throwaway admin account with a real JWT (so `auth.getUser` + `isAdmin` ran for real):

1. `cover_list` showed the TRU-137 fixture (Biscuit / Sarah / late / reason) ✓
2. `cover_reassign`: snapshot + inactive backup profile + confirmed + owner message ✓; double-tap → 409 ✓
3. Completed the walk → **real $25 test charge: `application_fee_cents: 0`, `covered: true`, no transfer** — platform retained 100% (PI `pi_3TojGc1Sh4qkQvUZ04YoCtd7`, visible in the Stripe test dashboard with no transfer attached) ✓
4. Second covered cancellation → `cover_fell_through`: `$10` credit row + apology system message; Sarah's own RLS banner query returns 1000¢ ✓
5. `credit_redeem` + re-redeem guard ✓ (credit then reopened as demo data for the admin UI)
6. Admin + profile page JS pass `node --check`; test admin demoted afterwards ✓

Migration applied via `apply_migration`; `stripe-api` (v8) and `charge-booking` (v3) deployed.

**Post-merge check for Tom:** the Cover tab in `/admin/` should show Biscuit's two walks (one covered ✓, one fell-through) and the $10 outstanding credit. There's also a leftover test account `tom_farmery+covertest_admin@hotmail.co.uk` (demoted, random password) — delete at leisure.

Closes TRU-139. Closes TRU-62 (epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)