### PR TITLE
Fix: owner single-booking cancel never worked (no customer UPDATE policy)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -130,7 +130,7 @@ async function onLogin(e) {
 }
 
 // ── Console shell ──
-const SECTIONS = [ { id:'refunds', label:'Refunds' } ];
+const SECTIONS = [ { id:'refunds', label:'Refunds' }, { id:'cover', label:'Cover' } ];
 function showConsole() {
   currentSection = SECTIONS.some(s => s.id === currentSection) ? currentSection : 'refunds';
   app().innerHTML = `
@@ -152,7 +152,95 @@ function switchSection(name) {
 function renderSection(name) {
   const c = document.getElementById('adm-content');
   if (name === 'refunds') return renderRefunds(c);
+  if (name === 'cover') return renderCover(c);
   c.innerHTML = '<p class="empty">Coming soon.</p>';
+}
+
+// ── Cover section (TRU-139) ──
+function coverWhen(iso) {
+  if (!iso) return '';
+  try { return new Date(iso).toLocaleString('en-AU', { weekday:'short', day:'numeric', month:'short', hour:'numeric', minute:'2-digit' }); } catch (e) { return ''; }
+}
+function coverCard(cv) {
+  const badge = cv.cover_status === 'triggered' ? '<span class="badge b-failed">needs cover</span>'
+    : cv.cover_status === 'reassigned' ? '<span class="badge b-paid">covered</span>'
+    : '<span class="badge b-refunded">fell through</span>';
+  const late = cv.late_cancellation ? ' · <b>late (&lt;3h)</b>' : '';
+  let actions = '';
+  if (cv.cover_status === 'triggered') {
+    actions = `<div class="actions">
+      <button class="btn" onclick="coverReassign('${cv.id}')">I'll cover it</button>
+      <span style="font-size:0.84rem;color:var(--muted);">or credit $</span>
+      <input class="reason" id="cred-${cv.id}" type="number" value="10" min="0" step="1" style="max-width:80px;flex:0 1 auto;">
+      <button class="btn" style="background:#fff;color:var(--terracottaDark);" onclick="coverFellThrough('${cv.id}')">Couldn't cover</button>
+    </div>`;
+  } else if (cv.cover_status === 'reassigned') {
+    actions = `<div class="meta">Assigned to you — run it from the <a href="/dashboard/">dashboard</a> like any walk. Completing it charges the owner in full; Truffl retains the walker share.</div>`;
+  }
+  return `<div class="card">
+    <div class="row-top"><div><b>${esc(cv.pet)}</b> · ${esc(cv.customer)}${badge}</div><div class="meta">${coverWhen(cv.scheduled_at)}</div></div>
+    <div class="meta">Walker: ${esc(cv.walker)} · ${esc(cv.cancel_reason || 'no reason recorded')}${late}</div>
+    <div class="meta">${money(cv.total_cents)} · cancelled ${coverWhen(cv.cancelled_at)}</div>
+    ${actions}
+  </div>`;
+}
+function creditCard(cr) {
+  const state = cr.redeemed_at
+    ? `<div class="meta">Applied ${when(cr.redeemed_at)}${cr.redeemed_note ? ' · ' + esc(cr.redeemed_note) : ''}</div>`
+    : `<div class="actions"><input class="reason" id="crednote-${cr.id}" placeholder="How it was applied (optional)"><button class="btn" onclick="creditRedeem('${cr.id}')">Mark applied</button></div>`;
+  return `<div class="card">
+    <div class="row-top"><div><span class="amount">${money(cr.amount_cents)}</span><span class="badge ${cr.redeemed_at ? 'b-refunded' : 'b-paid'}">${cr.redeemed_at ? 'applied' : 'outstanding'}</span></div><div class="meta">${when(cr.created_at)}</div></div>
+    <div class="meta">${esc(cr.customer)} · ${esc(cr.reason || '')}</div>
+    ${state}
+  </div>`;
+}
+async function renderCover(c) {
+  c.innerHTML = '<div id="adm-msg" class="msg"></div><p class="empty">Loading…</p>';
+  try {
+    const { cover, credits } = await sbFn('stripe-api', { action:'cover_list' });
+    const coverHtml = (cover && cover.length) ? cover.map(coverCard).join('') : '<p class="empty">No covered cancellations yet.</p>';
+    const outstanding = (credits || []).filter(cr => !cr.redeemed_at);
+    const applied = (credits || []).filter(cr => cr.redeemed_at);
+    const creditsHtml = (outstanding.length + applied.length)
+      ? outstanding.map(creditCard).join('') + applied.map(creditCard).join('')
+      : '<p class="empty">No credits issued.</p>';
+    c.innerHTML = `
+      <p class="sub" style="margin-bottom:14px;">Covered cancellations. "I'll cover it" reassigns the walk to you (owner keeps the original price; the walker share is retained). "Couldn't cover" applies the fall-through promise: no charge + a manual credit.</p>
+      <div id="adm-msg" class="msg"></div>
+      ${coverHtml}
+      <h1 style="font-size:1.2rem;margin:22px 0 10px;">Credits (manual)</h1>
+      ${creditsHtml}`;
+  } catch (e) {
+    if (e.message === 'Not authenticated') return signOut();
+    c.innerHTML = `<p class="empty">${esc(e.message)}</p>`;
+  }
+}
+async function coverReassign(id) {
+  if (!confirm('Take this walk? It will be reassigned to you and confirmed for the owner.')) return;
+  admMsg('');
+  try {
+    await sbFn('stripe-api', { action:'cover_reassign', booking_id:id });
+    admMsg('Reassigned to you ✓ — it now shows in your dashboard.', 'ok');
+    renderCover(document.getElementById('adm-content'));
+  } catch (e) { admMsg(e.message, 'error'); }
+}
+async function coverFellThrough(id) {
+  const dollars = parseFloat((document.getElementById('cred-' + id) || {}).value || '10') || 0;
+  if (!confirm(`Mark as couldn't cover? The owner is not charged and gets a $${dollars} credit.`)) return;
+  admMsg('');
+  try {
+    await sbFn('stripe-api', { action:'cover_fell_through', booking_id:id, credit_cents: Math.round(dollars * 100) });
+    admMsg('Recorded — owner messaged and credit issued.', 'ok');
+    renderCover(document.getElementById('adm-content'));
+  } catch (e) { admMsg(e.message, 'error'); }
+}
+async function creditRedeem(id) {
+  const note = (document.getElementById('crednote-' + id) || {}).value || '';
+  try {
+    await sbFn('stripe-api', { action:'credit_redeem', credit_id:id, note });
+    admMsg('Credit marked applied ✓', 'ok');
+    renderCover(document.getElementById('adm-content'));
+  } catch (e) { admMsg(e.message, 'error'); }
 }
 
 // ── Refunds section ──

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -49,6 +49,10 @@
   .cancel-inline span { font-size: 0.82rem; color: var(--text-secondary); }
   .cancel-inline.series { flex-direction: column; align-items: flex-start; }
   .cancel-inline-btns { display: flex; gap: 8px; flex-wrap: wrap; }
+  /* TRU-137: cancellation reason capture */
+  .cancel-reason { display: flex; flex-direction: column; gap: 6px; width: 100%; margin: 6px 0; }
+  .cancel-reason select, .cancel-reason input { font: inherit; font-size: 0.85rem; padding: 8px 10px; border: 1px solid var(--border); border-radius: 8px; background: #fff; color: var(--text); }
+  .cancel-notice { font-size: 0.76rem; color: var(--text-muted); width: 100%; }
   .nav-avatar {
     width: 32px; height: 32px; border-radius: 50%; background: var(--blush);
     display: flex; align-items: center; justify-content: center;
@@ -741,36 +745,80 @@ async function declineSeries(id) {
 }
 
 /* ── Cancelling an upcoming walk (and, for series walks, the whole series) ── */
+/* TRU-137: every walker cancellation records a reason; cancelling a confirmed
+   walk with under 3 hours' notice is flagged on the walker's record (server-side
+   trigger). If the owner has backup cover, cancelling also pages Truffl. */
+const CANCEL_REASONS = ['Feeling unwell', 'Personal emergency', 'Schedule conflict', 'Weather', 'Other'];
 function dashShowCancel(id) { dashCancelId = id; renderBookingsTab(); }
 function dashDismissCancel() { dashCancelId = null; renderBookingsTab(); }
+function cancelReasonUi(b) {
+  const hoursAway = (new Date(b.scheduled_at).getTime() - Date.now()) / 3600000;
+  const lateNote = (b.status === 'confirmed' && hoursAway < 3)
+    ? `<span class="cancel-notice">Heads up — this is under 3 hours' notice, which counts as a late cancellation on your record.</span>` : '';
+  return `<div class="cancel-reason">
+      <select id="cxl-reason-${b.id}">
+        <option value="">Why are you cancelling?</option>
+        ${CANCEL_REASONS.map(r => `<option>${r}</option>`).join('')}
+      </select>
+      <input type="text" id="cxl-note-${b.id}" maxlength="200" placeholder="Add a short note (optional)">
+    </div>${lateNote}`;
+}
 function dashCancelConfirm(b) {
   if (b.series_id) {
     return `<div class="cancel-inline series">
       <span>Recurring walk — cancel what?</span>
+      ${cancelReasonUi(b)}
       <div class="cancel-inline-btns">
         <button class="bc-btn decline" onclick="cancelWalk('${b.id}')">Just this walk</button>
-        <button class="bc-btn decline" onclick="cancelSeriesWalks('${b.series_id}')">All future walks</button>
+        <button class="bc-btn decline" onclick="cancelSeriesWalks('${b.series_id}', '${b.id}')">All future walks</button>
         <button class="bc-btn" style="border:1px solid var(--border);color:var(--text-muted);" onclick="dashDismissCancel()">Keep</button>
       </div>
     </div>`;
   }
-  return `<div class="cancel-inline">
+  return `<div class="cancel-inline series">
     <span>Cancel this walk?</span>
-    <button class="bc-btn decline" onclick="cancelWalk('${b.id}')">Yes, cancel</button>
-    <button class="bc-btn" style="border:1px solid var(--border);color:var(--text-muted);" onclick="dashDismissCancel()">Keep</button>
+    ${cancelReasonUi(b)}
+    <div class="cancel-inline-btns">
+      <button class="bc-btn decline" onclick="cancelWalk('${b.id}')">Yes, cancel</button>
+      <button class="bc-btn" style="border:1px solid var(--border);color:var(--text-muted);" onclick="dashDismissCancel()">Keep</button>
+    </div>
   </div>`;
 }
+function collectCancelReason(bookingId) {
+  const sel = document.getElementById('cxl-reason-' + bookingId);
+  const reason = sel ? sel.value : '';
+  if (!reason) {
+    showMsg('Please pick a reason for cancelling — the owner will want to know.', 'error');
+    return null;
+  }
+  const noteEl = document.getElementById('cxl-note-' + bookingId);
+  const note = noteEl && noteEl.value.trim() ? ': ' + noteEl.value.trim() : '';
+  return reason + note;
+}
 async function cancelWalk(id) {
+  const reason = collectCancelReason(id);
+  if (reason === null) return;
   try {
-    await sbPatch('bookings', 'id', id, { status: 'cancelled' });
+    await sbPatch('bookings', 'id', id, { status: 'cancelled', cancel_reason: reason });
     const b = bookings.find(x => x.id === id);
     if (b) b.status = 'cancelled';
     dashCancelId = null;
     renderBookingsTab();
   } catch(e) { showMsg(e.message, 'error'); }
 }
-async function cancelSeriesWalks(seriesId) {
+async function cancelSeriesWalks(seriesId, promptBookingId) {
+  // The booking the carer is looking at gets their chosen reason directly (so a
+  // covered-walk alert carries it); the series cascade then stamps the rest with
+  // "Recurring schedule cancelled" and skips this already-cancelled row.
+  const reason = promptBookingId ? collectCancelReason(promptBookingId) : null;
+  if (promptBookingId && reason === null) return;
   try {
+    if (promptBookingId) {
+      const pb = bookings.find(x => x.id === promptBookingId);
+      if (pb && (pb.status === 'pending' || pb.status === 'confirmed')) {
+        await sbPatch('bookings', 'id', promptBookingId, { status: 'cancelled', cancel_reason: reason });
+      }
+    }
     await sbPatch('booking_series', 'id', seriesId, { status: 'cancelled' });
     const now = Date.now();
     bookings.forEach(b => {
@@ -778,6 +826,8 @@ async function cancelSeriesWalks(seriesId) {
         b.status = 'cancelled';
       }
     });
+    const pb = bookings.find(x => x.id === promptBookingId);
+    if (pb) pb.status = 'cancelled';
     dashCancelId = null;
     renderBookingsTab();
     showMsg('Recurring schedule cancelled — upcoming walks were cancelled. Past walks are unchanged.', 'success');

--- a/profile/index.html
+++ b/profile/index.html
@@ -107,6 +107,9 @@
   .cover-check{display:flex;gap:9px;align-items:flex-start;font-size:0.85rem;line-height:1.55;color:var(--text);margin:12px 0;}
   .cover-check input{margin-top:3px;flex-shrink:0;}
   .cover-meta{font-size:0.82rem;color:var(--text-muted);margin:4px 0 10px;}
+  /* TRU-139: fall-through note + manual credit banner */
+  .cover-note{margin-bottom:10px;background:#fdf3ec;border:1px solid #f0d9c8;border-radius:8px;padding:8px 12px;font-size:0.82rem;color:#8a5a3b;line-height:1.5;}
+  .credit-banner{background:var(--success-bg);border:1px solid #d3e3d2;border-radius:10px;padding:10px 14px;font-size:0.86rem;color:var(--sage-dark);margin-bottom:14px;}
   .btn-cancel-yes{padding:8px 14px;background:var(--error);color:white;border:none;border-radius:8px;font-size:0.82rem;font-weight:500;cursor:pointer;font-family:'DM Sans',sans-serif;}
   .btn-cancel-yes:hover{opacity:0.9;}
   .btn-cancel-keep{padding:8px 14px;background:transparent;border:1px solid var(--border);color:var(--text-muted);border-radius:8px;font-size:0.82rem;cursor:pointer;font-family:'DM Sans',sans-serif;}
@@ -272,6 +275,7 @@ const COVER_CONSENT_VERSION = 'v1-2026-07-03';
 const COVERED_SERVICES = ['dog_walking', 'drop_in'];
 let editingCover = false;     // opt-in/edit form open in the account tab
 let coverPrefill = null;      // row from get_backup_access() when editing
+let myCredits = [];           // outstanding manual credits (TRU-139)
 
 const ALLOWED_PHOTO_TYPES = ['image/png', 'image/jpeg', 'image/webp'];
 const MAX_PHOTO_BYTES = 5 * 1024 * 1024;
@@ -607,6 +611,7 @@ function bookingCardHtml(b) {
       <div class="bc-time">${esc(dateStr)}</div>
       ${statusBadge(b.status)}
       ${paymentNotice(b)}
+      ${b.cover_status === 'fell_through' ? `<div class="cover-note">We're really sorry — we weren't able to cover this walk. You haven't been charged for it, and we've added a credit to your account for next time.</div>` : ''}
       <div class="bc-actions">${actions}${msgLink}</div>
     </div>
   `;
@@ -915,6 +920,10 @@ function renderBookingsTab() {
   }
 
   let html = '';
+  const creditTotal = (myCredits || []).reduce((s, c) => s + (c.amount_cents || 0), 0);
+  if (creditTotal > 0) {
+    html += `<div class="credit-banner">You have a $${(creditTotal / 100).toFixed(0)} credit — we'll apply it to an upcoming walk.</div>`;
+  }
   if (active.length > 0) {
     html += `<div class="section-heading">Active &amp; upcoming</div>`;
     html += active.map(bookingCardHtml).join('');
@@ -1471,6 +1480,9 @@ async function init() {
     }
     customerProfile = profiles[0];
     profileRow = profiles[0];
+
+    // TRU-139: outstanding manual credits (RLS scopes to own rows).
+    try { myCredits = await sbGet('customer_credits', 'select=amount_cents&redeemed_at=is.null'); } catch (e) { myCredits = []; }
 
     const rawBookings = await sbGet('bookings', `customer_id=eq.${customerProfile.id}&select=*&order=scheduled_at.desc`);
 

--- a/profile/index.html
+++ b/profile/index.html
@@ -1145,7 +1145,9 @@ function showCancelConfirm(id) { pendingCancelId = id; renderBookingsTab(); }
 function dismissCancel() { pendingCancelId = null; renderBookingsTab(); }
 async function doCancelBooking(id) {
   try {
-    await sbPatch('bookings', 'id', id, { status: 'cancelled' });
+    // Customers have no UPDATE policy on bookings (a direct PATCH matches 0 rows),
+    // so cancelling goes through a definer RPC scoped to exactly this transition.
+    await sbRpc('cancel_my_booking', { p_booking_id: id });
     const b = bookings.find(x => x.id === id);
     if (b) b.status = 'cancelled';
     pendingCancelId = null;

--- a/supabase/functions/charge-booking/index.ts
+++ b/supabase/functions/charge-booking/index.ts
@@ -67,10 +67,15 @@ Deno.serve(async (req) => {
 
   try {
     const { data: b } = await sb.from('bookings')
-      .select('id,total_cents,customer_id,provider_id,is_meet_and_greet,payment_status')
+      .select('id,total_cents,customer_id,provider_id,is_meet_and_greet,payment_status,cover_status')
       .eq('id', bookingId).single();
     if (!b) return json({ error: 'booking not found' }, 404);
     if (b.is_meet_and_greet || (b.total_cents || 0) <= 0) return json({ skipped: 'not chargeable' });
+    // TRU-139: a covered walk completed by the Truffl backup. Owner pays the full
+    // original price; NO destination transfer and NO application fee — the share
+    // that would have gone to the original walker is retained by the platform
+    // (they cancelled; they are not paid for this booking).
+    const covered = b.cover_status === 'reassigned';
 
     // Atomic claim: only one invocation may move unpaid/failed -> processing.
     const { data: claimed } = await sb.from('bookings')
@@ -86,10 +91,6 @@ Deno.serve(async (req) => {
     const pm = cust?.invoice_settings?.default_payment_method;
     if (!pm) { await markFailed(bookingId); return json({ error: 'no saved card on file' }, 400); }
 
-    const { data: pp } = await sb.from('provider_profiles').select('stripe_account_id').eq('id', b.provider_id).single();
-    if (!pp?.stripe_account_id) { await markFailed(bookingId); return json({ error: 'carer has no payout account' }, 400); }
-
-    const fee = Math.round((b.total_cents * PLATFORM_FEE_BPS) / 10000);
     const piBody: Record<string, unknown> = {
       amount: b.total_cents,
       currency: CURRENCY,
@@ -97,10 +98,16 @@ Deno.serve(async (req) => {
       payment_method: pm,
       off_session: true,
       confirm: true,
-      'transfer_data[destination]': pp.stripe_account_id,
       'metadata[booking_id]': bookingId,
     };
-    if (fee > 0) piBody['application_fee_amount'] = fee; // omitted at 0% — Stripe requires it positive
+    let fee = 0;
+    if (!covered) {
+      const { data: pp } = await sb.from('provider_profiles').select('stripe_account_id').eq('id', b.provider_id).single();
+      if (!pp?.stripe_account_id) { await markFailed(bookingId); return json({ error: 'carer has no payout account' }, 400); }
+      piBody['transfer_data[destination]'] = pp.stripe_account_id;
+      fee = Math.round((b.total_cents * PLATFORM_FEE_BPS) / 10000);
+      if (fee > 0) piBody['application_fee_amount'] = fee; // omitted at 0% — Stripe requires it positive
+    }
 
     let pi;
     try {
@@ -118,7 +125,7 @@ Deno.serve(async (req) => {
         application_fee_cents: fee,
         charged_at: new Date().toISOString(),
       }).eq('id', bookingId);
-      return json({ ok: true, payment_intent: pi.id, amount: b.total_cents, application_fee_cents: fee });
+      return json({ ok: true, payment_intent: pi.id, amount: b.total_cents, application_fee_cents: fee, covered });
     }
 
     // requires_action etc. — an off-session charge can't complete; flag for follow-up.

--- a/supabase/functions/send-notification/index.ts
+++ b/supabase/functions/send-notification/index.ts
@@ -162,6 +162,75 @@ async function buildMessages(type: string, payload: Record<string, unknown>) {
         footnote: 'Your carer has already provided the service, so please retry soon.',
       }),
     });
+  } else if (type === 'cover_cancellation') {
+    // TRU-138: a covered walk was cancelled by its walker — page every admin
+    // immediately with everything needed to act. This is the ONE operational
+    // surface where stored access detail (TRU-135) appears; the footnote asks
+    // for the email to be deleted once the walk is covered.
+    const d = await loadBooking(payload.booking_id as string);
+    const { data: admins } = await sb.from('users').select('email,first_name').eq('is_admin', true);
+    if (!admins?.length) return out;
+    const { data: cover } = await sb.rpc('get_cover_details', { p_booking_id: d.booking.id });
+    const c = (cover ?? {}) as Record<string, string | null>;
+
+    // Per-dog handling notes, linked from the pet profile (booking_pets with the
+    // legacy single-pet fallback). The service client bypasses RLS.
+    const { data: bps } = await sb.from('booking_pets').select('pet_id').eq('booking_id', d.booking.id);
+    const petIds = (bps?.length ? bps.map((r: { pet_id: string }) => r.pet_id) : [d.booking.pet_id]).filter(Boolean);
+    const { data: petRows } = petIds.length
+      ? await sb.from('pets').select('name,breed,behaviour_notes,medical_notes,vet_name,vet_phone').in('id', petIds)
+      : { data: [] as never[] };
+    const dogs = (petRows ?? []) as { name: string; breed: string | null; behaviour_notes: string | null; medical_notes: string | null; vet_name: string | null; vet_phone: string | null }[];
+    const dogNames = dogs.map((p) => p.name).join(' & ') || d.petName;
+
+    const windowStr = d.booking.window_end_at
+      ? `${fmtWhen(d.booking.scheduled_at, null)}–${new Date(d.booking.window_end_at).toLocaleTimeString('en-AU', { hour: 'numeric', minute: '2-digit', timeZone: 'Australia/Sydney' })}${d.durationMins ? ` · ${d.durationMins} min` : ''}`
+      : fmtWhen(d.booking.scheduled_at, d.durationMins);
+
+    const rows: [string, string][] = [
+      ['Dog', dogs.map((p) => p.breed ? `${p.name} (${p.breed})` : p.name).join(' & ') || d.petName],
+      ['Window', windowStr],
+      ['Address', [c.address, c.suburb, c.postcode].filter(Boolean).join(', ') || '⚠ missing'],
+      ['Lockbox', c.access_location || '⚠ missing — contact owner'],
+      ['Code', c.access_code || '⚠ missing'],
+    ];
+    if (c.access_notes) rows.push(['Access notes', c.access_notes]);
+    rows.push(
+      ['Owner', c.owner_name || 'Owner'],
+      ['Owner phone', c.owner_phone || '—'],
+      ['Owner email', c.owner_email || '—'],
+      ['Original walker', d.provider?.first_name || '—'],
+      ['Reason', d.booking.cancel_reason || '—'],
+      ['Late (<3h notice)', d.booking.late_cancellation ? 'YES' : 'no'],
+    );
+
+    const notesHtml = dogs
+      .map((pet) => {
+        const bits = [];
+        if (pet.behaviour_notes) bits.push(`Behaviour: ${esc(pet.behaviour_notes)}`);
+        if (pet.medical_notes) bits.push(`Medical: ${esc(pet.medical_notes)}`);
+        if (pet.vet_name || pet.vet_phone) bits.push(`Vet: ${esc([pet.vet_name, pet.vet_phone].filter(Boolean).join(' · '))}`);
+        return bits.length ? p(`<b>${esc(pet.name)}</b> — ${bits.join(' · ')}`) : '';
+      })
+      .filter(Boolean)
+      .join('');
+
+    for (const admin of admins) {
+      if (!admin.email) continue;
+      out.push({
+        to: admin.email,
+        subject: `🚨 Cover needed — ${dogNames} · ${fmtWhen(d.booking.scheduled_at, null)}`,
+        html: layout({
+          preview: `Covered walk cancelled — ${dogNames} needs cover`,
+          heading: 'A covered walk needs you',
+          body: p(`${esc(d.provider?.first_name || 'The walker')} cancelled a covered ${esc(d.serviceLabel.toLowerCase())}. Everything you need is below.`) +
+            detailsTable(rows) +
+            (notesHtml || p('No handling notes on file.')),
+          cta: { label: 'Open the admin console', href: `${SITE}/admin/` },
+          footnote: 'This email contains entry access details — delete it once the walk is covered.',
+        }),
+      });
+    }
   } else if (type === 'walk_started') {
     const { data: ws } = await sb.from('walk_sessions').select('booking_id').eq('id', payload.walk_session_id as string).single();
     if (!ws) return out;

--- a/supabase/functions/stripe-api/index.ts
+++ b/supabase/functions/stripe-api/index.ts
@@ -14,6 +14,10 @@
 //   sync_payment    - reconcile a booking's payment_status from its PaymentIntent
 //   list_recent_charges - (admin) recent paid/failed/refunded bookings for the admin page
 //   refund_booking  - (admin) refund a paid booking + reverse the carer's transfer
+//   cover_list      - (admin) covered bookings (triggered/reassigned/fell_through) + credits
+//   cover_reassign  - (admin) take over a covered cancelled booking (TRU-139)
+//   cover_fell_through - (admin) mark cover as failed; issue a manual credit + owner message
+//   credit_redeem   - (admin) mark a manual credit as applied
 //
 // Required function secrets (Supabase → Edge Functions → Secrets):
 //   STRIPE_SECRET_KEY   - sk_test_… (platform secret key)
@@ -193,26 +197,31 @@ Deno.serve(async (req) => {
       if (!customer) return json({ error: 'Not a customer account' }, 403);
       const bookingId = String(payload.booking_id || '');
       const { data: b } = await sb.from('bookings')
-        .select('id,total_cents,provider_id,is_meet_and_greet,payment_status')
+        .select('id,total_cents,provider_id,is_meet_and_greet,payment_status,cover_status')
         .eq('id', bookingId).eq('customer_id', customer.id).single();
       if (!b) return json({ error: 'Booking not found' }, 404);
       if (b.is_meet_and_greet || (b.total_cents || 0) <= 0) return json({ error: 'Nothing to pay' }, 400);
       if (b.payment_status !== 'failed') return json({ error: 'This booking is not awaiting payment' }, 400);
       if (!customer.stripe_customer_id) return json({ error: 'No payment profile on file' }, 400);
-      const { data: pp } = await sb.from('provider_profiles').select('stripe_account_id').eq('id', b.provider_id).single();
-      if (!pp?.stripe_account_id) return json({ error: 'Carer has no payout account' }, 400);
-
-      const fee = Math.round((b.total_cents * PLATFORM_FEE_BPS) / 10000);
+      // A covered walk completed by the Truffl backup is retained in full (TRU-139):
+      // no destination transfer, no application fee — mirrors charge-booking.
+      const covered = b.cover_status === 'reassigned';
       const piBody: Record<string, unknown> = {
         amount: b.total_cents,
         currency: 'aud',
         customer: customer.stripe_customer_id,
-        'transfer_data[destination]': pp.stripe_account_id,
         'payment_method_types[]': 'card',
         setup_future_usage: 'off_session', // save the working card for future charges
         'metadata[booking_id]': bookingId,
       };
-      if (fee > 0) piBody['application_fee_amount'] = fee;
+      let fee = 0;
+      if (!covered) {
+        const { data: pp } = await sb.from('provider_profiles').select('stripe_account_id').eq('id', b.provider_id).single();
+        if (!pp?.stripe_account_id) return json({ error: 'Carer has no payout account' }, 400);
+        piBody['transfer_data[destination]'] = pp.stripe_account_id;
+        fee = Math.round((b.total_cents * PLATFORM_FEE_BPS) / 10000);
+        if (fee > 0) piBody['application_fee_amount'] = fee;
+      }
       // No confirm — the client confirms with the Payment Element so a new card / 3DS works.
       const pi = await stripe('payment_intents', 'POST', piBody);
       await sb.from('bookings').update({ stripe_payment_intent_id: pi.id, application_fee_cents: fee }).eq('id', bookingId);
@@ -304,6 +313,140 @@ Deno.serve(async (req) => {
         .update({ payment_status: 'refunded', refunded_at: new Date().toISOString(), stripe_refund_id: refund.id })
         .eq('id', bookingId);
       return json({ ok: true, refund_id: refund.id });
+    }
+
+    // ── Backup cover (TRU-139) — admin actions ──
+
+    if (action === 'cover_list') {
+      if (!(await isAdmin(user.id))) return json({ error: 'Not authorised' }, 403);
+      const { data } = await sb.from('bookings')
+        .select('id,scheduled_at,window_end_at,duration_mins,total_cents,status,payment_status,cover_status,cancel_reason,cancelled_at,late_cancellation,customer_id,provider_id,original_provider_id,pet_id')
+        .neq('cover_status', 'none')
+        .order('scheduled_at', { ascending: false })
+        .limit(30);
+      const rows = data || [];
+      const NONE = ['00000000-0000-0000-0000-000000000000'];
+      const custIds = [...new Set(rows.map((r) => r.customer_id))];
+      const provIds = [...new Set(rows.flatMap((r) => [r.provider_id, r.original_provider_id]).filter(Boolean))] as string[];
+      const petIds = [...new Set(rows.map((r) => r.pet_id).filter(Boolean))] as string[];
+      const [{ data: cps }, { data: pps }, { data: petsData }, { data: credits }] = await Promise.all([
+        sb.from('customer_profiles').select('id,user_id').in('id', custIds.length ? custIds : NONE),
+        sb.from('provider_profiles').select('id,user_id').in('id', provIds.length ? provIds : NONE),
+        sb.from('pets').select('id,name').in('id', petIds.length ? petIds : NONE),
+        sb.from('customer_credits').select('id,customer_id,amount_cents,reason,created_at,redeemed_at,redeemed_note,booking_id')
+          .order('created_at', { ascending: false }).limit(30),
+      ]);
+      const custUser = Object.fromEntries((cps || []).map((c) => [c.id, c.user_id]));
+      const provUser = Object.fromEntries((pps || []).map((p) => [p.id, p.user_id]));
+      const petName = Object.fromEntries((petsData || []).map((p) => [p.id, p.name]));
+      const creditCustIds = [...new Set((credits || []).map((c) => c.customer_id))];
+      const { data: creditCps } = await sb.from('customer_profiles').select('id,user_id').in('id', creditCustIds.length ? creditCustIds : NONE);
+      (creditCps || []).forEach((c) => { custUser[c.id] = c.user_id; });
+      const userIds = [...new Set([...Object.values(custUser), ...Object.values(provUser)])] as string[];
+      const { data: us } = await sb.from('users').select('id,first_name,last_name').in('id', userIds.length ? userIds : NONE);
+      const nameBy = Object.fromEntries((us || []).map((u) => [u.id, `${u.first_name || ''} ${u.last_name || ''}`.trim()]));
+      return json({
+        cover: rows.map((r) => ({
+          ...r,
+          customer: nameBy[custUser[r.customer_id]] || 'Customer',
+          walker: nameBy[provUser[r.original_provider_id || r.provider_id]] || 'Walker',
+          pet: petName[r.pet_id] || 'Dog',
+        })),
+        credits: (credits || []).map((c) => ({ ...c, customer: nameBy[custUser[c.customer_id]] || 'Customer' })),
+      });
+    }
+
+    if (action === 'cover_reassign') {
+      if (!(await isAdmin(user.id))) return json({ error: 'Not authorised' }, 403);
+      const bookingId = String(payload.booking_id || '');
+      const { data: b } = await sb.from('bookings')
+        .select('id,status,cover_status,provider_id,original_provider_id,customer_id,pet_id')
+        .eq('id', bookingId).maybeSingle();
+      if (!b) return json({ error: 'Booking not found' }, 404);
+      if (b.cover_status !== 'triggered' || b.status !== 'cancelled') {
+        return json({ error: 'This booking is not awaiting cover' }, 400);
+      }
+      // The admin doing the reassign becomes the backup walker. Ensure they have a
+      // provider profile — created inactive + unverified so it is never searchable;
+      // it's just the identity the walk hangs off so tracking/completion work
+      // unchanged (records: original_provider_id = booked, provider_id = actual).
+      let { data: mypp } = await sb.from('provider_profiles').select('id').eq('user_id', user.id).maybeSingle();
+      if (!mypp) {
+        const ins = await sb.from('provider_profiles')
+          .insert({ user_id: user.id, is_active: false, is_verified: false, bio: 'Truffl backup' })
+          .select('id').single();
+        if (ins.error || !ins.data) return json({ error: 'Could not create backup profile' }, 500);
+        mypp = ins.data;
+      }
+      if (mypp.id === b.provider_id) return json({ error: 'Booking is already assigned to you' }, 400);
+      const upd = await sb.from('bookings').update({
+        original_provider_id: b.original_provider_id || b.provider_id,
+        provider_id: mypp.id,
+        status: 'confirmed',
+        cover_status: 'reassigned',
+      }).eq('id', bookingId).eq('cover_status', 'triggered').select('id');
+      if (upd.error || !upd.data?.length) return json({ error: 'Reassign failed — booking may already be handled' }, 409);
+      // Tell the owner in-app (one-way Truffl channel; service role writes directly).
+      const { data: cp } = await sb.from('customer_profiles').select('user_id').eq('id', b.customer_id).single();
+      const { data: pet } = b.pet_id ? await sb.from('pets').select('name').eq('id', b.pet_id).single() : { data: null };
+      if (cp?.user_id) {
+        await sb.from('system_messages').insert({
+          recipient_user_id: cp.user_id,
+          body: `Good news — your walker had to cancel, but backup cover kicked in. A Truffl backup will walk ${pet?.name || 'your dog'} as planned.`,
+          link_url: `/track/?booking=${bookingId}`,
+          link_label: 'View booking',
+        });
+      }
+      return json({ ok: true });
+    }
+
+    if (action === 'cover_fell_through') {
+      if (!(await isAdmin(user.id))) return json({ error: 'Not authorised' }, 403);
+      const bookingId = String(payload.booking_id || '');
+      const creditCents = Math.max(0, Math.round(Number(payload.credit_cents ?? 1000)) || 0);
+      const { data: b } = await sb.from('bookings')
+        .select('id,status,cover_status,customer_id,pet_id')
+        .eq('id', bookingId).maybeSingle();
+      if (!b) return json({ error: 'Booking not found' }, 404);
+      if (b.cover_status !== 'triggered' || b.status !== 'cancelled') {
+        return json({ error: 'This booking is not awaiting cover' }, 400);
+      }
+      const upd = await sb.from('bookings').update({ cover_status: 'fell_through' })
+        .eq('id', bookingId).eq('cover_status', 'triggered').select('id');
+      if (upd.error || !upd.data?.length) return json({ error: 'Update failed — booking may already be handled' }, 409);
+      // The walk was never charged (charging happens on completion), so "full
+      // refund" needs no money movement — the credit is the goodwill on top.
+      if (creditCents > 0) {
+        await sb.from('customer_credits').insert({
+          customer_id: b.customer_id,
+          amount_cents: creditCents,
+          reason: 'Backup cover fell through',
+          booking_id: bookingId,
+        });
+      }
+      const { data: cp } = await sb.from('customer_profiles').select('user_id').eq('id', b.customer_id).single();
+      const { data: pet } = b.pet_id ? await sb.from('pets').select('name').eq('id', b.pet_id).single() : { data: null };
+      if (cp?.user_id) {
+        const creditLine = creditCents > 0 ? ` and we've added a $${(creditCents / 100).toFixed(0)} credit to your account for next time` : '';
+        await sb.from('system_messages').insert({
+          recipient_user_id: cp.user_id,
+          body: `We're really sorry — we weren't able to cover ${pet?.name || 'your dog'}'s walk. You haven't been charged for it${creditLine}. No questions asked.`,
+          link_url: '/profile/',
+          link_label: 'View your bookings',
+        });
+      }
+      return json({ ok: true, credit_cents: creditCents });
+    }
+
+    if (action === 'credit_redeem') {
+      if (!(await isAdmin(user.id))) return json({ error: 'Not authorised' }, 403);
+      const creditId = String(payload.credit_id || '');
+      const note = String(payload.note || '').slice(0, 300);
+      const upd = await sb.from('customer_credits')
+        .update({ redeemed_at: new Date().toISOString(), redeemed_note: note || null })
+        .eq('id', creditId).is('redeemed_at', null).select('id');
+      if (upd.error || !upd.data?.length) return json({ error: 'Credit not found or already applied' }, 409);
+      return json({ ok: true });
     }
 
     return json({ error: `Unknown action: ${action}` }, 400);

--- a/supabase/migrations/20260703000001_tru137_138_cancellation_flow.sql
+++ b/supabase/migrations/20260703000001_tru137_138_cancellation_flow.sql
@@ -1,0 +1,187 @@
+-- TRU-137: walker cancellation flow + minimum-notice policy.
+-- TRU-138: covered-cancellation founder alert (the event fires here; the email is
+-- rendered/sent by the send-notification edge function, type 'cover_cancellation').
+--
+-- Policy constants (MVP, founder-changeable by editing the trigger fn):
+--   * minimum notice window = 3 hours (cancelling a confirmed walk with less
+--     notice — or after its start — is a "late cancellation", treated like a
+--     no-show on the walker's record);
+--   * cover trigger horizon = 48 hours (a covered walk only pages the founder
+--     when it's actually imminent; further-out walks can simply be rebooked).
+--
+-- Scope decisions (per ticket): cancellations only, no no-show detection; cover
+-- applies to walks and drop-ins only; declining a *pending* request is not a
+-- cancellation (counters and cover fire only when a CONFIRMED booking is
+-- cancelled by its walker). Series cascades cancel each future booking, so each
+-- confirmed one counts individually and each covered one within the horizon
+-- alerts individually.
+--
+-- Applied to the live DB via apply_migration; committed for version control.
+
+alter table public.bookings
+  add column if not exists cancel_reason text,
+  add column if not exists cancelled_by text
+    check (cancelled_by in ('customer','provider','admin')),
+  add column if not exists cancelled_at timestamptz,
+  add column if not exists late_cancellation boolean,
+  add column if not exists cover_status text not null default 'none'
+    check (cover_status in ('none','triggered','reassigned','fell_through'));
+
+alter table public.provider_profiles
+  add column if not exists cancellation_count integer not null default 0,
+  add column if not exists late_cancellation_count integer not null default 0;
+
+-- ── Stamp pass (BEFORE): who cancelled, when, late?, covered? ────────────────
+create or replace function public.trg_booking_cancel_stamp()
+returns trigger
+language plpgsql security definer set search_path = public
+as $$
+declare
+  v_service_type text;
+begin
+  if NEW.status = 'cancelled' and OLD.status is distinct from 'cancelled' then
+    NEW.cancelled_at := coalesce(NEW.cancelled_at, now());
+
+    if NEW.cancelled_by is null then
+      if exists (select 1 from provider_profiles pp
+                 where pp.id = NEW.provider_id and pp.user_id = auth.uid()) then
+        NEW.cancelled_by := 'provider';
+      elsif exists (select 1 from customer_profiles cp
+                    where cp.id = NEW.customer_id and cp.user_id = auth.uid()) then
+        NEW.cancelled_by := 'customer';
+      elsif exists (select 1 from users u
+                    where u.id = auth.uid() and u.is_admin) then
+        NEW.cancelled_by := 'admin';
+      end if;
+    end if;
+
+    -- Reliability + cover only apply when a walker cancels a CONFIRMED booking.
+    if NEW.cancelled_by = 'provider' and OLD.status = 'confirmed' then
+      -- Late = inside the 3-hour minimum-notice window (or after the start).
+      NEW.late_cancellation := (NEW.scheduled_at - now()) < interval '3 hours';
+
+      select ps.service_type into v_service_type
+        from provider_services ps where ps.id = NEW.service_id;
+
+      if v_service_type in ('dog_walking', 'drop_in')
+         and not coalesce(NEW.is_meet_and_greet, false)
+         and NEW.scheduled_at > now()
+         and NEW.scheduled_at < now() + interval '48 hours'
+         and exists (
+           select 1
+             from customer_profiles cp
+             join private.backup_access ba on ba.customer_id = cp.id
+            where cp.id = NEW.customer_id
+              and cp.backup_cover_enabled
+         ) then
+        NEW.cover_status := 'triggered';
+      end if;
+    end if;
+  end if;
+  return NEW;
+end;
+$$;
+
+drop trigger if exists booking_cancel_stamp on public.bookings;
+create trigger booking_cancel_stamp
+  before update of status on public.bookings
+  for each row execute function public.trg_booking_cancel_stamp();
+
+-- ── Effects pass (AFTER): reliability counters + founder alert ───────────────
+create or replace function public.trg_booking_cancel_effects()
+returns trigger
+language plpgsql security definer set search_path = public
+as $$
+begin
+  if NEW.status = 'cancelled' and OLD.status is distinct from 'cancelled'
+     and NEW.cancelled_by = 'provider' and OLD.status = 'confirmed' then
+    update provider_profiles
+       set cancellation_count = cancellation_count + 1,
+           late_cancellation_count = late_cancellation_count
+             + (case when coalesce(NEW.late_cancellation, false) then 1 else 0 end)
+     where id = NEW.provider_id;
+
+    if NEW.cover_status = 'triggered' then
+      -- Same fire-and-forget pg_net path as the email pipeline; an alert hiccup
+      -- must never roll back the cancellation write.
+      begin
+        perform private.notify_email(
+          jsonb_build_object('type', 'cover_cancellation', 'booking_id', NEW.id));
+      exception when others then null;
+      end;
+    end if;
+  end if;
+  return NEW;
+end;
+$$;
+
+drop trigger if exists booking_cancel_effects on public.bookings;
+create trigger booking_cancel_effects
+  after update of status on public.bookings
+  for each row execute function public.trg_booking_cancel_effects();
+
+-- Internal trigger functions — not RPC-callable (TRU-153 pattern).
+revoke execute on function public.trg_booking_cancel_stamp() from public, anon, authenticated;
+revoke execute on function public.trg_booking_cancel_effects() from public, anon, authenticated;
+
+-- ── Series cascade: record a reason on the cancelled rows ────────────────────
+-- Same body as the TRU-14 version, plus cancel_reason so cascaded cancellations
+-- always carry a reason (AC: "walker cancellation always records a reason").
+create or replace function public.trg_series_cancelled()
+returns trigger
+language plpgsql security definer set search_path = public
+as $$
+begin
+  if NEW.status = 'cancelled' and (OLD.status is distinct from 'cancelled') then
+    update public.bookings
+       set status = 'cancelled',
+           cancel_reason = coalesce(cancel_reason, 'Recurring schedule cancelled'),
+           updated_at = now()
+     where series_id = NEW.id
+       and not coalesce(is_meet_and_greet, false)
+       and status in ('pending', 'confirmed')
+       and scheduled_at > now();
+  end if;
+  return NEW;
+end;
+$$;
+
+-- ── Founder-alert data (TRU-138) ─────────────────────────────────────────────
+-- The ONE operational surface where stored access detail is exposed. The private
+-- schema isn't reachable over the API, so send-notification (service role) reads
+-- through this definer fn. service_role only — not callable by users.
+create or replace function public.get_cover_details(p_booking_id uuid)
+returns jsonb
+language plpgsql security definer stable set search_path = public
+as $$
+declare
+  b public.bookings%rowtype;
+  result jsonb;
+begin
+  select * into b from bookings where id = p_booking_id;
+  if not found then return null; end if;
+
+  select jsonb_build_object(
+    'access_location', ba.access_location,
+    'access_code',     ba.access_code,
+    'access_notes',    ba.access_notes,
+    'consent_at',      ba.consent_at,
+    'consent_version', ba.consent_version,
+    'address',         cp.address,
+    'suburb',          cp.suburb,
+    'postcode',        cp.postcode,
+    'owner_name',      trim(coalesce(u.first_name,'') || ' ' || coalesce(u.last_name,'')),
+    'owner_phone',     u.phone,
+    'owner_email',     u.email
+  ) into result
+  from customer_profiles cp
+  join users u on u.id = cp.user_id
+  left join private.backup_access ba on ba.customer_id = cp.id
+  where cp.id = b.customer_id;
+
+  return result;
+end;
+$$;
+
+revoke all on function public.get_cover_details(uuid) from public, anon, authenticated;
+grant execute on function public.get_cover_details(uuid) to service_role;

--- a/supabase/migrations/20260703000002_tru139_reassign_credits.sql
+++ b/supabase/migrations/20260703000002_tru139_reassign_credits.sql
@@ -1,0 +1,48 @@
+-- TRU-139: reassign a covered booking to the backup (founder) + payment handling.
+--
+-- Reassignment model: the booking's provider_id is swapped to the backup's
+-- provider profile (created inactive+unverified on first use, so it is never
+-- searchable) and the originally booked walker is snapshotted in
+-- original_provider_id — records always distinguish booked walker from actual
+-- walker, and walk tracking / RLS / owner UI keep working unchanged for the
+-- covered walk. Payment: charge-booking charges the owner the full original
+-- price but omits the destination transfer for cover_status='reassigned', so
+-- the walker share is retained by the platform and the original walker is not
+-- paid (they cancelled).
+--
+-- Fall-through: cover_status='fell_through' + a customer_credits row. Credits
+-- are MANUAL at MVP (decided with Tom): admin-issued, admin-redeemed, visible
+-- to the owner — the charge engine does NOT auto-apply them.
+--
+-- Applied to the live DB via apply_migration; committed for version control.
+
+alter table public.bookings
+  add column if not exists original_provider_id uuid references public.provider_profiles(id);
+
+create table if not exists public.customer_credits (
+  id            uuid primary key default gen_random_uuid(),
+  customer_id   uuid not null references public.customer_profiles(id) on delete cascade,
+  amount_cents  integer not null check (amount_cents > 0),
+  reason        text,
+  booking_id    uuid references public.bookings(id) on delete set null,
+  created_at    timestamptz not null default now(),
+  redeemed_at   timestamptz,
+  redeemed_note text
+);
+create index if not exists idx_customer_credits_customer
+  on public.customer_credits (customer_id, redeemed_at);
+
+alter table public.customer_credits enable row level security;
+
+-- Owners can see their own credits (profile banner); only the admin console
+-- (service role via stripe-api) writes them.
+drop policy if exists credits_owner_read on public.customer_credits;
+create policy credits_owner_read on public.customer_credits
+  for select to authenticated
+  using (exists (
+    select 1 from public.customer_profiles cp
+    where cp.id = customer_credits.customer_id and cp.user_id = auth.uid()
+  ));
+
+revoke insert, update, delete on public.customer_credits from anon, authenticated;
+grant select on public.customer_credits to authenticated, service_role;

--- a/supabase/migrations/20260703000003_owner_booking_cancel_rpc.sql
+++ b/supabase/migrations/20260703000003_owner_booking_cancel_rpc.sql
@@ -1,0 +1,50 @@
+-- Fix: the owner's single-booking Cancel button never worked. profile/index.html
+-- PATCHes bookings.status='cancelled', but customers have no UPDATE policy on
+-- bookings (only providers do), so the PATCH matches 0 rows and the UI shows
+-- "Couldn't save — you may not have permission". Verified live: an RLS-scoped
+-- UPDATE as a test customer updates 0 rows.
+--
+-- Fixed with a definer RPC rather than a customer UPDATE policy: an UPDATE policy
+-- can't restrict WHICH columns change, so it would let an owner PATCH total_cents
+-- or payment_status. The RPC allows exactly one transition — cancel your own
+-- pending booking (any time) or confirmed booking that hasn't started — and
+-- nothing else. Meet & greets are excluded (they cancel through the series
+-- decline flow). The TRU-137 cancel triggers still fire: cancelled_by stamps as
+-- 'customer' via auth.uid(), and no walker counters / cover path run (those
+-- require cancelled_by='provider').
+--
+-- Applied to the live DB via apply_migration; committed for version control.
+
+create or replace function public.cancel_my_booking(p_booking_id uuid, p_reason text default null)
+returns public.bookings
+language plpgsql security definer set search_path = public
+as $$
+declare
+  b public.bookings%rowtype;
+begin
+  select bk.* into b
+  from public.bookings bk
+  join public.customer_profiles cp on cp.id = bk.customer_id
+  where bk.id = p_booking_id and cp.user_id = auth.uid();
+  if not found then
+    raise exception 'Booking not found';
+  end if;
+  if coalesce(b.is_meet_and_greet, false) then
+    raise exception 'Meet & greets are cancelled from the meet & greet card';
+  end if;
+  if not (b.status = 'pending' or (b.status = 'confirmed' and b.scheduled_at > now())) then
+    raise exception 'This booking can no longer be cancelled';
+  end if;
+
+  update public.bookings
+     set status = 'cancelled',
+         cancel_reason = coalesce(nullif(trim(p_reason), ''), 'Cancelled by owner'),
+         updated_at = now()
+   where id = p_booking_id
+   returning * into b;
+  return b;
+end;
+$$;
+
+revoke all on function public.cancel_my_booking(uuid, text) from public, anon;
+grant execute on function public.cancel_my_booking(uuid, text) to authenticated;


### PR DESCRIPTION
## The bug

The owner profile page's **Cancel** button on a single booking has never worked: it PATCHes `bookings.status='cancelled'`, but customers have no UPDATE policy on `bookings` (only providers do), so the PATCH matches 0 rows and the UI shows *"Couldn't save — you may not have permission."* Confirmed live with an RLS-scoped UPDATE as a test customer → 0 rows. (Series cancels were fine — customers do have UPDATE on `booking_series`.)

## The fix

A definer RPC, `cancel_my_booking(booking_id, reason)`, instead of a customer UPDATE policy — a policy can't restrict *which columns* change, so it would have let an owner PATCH `total_cents` or `payment_status`. The RPC permits exactly one transition:

- your own booking only (scoped by `auth.uid()`)
- `pending` → cancelled (any time), or `confirmed` → cancelled while it hasn't started
- meet & greets excluded (they cancel through the M&G/series flow)
- optional reason, default "Cancelled by owner"

The TRU-137 cancellation triggers still fire: `cancelled_by` stamps as `customer`, and the walker counters / cover path correctly don't run (those are provider-only).

## Verified live

- Owner cancel works; row stamped `customer` + timestamped ✓
- Another customer → "Booking not found"; `anon` → permission denied ✓
- Re-cancel and no-longer-cancellable bookings refused ✓
- Walker counters bit-identical before/after an owner cancel (controlled snapshot) ✓
- Page JS passes `node --check`; test fixtures deleted ✓

Migration applied to live via `apply_migration`; the `.sql` is the committed record.

**Note:** this branch is cut from the #77 recovery tip, so its diff shows B+C until #77 merges — merge **#77 first** and this collapses to just the fix. (Merging this first would also land B+C — either order leaves main complete.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)