### PR TITLE
TRU-110: proximity + same-day route context on booking requests

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -49,6 +49,9 @@
   .cancel-inline span { font-size: 0.82rem; color: var(--text-secondary); }
   .cancel-inline.series { flex-direction: column; align-items: flex-start; }
   .cancel-inline-btns { display: flex; gap: 8px; flex-wrap: wrap; }
+  /* TRU-110: request proximity context */
+  .bc-context { font-size: 0.8rem; color: var(--text-muted); margin-top: 4px; }
+  .bc-context.hot { display: inline-block; color: #8a5a3b; background: #f3e8d9; border-radius: 8px; padding: 4px 10px; font-weight: 500; }
   /* TRU-137: cancellation reason capture */
   .cancel-reason { display: flex; flex-direction: column; gap: 6px; width: 100%; margin: 6px 0; }
   .cancel-reason select, .cancel-reason input { font: inherit; font-size: 0.85rem; padding: 8px 10px; border: 1px solid var(--border); border-radius: 8px; background: #fff; color: var(--text); }
@@ -403,6 +406,11 @@ async function sbGet(table, params) {
   const r = await fetch(`${SUPABASE_URL}/rest/v1/${table}?${params}`, { headers: headers(authToken) });
   if (!r.ok) { const e = await r.json(); throw new Error(e.message); } return await r.json();
 }
+async function sbRpc(fn, args) {
+  const r = await fetch(`${SUPABASE_URL}/rest/v1/rpc/${fn}`, { method: 'POST', headers: headers(authToken), body: JSON.stringify(args || {}) });
+  if (!r.ok) { const e = await r.json().catch(() => ({})); throw new Error(e.message || 'Request failed'); }
+  return await r.json();
+}
 async function sbPatch(table, col, val, updates) {
   const r = await fetch(`${SUPABASE_URL}/rest/v1/${table}?${col}=eq.${val}`, {
     method: 'PATCH', headers: { ...headers(authToken), 'Prefer':'return=representation' }, body: JSON.stringify(updates)
@@ -622,6 +630,13 @@ async function loadBookings() {
   bookings = await sbGet('bookings', `provider_id=eq.${providerProfile.id}&select=*&order=scheduled_at.asc`);
   if (!bookings.length) return;
 
+  // TRU-110: proximity/efficiency context for new requests — how far from home,
+  // and whether it slots next to a walk already booked that day. Server-side
+  // definer RPC returns distances only; failures just hide the line.
+  await Promise.all(bookings.filter(b => b.status === 'pending').map(async b => {
+    try { b._context = await sbRpc('booking_request_context', { p_booking_id: b.id }); } catch (e) { /* enhancement only */ }
+  }));
+
   const ids = bookings.map(b => b.id);
 
   // Providers can't read a customer's users/customer_profiles/pets rows directly under
@@ -742,6 +757,22 @@ async function declineSeries(id) {
     await loadSeries();
     renderBookingsTab();
   } catch(e) { showMsg(e.message, 'error'); }
+}
+
+/* TRU-110: proximity line on new requests. A same-day walk within 4km is the
+   headline ("slots right in"); otherwise just the distance from home. */
+function requestContextHtml(b) {
+  const c = b._context;
+  if (!c) return '';
+  const near = (c.same_day || []).find(j => j.distance_km != null && j.distance_km <= 4);
+  if (near) {
+    const t = new Date(near.scheduled_at).toLocaleTimeString('en-AU', { hour: 'numeric', minute: '2-digit' });
+    return `<div class="bc-context hot">🎯 ${near.distance_km} km from your ${t} walk${near.pet_name ? ' with ' + esc(near.pet_name) : ''} that day — slots right in</div>`;
+  }
+  if (c.distance_from_home_km != null) {
+    return `<div class="bc-context">${c.distance_from_home_km} km from home</div>`;
+  }
+  return '';
 }
 
 /* ── Cancelling an upcoming walk (and, for series walks, the whole series) ── */
@@ -927,6 +958,7 @@ function renderBookingsTab() {
           <div class="bc-pet">${b._pet_label || 'Pet'}</div>
           <span class="bc-service">${SERVICE_LABELS[b._service_type] || b._service_type || 'Service'}</span>
           <div class="bc-time">${bookingTimeLine(b)}</div>
+          ${requestContextHtml(b)}
           ${b.customer_notes ? `<div class="bc-notes">"${esc(b.customer_notes)}"</div>` : ''}
           ${bookingDetailsHtml(b)}
         </div>

--- a/supabase/migrations/20260703000005_tru110_booking_request_context.sql
+++ b/supabase/migrations/20260703000005_tru110_booking_request_context.sql
@@ -1,0 +1,68 @@
+-- TRU-110: booking request context for walkers.
+--
+-- When a request lands, give the walker the efficiency signals the ticket asks
+-- for: how far the job is from home, and whether it slots next to a walk they
+-- already have that day ("you're already walking 0.9km away at 2pm"). This is
+-- the supply-side twin of the TRU-154 search ranking and rides the same geo
+-- groundwork (customer_profiles.location, provider locations, PostGIS).
+--
+-- Privacy: definer fn; only the request's own walker (or the service role, for
+-- the future email enhancement) can call it, and only distances + the walker's
+-- own booking details leave the DB — never another customer's coordinates.
+--
+-- Applied to the live DB via apply_migration; committed for version control.
+
+create or replace function public.booking_request_context(p_booking_id uuid)
+returns jsonb
+language plpgsql stable security definer set search_path = public
+as $$
+declare
+  b public.bookings%rowtype;
+  pp public.provider_profiles%rowtype;
+  req_loc geography;
+  result jsonb;
+begin
+  select * into b from bookings where id = p_booking_id;
+  if not found then return null; end if;
+  select * into pp from provider_profiles where id = b.provider_id;
+  -- The request's own walker only. A service_role call carries no uid (allowed);
+  -- anon has EXECUTE revoked below.
+  if auth.uid() is not null and pp.user_id is distinct from auth.uid() then
+    raise exception 'Not authorised';
+  end if;
+  select cp.location into req_loc from customer_profiles cp where cp.id = b.customer_id;
+
+  select jsonb_build_object(
+    'distance_from_home_km',
+      case when pp.location is not null and req_loc is not null
+           then round((st_distance(pp.location, req_loc) / 1000.0)::numeric, 1) end,
+    'same_day', coalesce((
+      select jsonb_agg(jsonb_build_object(
+               'scheduled_at', o.scheduled_at,
+               'pet_name', o.pet_name,
+               'distance_km', o.distance_km) order by o.distance_km)
+      from (
+        select ob.scheduled_at, p.name as pet_name,
+               round((st_distance(ocp.location, req_loc) / 1000.0)::numeric, 1) as distance_km
+        from bookings ob
+        join customer_profiles ocp on ocp.id = ob.customer_id
+        left join pets p on p.id = ob.pet_id
+        where ob.provider_id = b.provider_id
+          and ob.id <> b.id
+          and ob.status in ('confirmed', 'in_progress')
+          and not coalesce(ob.is_meet_and_greet, false)
+          and (ob.scheduled_at at time zone 'Australia/Sydney')::date
+              = (b.scheduled_at at time zone 'Australia/Sydney')::date
+          and ocp.location is not null
+          and req_loc is not null
+        order by st_distance(ocp.location, req_loc)
+        limit 3
+      ) o
+    ), '[]'::jsonb)
+  ) into result;
+  return result;
+end;
+$$;
+
+revoke all on function public.booking_request_context(uuid) from public, anon;
+grant execute on function public.booking_request_context(uuid) to authenticated, service_role;


### PR DESCRIPTION
## What

New requests on the carer dashboard now carry the decision signals TRU-110 asks for:

- **🎯 "0.9 km from your 2:00 pm walk with Biscuit that day — slots right in"** (highlighted) when the walker already has a confirmed walk within 4 km of the request on the same day — the supply-side twin of the TRU-154 search boost: search steers owners toward walkers already nearby, this shows walkers which requests build a dense back-to-back route.
- Otherwise a muted **"1.8 km from home"**.

## How

`booking_request_context(booking_id)` definer RPC over the TRU-154 geo groundwork (`customer_profiles.location`, provider locations, PostGIS). Only the request's **own walker** may call it (anon revoked; `service_role` granted for the future email enhancement), and only **distances** plus the walker's own booking details leave the DB — never another customer's coordinates. The dashboard fetches contexts for pending requests in parallel after `loadBookings`; any failure silently hides the line (progressive enhancement).

## Verified live

- Fixture (walker with a confirmed 2pm Newington walk + a pending Homebush request): `distance_from_home_km: 10.1`, `same_day: [{Mochi, 3.1 km, 2pm}]` ✓
- Different walker → "Not authorised"; anon → permission denied ✓ (fixtures deleted)
- Dashboard JS passes `node --check` ✓

## Follow-up (kept out to avoid an edge-function redeploy here)

Same signals in the `booking_request` email — noted on the ticket.

Closes TRU-110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)