### PR TITLE
TRU-142 (1/2): kill client request waterfalls + Supabase preconnect

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -418,6 +418,7 @@
       .cta-section { padding: 48px 20px; }
     }
   </style>
+  <link rel="preconnect" href="https://gadflsntbnbnnxbpiral.supabase.co" crossorigin>
   <script src="/session.js"></script>
 </head>
 <body>

--- a/admin/index.html
+++ b/admin/index.html
@@ -48,6 +48,7 @@
   .login label{display:block;font-size:0.82rem;color:var(--muted);margin-bottom:5px;}
   .login button{width:100%;margin-top:6px;}
 </style>
+  <link rel="preconnect" href="https://gadflsntbnbnnxbpiral.supabase.co" crossorigin>
   <script src="/session.js"></script>
 </head>
 <body>

--- a/book/index.html
+++ b/book/index.html
@@ -183,6 +183,7 @@
   @keyframes fadeIn { from { opacity:0; transform:translateY(8px); } to { opacity:1; transform:translateY(0); } }
   .fade-in { animation: fadeIn 0.3s ease; }
 </style>
+  <link rel="preconnect" href="https://gadflsntbnbnnxbpiral.supabase.co" crossorigin>
   <script src="/session.js"></script>
 </head>
 <body>

--- a/carer-guidelines/emergencies-and-safety/index.html
+++ b/carer-guidelines/emergencies-and-safety/index.html
@@ -54,6 +54,7 @@
     .footer-nav a{color:var(--terracotta);font-weight:500;}
     @media(max-width:720px){.nav{padding:0 1rem;}}
   </style>
+  <link rel="preconnect" href="https://gadflsntbnbnnxbpiral.supabase.co" crossorigin>
   <script src="/session.js"></script>
 </head>
 <body>

--- a/carer-guidelines/your-commitments/index.html
+++ b/carer-guidelines/your-commitments/index.html
@@ -48,6 +48,7 @@
     .footer-nav a{color:var(--terracotta);font-weight:500;}
     @media(max-width:720px){.nav{padding:0 1rem;}}
   </style>
+  <link rel="preconnect" href="https://gadflsntbnbnnxbpiral.supabase.co" crossorigin>
   <script src="/session.js"></script>
 </head>
 <body>

--- a/carer/index.html
+++ b/carer/index.html
@@ -257,6 +257,7 @@
   @keyframes fadeIn { from { opacity:0; transform:translateY(8px); } to { opacity:1; transform:translateY(0); } }
   .fade-in { animation: fadeIn 0.3s ease; }
 </style>
+  <link rel="preconnect" href="https://gadflsntbnbnnxbpiral.supabase.co" crossorigin>
   <script src="/session.js"></script>
 </head>
 <body>

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -305,6 +305,7 @@
     .tab { padding: 10px 14px; font-size: 0.8rem; }
   }
 </style>
+  <link rel="preconnect" href="https://gadflsntbnbnnxbpiral.supabase.co" crossorigin>
   <script src="/session.js"></script>
 </head>
 <body>
@@ -1637,13 +1638,15 @@ async function init() {
     }
     providerProfile = profiles[0];
 
-    // Load services
-    providerServices = await sbGet('provider_services', `provider_id=eq.${authUid}&select=*`);
-
-    // Load bookings
-    await loadBookings();
-    await loadSeries();
-    await loadMgSeries();
+    // TRU-142: services, bookings and both series loads are independent — run
+    // them in one parallel round instead of four serial ones.
+    const [svcRows] = await Promise.all([
+      sbGet('provider_services', `provider_id=eq.${authUid}&select=*`),
+      loadBookings(),
+      loadSeries(),
+      loadMgSeries(),
+    ]);
+    providerServices = svcRows;
 
     // Returning from Stripe Connect onboarding? refresh payout readiness before first paint.
     const payoutsParam = new URLSearchParams(location.search).get('payouts');

--- a/index.html
+++ b/index.html
@@ -305,6 +305,7 @@
       .strip-divider { display: none; }
     }
   </style>
+  <link rel="preconnect" href="https://gadflsntbnbnnxbpiral.supabase.co" crossorigin>
   <script src="/session.js"></script>
 </head>
 <body>

--- a/login/index.html
+++ b/login/index.html
@@ -249,6 +249,7 @@
     .page-header h1 { font-size: 1.8rem; }
   }
 </style>
+  <link rel="preconnect" href="https://gadflsntbnbnnxbpiral.supabase.co" crossorigin>
   <script src="/session.js"></script>
 </head>
 <body>

--- a/messages/index.html
+++ b/messages/index.html
@@ -116,6 +116,7 @@
     .thread-back{display:inline-flex;}
   }
 </style>
+  <link rel="preconnect" href="https://gadflsntbnbnnxbpiral.supabase.co" crossorigin>
   <script src="/session.js"></script>
 </head>
 <body>

--- a/my/index.html
+++ b/my/index.html
@@ -18,6 +18,7 @@
 <style>
   body{font-family:system-ui,-apple-system,sans-serif;background:#FAF7F2;color:#9B8B7E;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;font-size:0.9rem;}
 </style>
+  <link rel="preconnect" href="https://gadflsntbnbnnxbpiral.supabase.co" crossorigin>
   <script src="/session.js"></script>
 </head>
 <body>

--- a/profile/index.html
+++ b/profile/index.html
@@ -213,6 +213,7 @@
     .row-2{grid-template-columns:1fr;}
   }
 </style>
+  <link rel="preconnect" href="https://gadflsntbnbnnxbpiral.supabase.co" crossorigin>
   <script src="/session.js"></script>
 </head>
 <body>
@@ -1483,55 +1484,66 @@ async function init() {
     customerProfile = profiles[0];
     profileRow = profiles[0];
 
-    // TRU-139: outstanding manual credits (RLS scopes to own rows).
-    try { myCredits = await sbGet('customer_credits', 'select=amount_cents&redeemed_at=is.null'); } catch (e) { myCredits = []; }
-
-    const rawBookings = await sbGet('bookings', `customer_id=eq.${customerProfile.id}&select=*&order=scheduled_at.desc`);
-
-    // Series this customer owns — used to drive the meet & greet card state.
+    // TRU-142: one parallel round for the page data, then batched IN-queries to
+    // enrich bookings — replaces up to 6 SERIAL queries per booking (~10s for a
+    // busy owner). RLS visibility is identical; it's the same reads, batched.
+    const [creditsRows, rawBookings, seriesRows, myReviews, myPets] = await Promise.all([
+      sbGet('customer_credits', 'select=amount_cents&redeemed_at=is.null').catch(() => []),
+      sbGet('bookings', `customer_id=eq.${customerProfile.id}&select=*&order=scheduled_at.desc`),
+      sbGet('booking_series', `customer_id=eq.${customerProfile.id}&select=id,status,booking_kind,frequency_type,days_of_week,time_of_day,window_end_time,start_date,end_date,locked_price_cents,service_id`).catch(() => []),
+      sbGet('reviews', `customer_id=eq.${customerProfile.id}&select=booking_id`).catch(() => []),
+      sbGet('pets', `customer_id=eq.${customerProfile.id}&is_active=eq.true&select=*`).catch(() => []),
+    ]);
+    myCredits = creditsRows;
     seriesById = {};
-    try {
-      const seriesRows = await sbGet('booking_series', `customer_id=eq.${customerProfile.id}&select=id,status,booking_kind,frequency_type,days_of_week,time_of_day,window_end_time,start_date,end_date,locked_price_cents,service_id`);
-      seriesRows.forEach(s => { seriesById[s.id] = s; });
-    } catch(e) { /* non-fatal */ }
+    seriesRows.forEach(s => { seriesById[s.id] = s; });
+    const reviewedBookingIds = new Set(myReviews.map(r => r.booking_id));
+    pets = myPets;
 
-    let reviewedBookingIds = new Set();
-    try {
-      const myReviews = await sbGet('reviews', `customer_id=eq.${customerProfile.id}&select=booking_id`);
-      reviewedBookingIds = new Set(myReviews.map(r => r.booking_id));
-    } catch(e) { /* none reviewed */ }
+    if (rawBookings.length) {
+      const provIds = [...new Set(rawBookings.map(b => b.provider_id).filter(Boolean))];
+      const svcIds = [...new Set(rawBookings.map(b => b.service_id).filter(Boolean))];
+      const bookingIds = rawBookings.map(b => b.id);
+      const activeIds = rawBookings.filter(b => b.status === 'in_progress').map(b => b.id);
 
-    for (const b of rawBookings) {
-      try {
-        const provProfiles = await sbGet('provider_profiles', `id=eq.${b.provider_id}&select=user_id`);
-        if (provProfiles.length) {
-          b._provider_user_id = provProfiles[0].user_id;
-          const pUsers = await sbGet('users', `id=eq.${provProfiles[0].user_id}&select=first_name,last_name`);
-          if (pUsers.length) b._provider_name = `${pUsers[0].first_name} ${pUsers[0].last_name}`;
-        }
-        let petRows = [];
-        try {
-          const bp = await sbGet('booking_pets', `booking_id=eq.${b.id}&select=pet_id`);
-          const ids = bp.map(r => r.pet_id).filter(Boolean);
-          if (ids.length) petRows = await sbGet('pets', `id=in.(${ids.join(',')})&select=name,breed`);
-        } catch(e) {}
-        if (!petRows.length && b.pet_id) petRows = await sbGet('pets', `id=eq.${b.pet_id}&select=name,breed`);
+      const [provProfiles, bookingPets, svcs, sessions] = await Promise.all([
+        provIds.length ? sbGet('provider_profiles', `id=in.(${provIds.join(',')})&select=id,user_id`).catch(() => []) : [],
+        sbGet('booking_pets', `booking_id=in.(${bookingIds.join(',')})&select=booking_id,pet_id`).catch(() => []),
+        svcIds.length ? sbGet('provider_services', `id=in.(${svcIds.join(',')})&select=id,service_type`).catch(() => []) : [],
+        activeIds.length ? sbGet('walk_sessions', `booking_id=in.(${activeIds.join(',')})&status=eq.active&select=booking_id`).catch(() => []) : [],
+      ]);
+
+      const provUserById = Object.fromEntries(provProfiles.map(p => [p.id, p.user_id]));
+      const provUserIds = [...new Set(provProfiles.map(p => p.user_id).filter(Boolean))];
+      const petIdsByBooking = {};
+      bookingPets.forEach(r => { (petIdsByBooking[r.booking_id] = petIdsByBooking[r.booking_id] || []).push(r.pet_id); });
+      const fallbackPetIds = rawBookings.filter(b => !(petIdsByBooking[b.id] || []).length && b.pet_id).map(b => b.pet_id);
+      const allPetIds = [...new Set([...bookingPets.map(r => r.pet_id), ...fallbackPetIds].filter(Boolean))];
+
+      const [provUsers, petRowsAll] = await Promise.all([
+        provUserIds.length ? sbGet('users', `id=in.(${provUserIds.join(',')})&select=id,first_name,last_name`).catch(() => []) : [],
+        allPetIds.length ? sbGet('pets', `id=in.(${allPetIds.join(',')})&select=id,name,breed`).catch(() => []) : [],
+      ]);
+      const nameByUser = Object.fromEntries(provUsers.map(u => [u.id, `${u.first_name} ${u.last_name}`]));
+      const petById = Object.fromEntries(petRowsAll.map(p => [p.id, p]));
+      const svcById = Object.fromEntries(svcs.map(s => [s.id, s.service_type]));
+      const activeWalk = new Set(sessions.map(s => s.booking_id));
+
+      rawBookings.forEach(b => {
+        const pu = provUserById[b.provider_id];
+        if (pu) { b._provider_user_id = pu; if (nameByUser[pu]) b._provider_name = nameByUser[pu]; }
+        const petIds = (petIdsByBooking[b.id] || []).length ? petIdsByBooking[b.id] : (b.pet_id ? [b.pet_id] : []);
+        const petRows = petIds.map(id => petById[id]).filter(Boolean);
         if (petRows.length) {
           b._pet_name = petRows.map(p => p.name).filter(Boolean).join(' + ');
           b._pet_breed = petRows.length === 1 ? petRows[0].breed : null;
         }
-        const svcs = await sbGet('provider_services', `id=eq.${b.service_id}&select=service_type`);
-        if (svcs.length) b._service_type = svcs[0].service_type;
-        if (b.status === 'in_progress') {
-          const sessions = await sbGet('walk_sessions', `booking_id=eq.${b.id}&status=eq.active&select=id&limit=1`);
-          b._has_active_walk = sessions.length > 0;
-        }
+        if (svcById[b.service_id]) b._service_type = svcById[b.service_id];
+        if (b.status === 'in_progress') b._has_active_walk = activeWalk.has(b.id);
         b._has_review = reviewedBookingIds.has(b.id);
-      } catch(e) {}
+      });
     }
     bookings = rawBookings;
-
-    pets = await sbGet('pets', `customer_id=eq.${customerProfile.id}&is_active=eq.true&select=*`);
 
     renderNav();
     renderCustomerHub();

--- a/register/index.html
+++ b/register/index.html
@@ -415,6 +415,7 @@
   .form-step.active { display: block; animation: fadeIn 0.3s ease; }
   @keyframes fadeIn { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
 </style>
+  <link rel="preconnect" href="https://gadflsntbnbnnxbpiral.supabase.co" crossorigin>
   <script src="/session.js"></script>
 </head>
 <body>

--- a/review/index.html
+++ b/review/index.html
@@ -148,6 +148,7 @@
   @keyframes fadeIn { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
   .fade-in { animation: fadeIn 0.3s ease; }
 </style>
+  <link rel="preconnect" href="https://gadflsntbnbnnxbpiral.supabase.co" crossorigin>
   <script src="/session.js"></script>
 </head>
 <body>

--- a/search/index.html
+++ b/search/index.html
@@ -239,6 +239,7 @@
   @keyframes fadeIn { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
   .fade-in { animation: fadeIn 0.3s ease; }
 </style>
+  <link rel="preconnect" href="https://gadflsntbnbnnxbpiral.supabase.co" crossorigin>
   <script src="/session.js"></script>
 </head>
 <body>

--- a/track/index.html
+++ b/track/index.html
@@ -104,6 +104,7 @@
     #map{height:220px;}
   }
 </style>
+  <link rel="preconnect" href="https://gadflsntbnbnnxbpiral.supabase.co" crossorigin>
   <script src="/session.js"></script>
 </head>
 <body>

--- a/walk/index.html
+++ b/walk/index.html
@@ -139,6 +139,7 @@
     #map{height:220px;}
   }
 </style>
+  <link rel="preconnect" href="https://gadflsntbnbnnxbpiral.supabase.co" crossorigin>
   <script src="/session.js"></script>
 </head>
 <body>


### PR DESCRIPTION
## Diagnosis (measured, not guessed)

- GitHub Pages static TTFB: **33–270ms** — hosting is fine.
- Supabase REST: **1.7s first hit → 0.23s warm** — each *serial* round-trip costs ~230ms+.
- The killer: **profile/ ran up to 6 sequential queries per booking** (provider → user → booking_pets → pets → service → walk_session). A 5-booking owner = 34 serial round-trips ≈ **10s**. This — not the free tier — is why the site feels slow.

## Fixes

1. **profile/**: one parallel round for page data (credits, bookings, series, reviews, pets) + batched `in.()` enrichment maps — the exact pattern dashboard's `loadBookings` already used. 34 serial trips → **5 rounds (~13 requests)**; RLS visibility identical (same reads, batched).
2. **dashboard/**: services + bookings + both series loads (4 serial awaits) → one `Promise.all` round.
3. **All 17 pages**: `preconnect` to the Supabase origin so TLS setup overlaps page parse instead of delaying the first query.

## Proof

- Transport-level replay (same endpoint, old shape vs new): **10.9s → 2.2s**. Browsers reuse connections, so real-world improves further.
- Data completeness: all 5 of the test owner's bookings resolve provider name / pet / service via the batched joins — identical to the old loop's output.
- `node --check` passes on both rewritten pages.

Part 1 of TRU-142. Part 2 (DB-side: 65× `auth_rls_initplan`, 123× duplicate permissive policies on hot tables, 15 missing FK indexes — from the performance advisors) follows as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)