### PR TITLE
TRU-130/155: privacy policy update, how-we-vet page + honesty sweep

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -443,7 +443,7 @@
         <a href="/">Home</a>
         <a href="/about-us/" class="active">About</a>
         <a href="/#services">Services</a>
-        <a href="/trust-and-safety/">Trust &amp; safety</a>
+        <a href="/trust-and-safety/">Trust &amp; safety</a> <a href="/how-we-vet/">How we vet</a>
         <a href="/#how">How it works</a>
       </div>
     </div>
@@ -588,7 +588,7 @@
       <h2 class="section-h2">That problem shouldn't exist. So we decided to fix it.</h2>
       <div class="body-text">
         <p>Truffl Pets is built on one idea: that pet owners deserve to actually trust who's looking after their animals — and to know, in real time, that everything is fine.</p>
-        <p>Every carer on our platform is interviewed, identity checked, police checked, and observed before they ever take a solo booking. Every walk is GPS tracked. Every visit comes with a photo update.</p>
+        <p>Every carer on our platform is interviewed, identity checked, reference checked, and assessed in person before they ever take a solo booking. Every walk is GPS tracked. Every visit comes with a photo update.</p>
         <p>No more wondering. No more hoping for the best.</p>
       </div>
     </div>
@@ -619,8 +619,8 @@
       </div>
       <div class="vs-card">
         <div class="vs-num">03</div>
-        <div class="vs-name">Police checked</div>
-        <div class="vs-desc">Full background check required, renewed annually</div>
+        <div class="vs-name">Optional police check</div>
+        <div class="vs-desc">Some carers add a National Police Check — shown as a badge on their profile</div>
       </div>
       <div class="vs-card">
         <div class="vs-num">04</div>
@@ -724,7 +724,7 @@
     <div class="footer-links">
       <a href="/register/">For carers</a>
       <a href="/about-us/">About</a>
-      <a href="/trust-and-safety/">Trust &amp; safety</a>
+      <a href="/trust-and-safety/">Trust &amp; safety</a> <a href="/how-we-vet/">How we vet</a>
       <a href="#">Contact</a>
       <a href="/privacy/">Privacy</a>
     </div>

--- a/how-we-vet/index.html
+++ b/how-we-vet/index.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-T2CPSDBJ1L"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-T2CPSDBJ1L');
+</script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="canonical" href="https://trufflpets.com/how-we-vet/">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Truffl Pets">
+<meta property="og:title" content="How we vet every carer — Truffl Pets">
+<meta property="og:description" content="Identity verified, experience checked, references called, and met in person by a Truffl founder — how every carer earns their place.">
+<meta property="og:url" content="https://trufflpets.com/how-we-vet/">
+<meta property="og:image" content="https://trufflpets.com/dog-hero.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="How we vet every carer — Truffl Pets">
+<meta name="twitter:description" content="Identity verified, experience checked, references called, and met in person by a Truffl founder — how every carer earns their place.">
+<meta name="twitter:image" content="https://trufflpets.com/dog-hero.png">
+  <title>How we vet every carer — Truffl Pets</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <meta name="description" content="Identity verified, experience checked, references called, and met in person by a Truffl founder — how every carer earns their place.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --cream: #F7F3EE; --warm: #EDE7DC; --sage: #C8D5C0; --sage-dark: #8A9E82;
+      --blush: #E8D5CC; --terracotta: #C4866A; --terracotta-dark: #B8795C;
+      --brown: #5C4033; --brown-deep: #3A2E28; --text: #3A2E28; --text-mid: #7A6860;
+      --text-light: #A8978E; --border: rgba(92,64,51,0.12);
+    }
+    html { font-size: 16px; scroll-behavior: smooth; }
+    body { font-family: 'DM Sans', sans-serif; background: var(--cream); color: var(--text); line-height: 1.65; -webkit-font-smoothing: antialiased; }
+    a { text-decoration: none; color: inherit; }
+    nav { background: var(--cream); padding: 0 56px; height: 82px; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid var(--border); position: sticky; top: 0; z-index: 100; gap: 24px; flex-wrap: wrap; }
+    .nav-left { display: flex; align-items: center; gap: 32px; }
+    .nav-links { display: flex; gap: 28px; font-size: 13px; color: var(--text-mid); }
+    .nav-links a:hover, .nav-links a.active { color: var(--text); }
+    .nav-links a.active { font-weight: 500; }
+    .nav-actions { display: flex; gap: 24px; align-items: center; font-size: 13px; color: var(--text-mid); }
+    .nav-actions a:hover { color: var(--text); }
+    .btn-primary { background: var(--terracotta); color: #fff; padding: 11px 22px; border-radius: 999px; font-size: 13px; font-weight: 500; transition: background 0.2s, transform 0.2s; }
+    .btn-primary:hover { background: var(--terracotta-dark); transform: translateY(-1px); }
+    .article { max-width: 720px; margin: 0 auto; padding: 40px 24px 24px; }
+    .crumb { font-size: 13px; color: var(--text-mid); margin-bottom: 26px; display: inline-flex; align-items: center; gap: 7px; }
+    .crumb:hover { color: var(--terracotta); }
+    .article h1 { font-family: 'Cormorant Garamond', serif; font-weight: 500; font-size: 2.5rem; line-height: 1.12; color: var(--brown); margin-bottom: 18px; }
+    .lead { font-size: 1.08rem; color: var(--text-mid); margin-bottom: 30px; }
+    .article h2 { font-family: 'Cormorant Garamond', serif; font-weight: 500; font-size: 1.6rem; color: var(--brown); margin: 34px 0 12px; }
+    .article p { margin-bottom: 14px; color: var(--text); }
+    .note { background: #fff; border: 1px solid var(--border); border-left: 3px solid var(--sage-dark); border-radius: 12px; padding: 18px 20px; margin: 22px 0; }
+    .note p:last-child { margin-bottom: 0; }
+    .cta-row { margin: 36px 0 8px; display: flex; gap: 14px; flex-wrap: wrap; }
+    footer { background: var(--brown-deep); color: var(--text-light); padding: 40px 56px; display: flex; align-items: center; justify-content: space-between; gap: 20px; flex-wrap: wrap; margin-top: 48px; }
+    .footer-links { display: flex; gap: 24px; font-size: 13px; color: var(--text-light); flex-wrap: wrap; }
+    .footer-links a:hover { color: #fff; }
+    .footer-copy { font-size: 12px; color: var(--text-light); opacity: 0.7; }
+    @media (max-width: 860px) { nav { padding: 0 20px; } .nav-links { display: none; } .article h1 { font-size: 2rem; } footer { padding: 32px 20px; } }
+  </style>
+</head>
+<body>
+  <nav>
+    <div class="nav-left">
+      <a href="/" class="nav-logo" aria-label="Truffl Pets home">
+        <svg width="150" height="48" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <circle cx="20" cy="33" r="20" fill="#C4866A"/>
+          <text x="20" y="38" font-family="'Cormorant Garamond', Georgia, serif" font-size="14" font-style="italic" fill="#F7F3EE" text-anchor="middle">truffl</text>
+          <text x="52" y="30" font-family="'Cormorant Garamond', Georgia, serif" font-size="32" font-style="italic" fill="#5C4033" letter-spacing="-0.5">truffl</text>
+          <text x="52" y="50" font-family="'DM Sans', sans-serif" font-size="12" font-weight="600" fill="#B0A090" letter-spacing="4">PETS</text>
+        </svg>
+      </a>
+      <div class="nav-links">
+        <a href="/">Home</a>
+        <a href="/about-us/">About</a>
+        <a href="/trust-and-safety/">Trust &amp; safety</a>
+        <a href="/how-we-vet/" class="active">How we vet</a>
+      </div>
+    </div>
+    <div class="nav-actions">
+      <a href="/login/">Sign in</a>
+      <a href="/search/" class="btn-primary">Book a carer</a>
+    </div>
+  </nav>
+
+  <article class="article">
+    <a class="crumb" href="/trust-and-safety/"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg> Trust &amp; safety</a>
+    <h1>How Truffl vets every carer</h1>
+    <p class="lead">Trusting someone new with your dog is a big deal. We built Truffl because finding someone reliable is harder than it should be, and our rule is simple: if we wouldn't trust our own dogs with a carer, we wouldn't expect you to. So we vet every carer ourselves, properly, before they can take a single booking. Here's exactly how.</p>
+
+    <h2>We confirm they are who they say they are</h2>
+    <p>Every carer verifies their identity with government photo ID and a live selfie check before they can do anything else. No anonymous profiles, ever.</p>
+
+    <h2>We check their experience with dogs</h2>
+    <p>Every carer tells us about their hands-on experience, their own pets, any qualifications like pet first aid, and the kinds of dogs they're confident caring for. We read every application.</p>
+
+    <h2>We call their references</h2>
+    <p>We speak to people who can vouch for how they care for animals. Not a box to tick, an actual conversation.</p>
+
+    <h2>We meet every single carer in person</h2>
+    <p>This is the part most platforms skip. A Truffl founder personally sits down with every carer and takes them through a live assessment: how they read a dog's body language, how they handle an emergency, what they'd do if a dog slipped its lead or got hurt on a walk. If someone can't show us they'd keep your dog safe, they don't get on the platform. It's that simple.</p>
+
+    <h2>We're selective on purpose</h2>
+    <p>We turn away carers who don't meet our standard. A profile on Truffl means a real person has earned their place here.</p>
+
+    <h2>Some carers go further</h2>
+    <p>Carers can choose to complete a National Police Check and share it with us. When they do, you'll see a verified badge on their profile. Not every carer has one, and we'll always be upfront about that, so you can decide what matters to you.</p>
+
+    <h2>On every booking, you stay connected</h2>
+    <p>GPS tracking on walks, check-ins, and updates mean you're never left wondering how your dog is doing.</p>
+
+    <h2>About care companies</h2>
+    <p>Some care on Truffl is provided by established local pet care businesses. We vet these businesses as partners: we check they're a legitimate, insured operation and that their own vetting of their people meets or beats the standard we hold our independent carers to. When care comes from a partner business rather than an independent Truffl carer, we'll make that clear.</p>
+
+    <div class="cta-row">
+      <a href="/search/" class="btn-primary">Find your carer</a>
+    </div>
+    <p style="margin-top:20px;">See also our <a style="color:var(--terracotta);border-bottom:1px solid rgba(196,134,106,0.4);" href="/trust-and-safety/">Trust &amp; safety</a> guidance.</p>
+  </article>
+
+  <footer>
+    <a href="/" aria-label="Truffl Pets home">
+      <svg width="130" height="40" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="20" cy="33" r="20" fill="#C4866A" opacity="0.6"/>
+        <text x="20" y="38" font-family="'Cormorant Garamond', Georgia, serif" font-size="14" font-style="italic" fill="#F7F3EE" text-anchor="middle">truffl</text>
+        <text x="52" y="30" font-family="'Cormorant Garamond', Georgia, serif" font-size="32" font-style="italic" fill="#A8978E" letter-spacing="-0.5">truffl</text>
+      </svg>
+    </a>
+    <div class="footer-links">
+      <a href="/register/">For carers</a>
+      <a href="/about-us/">About</a>
+      <a href="/trust-and-safety/">Trust &amp; safety</a>
+      <a href="/how-we-vet/">How we vet</a>
+      <a href="mailto:hello@trufflpets.com">Contact</a>
+      <a href="/privacy/">Privacy</a>
+    </div>
+    <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -13,20 +13,20 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Truffl Pets — Sydney's trusted pet care</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-  <meta name="description" content="Vetted, trusted pet care professionals in Sydney. GPS tracked walks, real-time updates, police checked carers.">
+  <meta name="description" content="Vetted, trusted pet care professionals in Sydney. Every carer assessed in person, GPS tracked walks, real-time updates.">
   <link rel="canonical" href="https://trufflpets.com/">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Truffl Pets">
   <meta property="og:title" content="Truffl Pets — Sydney's trusted pet care">
-  <meta property="og:description" content="Vetted, police-checked pet carers in Sydney. GPS-tracked walks, live updates and photos — book dog walking, boarding, sitting and daycare.">
+  <meta property="og:description" content="Vetted pet carers in Sydney, every one assessed in person. GPS-tracked walks, live updates and photos — book dog walking, boarding, sitting and daycare.">
   <meta property="og:url" content="https://trufflpets.com/">
   <meta property="og:image" content="https://trufflpets.com/dog-hero.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Truffl Pets — Sydney's trusted pet care">
-  <meta name="twitter:description" content="Vetted, police-checked pet carers in Sydney. GPS-tracked walks, live updates and photos.">
+  <meta name="twitter:description" content="Vetted pet carers in Sydney, every one assessed in person. GPS-tracked walks, live updates and photos.">
   <meta name="twitter:image" content="https://trufflpets.com/dog-hero.png">
   <script type="application/ld+json">
-  {"@context":"https://schema.org","@type":"LocalBusiness","name":"Truffl Pets","description":"Vetted, police-checked pet carers in Sydney offering GPS-tracked dog walking, boarding, sitting and daycare.","url":"https://trufflpets.com/","image":"https://trufflpets.com/dog-hero.png","areaServed":"Sydney, NSW, Australia","address":{"@type":"PostalAddress","addressLocality":"Sydney","addressRegion":"NSW","addressCountry":"AU"}}
+  {"@context":"https://schema.org","@type":"LocalBusiness","name":"Truffl Pets","description":"Vetted pet carers in Sydney, assessed in person, offering GPS-tracked dog walking, boarding, sitting and daycare.","url":"https://trufflpets.com/","image":"https://trufflpets.com/dog-hero.png","areaServed":"Sydney, NSW, Australia","address":{"@type":"PostalAddress","addressLocality":"Sydney","addressRegion":"NSW","addressCountry":"AU"}}
   </script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -332,7 +332,7 @@
         <a href="/about-us/">About</a>
         <a href="#why">Our carers</a>
         <a href="#how">How it works</a>
-        <a href="/trust-and-safety/">Trust &amp; safety</a>
+        <a href="/trust-and-safety/">Trust &amp; safety</a> <a href="/how-we-vet/">How we vet</a>
       </div>
     </div>
 
@@ -372,9 +372,9 @@
     <div class="hero-left">
       <p class="eyebrow fade-up delay-1">Sydney's trusted pet care</p>
       <h1 class="hero-h1 fade-up delay-2">Find a carer your dog will <em>love.</em></h1>
-      <p class="hero-body fade-up delay-3">Every carer is interviewed, police-checked and vetted by us. No bidding wars, no guesswork — just thoughtful pet care, on your terms.</p>
+      <p class="hero-body fade-up delay-3">Every carer is interviewed, ID-verified and assessed in person by us. No bidding wars, no guesswork — just thoughtful pet care, on your terms.</p>
       <div class="hero-trust fade-up delay-4">
-        <div class="trust-item"><div class="trust-dot"></div>Police checked</div>
+        <div class="trust-item"><div class="trust-dot"></div>Vetted in person</div>
         <div class="trust-item"><div class="trust-dot"></div>GPS tracked walks</div>
         <div class="trust-item"><div class="trust-dot"></div>Photo updates</div>
       </div>
@@ -494,7 +494,7 @@
   <!-- Trust strip below hero -->
   <div class="trust-strip">
     <span>★ 4.9 from local owners</span>
-    <span>· 100% police-checked carers ·</span>
+    <span>· Every carer vetted in person ·</span>
     <span>Insured up to $20,000</span>
   </div>
 
@@ -730,7 +730,7 @@
 
   <!-- STRIP -->
   <div class="strip">
-    <div class="strip-item">Police checked carers</div>
+    <div class="strip-item">Carers vetted in person</div>
     <div class="strip-divider"></div>
     <div class="strip-item">Live GPS on every walk</div>
     <div class="strip-divider"></div>
@@ -811,7 +811,7 @@
       </div>
       <div class="vc">
         <div class="vc-num">03</div>
-        <div><div class="vc-title">Police checked</div><div class="vc-sub">Full background check, renewed annually</div></div>
+        <div><div class="vc-title">Optional police check</div><div class="vc-sub">Some carers add a National Police Check — shown as a badge on their profile</div></div>
       </div>
       <div class="vc">
         <div class="vc-num">04</div>
@@ -882,7 +882,7 @@
     <div class="footer-links">
       <a href="/register/">For carers</a>
       <a href="/about-us/">About</a>
-      <a href="/trust-and-safety/">Trust &amp; safety</a>
+      <a href="/trust-and-safety/">Trust &amp; safety</a> <a href="/how-we-vet/">How we vet</a>
       <a href="#">Contact</a>
       <a href="/privacy/">Privacy</a>
     </div>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -105,13 +105,11 @@
   <article class="article">
     <a class="crumb" href="/"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg> Home</a>
     <h1>Privacy policy</h1>
-    <!-- PLACEHOLDER: confirm effective date before launch -->
-    <p class="updated" data-placeholder="effective-date">Last updated: 22 June 2026</p>
+    <p class="updated">Last updated: 4 July 2026</p>
     <p class="lead">Truffl Pets connects pet owners with vetted local carers in Sydney. This policy explains what personal information we collect, how we use it, who we share it with, and the choices and rights you have. It applies to our website, our mobile apps, and the services we provide through them.</p>
 
     <div class="note">
-      <!-- PLACEHOLDER: confirm legal entity name + ABN before launch -->
-      <p>Truffl Pets <span data-placeholder="legal-entity">(legal entity name and ABN to be confirmed)</span> is the organisation responsible for your personal information. We handle it in accordance with the Australian <em>Privacy Act 1988</em> (Cth) and the Australian Privacy Principles (APPs).</p>
+      <p>Truffl Pets (ABN 14 690 054 980) is the organisation responsible for your personal information. We handle it in accordance with the Australian <em>Privacy Act 1988</em> (Cth) and the Australian Privacy Principles (APPs). A copy of the APPs is available from the Office of the Australian Information Commissioner at <a class="inline" href="https://www.oaic.gov.au" target="_blank" rel="noopener">oaic.gov.au</a>.</p>
     </div>
 
     <div class="toc">
@@ -152,9 +150,22 @@
       <li>Photos and updates a carer shares during a booking.</li>
     </ul>
 
+    <h3>Payments</h3>
+    <ul>
+      <li>Payments are processed by <strong>Stripe</strong>. Your card details go directly to Stripe and are never stored on, and never pass through, Truffl's systems.</li>
+      <li>We keep a reference to your Stripe customer or payout account, and records of charges and refunds for your bookings.</li>
+    </ul>
+
+    <h3>Home access details (backup cover)</h3>
+    <ul>
+      <li>If you choose to turn on backup cover, we collect your lockbox or key access location, its code, and any access notes — together with your explicit, timestamped consent for a Truffl backup to use them if your walker cancels.</li>
+      <li>These details are stored separately from your booking data with restricted access, are only ever surfaced to Truffl when a covered walk is actually cancelled, and are <strong>deleted immediately</strong> if you turn backup cover off.</li>
+    </ul>
+
     <h3>Location &amp; GPS</h3>
     <ul>
       <li>During a walk, the carer's app records GPS location so owners can follow along live and review the route afterwards. See <a class="inline" href="#location">Location &amp; GPS</a> below.</li>
+      <li>We also store approximate (suburb-level) coordinates for carers and owners, derived from the suburb on your profile, so search can match carers to the areas they serve.</li>
     </ul>
 
     <h3>Technical &amp; usage information</h3>
@@ -186,9 +197,12 @@
     <p>We do not sell your personal information. We share it only where it is needed to provide the service:</p>
     <ul>
       <li><strong>Between owners and carers.</strong> When you book or accept a booking, the other party sees the information they need to provide or receive care — for example a carer sees your pet's details and relevant notes, and you see the carer's profile.</li>
-      <li><strong>Service providers who help us run Truffl.</strong> We use trusted third parties to host data and understand usage:
+      <li><strong>Service providers who help us run Truffl.</strong> We use trusted third parties to host data, process payments, send email and understand usage:
         <ul>
           <li><strong>Supabase</strong> — our database and authentication provider, where your account, booking, message and pet data is stored.</li>
+          <li><strong>Stripe</strong> — our payment processor. Stripe receives your card details directly and handles them under its own privacy policy; carers' payout accounts are also held with Stripe.</li>
+          <li><strong>Resend</strong> — delivers our transactional emails (booking confirmations, updates and alerts), and processes your name and email address to do so.</li>
+          <li><strong>GitHub Pages</strong> — hosts the Truffl website.</li>
           <li><strong>Google Analytics</strong> — to understand how the site and apps are used. This uses cookies and similar technologies and processes limited usage and device data.</li>
         </ul>
       </li>
@@ -202,7 +216,13 @@
     <p>Your data is stored with our database provider, Supabase, and protected by access controls so that owners and carers can only see the information relevant to their own account and bookings. We use encryption in transit and apply reasonable technical and organisational measures to protect your information. No system is perfectly secure, so we cannot guarantee absolute security, but we work to protect your data and to respond quickly if something goes wrong.</p>
 
     <h2 id="retention">6. How long we keep your information</h2>
-    <p>We keep your information while your account is active and for as long as we need it to provide the service, comply with our legal obligations, resolve disputes, and enforce our agreements. When information is no longer needed for these purposes, we delete it or de-identify it. If you close your account, you can ask us to delete your personal information, subject to any records we are required to keep.</p>
+    <p>We keep your information while your account is active and for as long as we need it to provide the service, comply with our legal obligations, resolve disputes, and enforce our agreements. In particular:</p>
+    <ul>
+      <li><strong>Home access details</strong> (backup cover) are deleted immediately when you turn backup cover off.</li>
+      <li><strong>Payment and transaction records</strong> are kept for up to seven years, as Australian tax and financial record-keeping laws require.</li>
+      <li><strong>Walk routes, messages and booking history</strong> are kept while your account is active so you and your carer can refer back to them.</li>
+    </ul>
+    <p>When information is no longer needed for these purposes, we delete it or de-identify it. If you close your account, you can ask us to delete your personal information, subject to any records we are required to keep.</p>
 
     <h2 id="rights">7. Your rights &amp; choices</h2>
     <p>You can:</p>
@@ -223,10 +243,11 @@
     <h2 id="contact">10. Contact us</h2>
     <p>If you have a question about this policy or about how we handle your personal information, or you want to make a privacy request, contact us at:</p>
     <ul>
-      <li><strong>Email:</strong> <a class="inline" href="mailto:privacy@trufflpets.com" data-placeholder="privacy-email">privacy@trufflpets.com</a></li>
+      <li><strong>Email:</strong> <a class="inline" href="mailto:privacy@trufflpets.com">privacy@trufflpets.com</a></li>
+      <li><strong>Business:</strong> Truffl Pets · ABN 14 690 054 980 · Sydney, NSW</li>
     </ul>
 
-    <p style="margin-top:28px;">See also our <a class="inline" href="/trust-and-safety/">Trust &amp; safety</a> guidance.</p>
+    <p style="margin-top:28px;">See also our <a class="inline" href="/trust-and-safety/">Trust &amp; safety</a> guidance and <a class="inline" href="/how-we-vet/">how we vet every carer</a>.</p>
   </article>
 
   <footer>
@@ -241,7 +262,8 @@
       <a href="/register/">For carers</a>
       <a href="/about-us/">About</a>
       <a href="/trust-and-safety/">Trust &amp; safety</a>
-      <a href="#">Contact</a>
+      <a href="/how-we-vet/">How we vet</a>
+      <a href="mailto:hello@trufflpets.com">Contact</a>
       <a href="/privacy/">Privacy</a>
     </div>
     <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>

--- a/search/index.html
+++ b/search/index.html
@@ -12,17 +12,17 @@
 </script>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="description" content="Find vetted, police-checked pet carers near you in Sydney. Book GPS-tracked dog walking, boarding, sitting and daycare.">
+<meta name="description" content="Find vetted pet carers near you in Sydney, every one assessed in person. Book GPS-tracked dog walking, boarding, sitting and daycare.">
 <link rel="canonical" href="https://trufflpets.com/search/">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Truffl Pets">
 <meta property="og:title" content="Find a carer — Truffl Pets">
-<meta property="og:description" content="Find vetted, police-checked pet carers near you in Sydney. Book GPS-tracked dog walking, boarding, sitting and daycare.">
+<meta property="og:description" content="Find vetted pet carers near you in Sydney, every one assessed in person. Book GPS-tracked dog walking, boarding, sitting and daycare.">
 <meta property="og:url" content="https://trufflpets.com/search/">
 <meta property="og:image" content="https://trufflpets.com/dog-hero.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Find a carer — Truffl Pets">
-<meta name="twitter:description" content="Find vetted, police-checked pet carers near you in Sydney. Book GPS-tracked dog walking, boarding, sitting and daycare.">
+<meta name="twitter:description" content="Find vetted pet carers near you in Sydney, every one assessed in person. Book GPS-tracked dog walking, boarding, sitting and daycare.">
 <meta name="twitter:image" content="https://trufflpets.com/dog-hero.png">
 <title>Find a Carer — Truffl Pets</title>
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">

--- a/trust-and-safety/index.html
+++ b/trust-and-safety/index.html
@@ -116,6 +116,12 @@
     </div>
 
     <div class="ts-cards">
+      <a class="ts-card" href="/how-we-vet/">
+        <span class="ts-card-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M9 12l2 2 4-4"/></svg></span>
+        <h2>How we vet every carer</h2>
+        <p>ID checks, references, and an in-person assessment — how a carer earns their place.</p>
+        <span class="ts-arrow">Read more →</span>
+      </a>
       <a class="ts-card" href="/trust-and-safety/choosing-your-carer/">
         <span class="ts-card-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>
         <h2>Choosing your carer</h2>


### PR DESCRIPTION
## TRU-130 — privacy policy brought up to date

The page existed (good APP-style skeleton) but predated the last fortnight of features. Added/updated:
- **Payments**: cards handled entirely by Stripe (never touch Truffl); we keep Stripe ids + charge/refund records.
- **Home access details (backup cover)**: explicit timestamped consent, stored separately with restricted access, surfaced only when a covered walk is cancelled, **deleted immediately on opt-out** — describes exactly what's built.
- Suburb-level geocoded coordinates (search matching) added to the Location section.
- Provider list: + **Stripe, Resend, GitHub Pages**.
- **Retention specifics** *(please confirm these in review)*: access details until opt-out · payment records up to **7 years** · routes/messages for account life.
- Entity: **ABN 14 690 054 980**; effective date → 4 July 2026; both `data-placeholder` markers resolved; dead footer Contact link fixed.

## TRU-155 — /how-we-vet/ page

Approved copy **verbatim**, in the privacy-page shell. Linked from the Trust & safety hub (first card), and navs/footers on index, about-us and privacy.

## Honesty sweep (TRU-155 acceptance criteria)

The site claimed **all carers are police checked in eleven places** — including a "100% police-checked carers" marquee and "full background check, renewed annually". All reframed to the approved language: in-person vetting + ID checks as the universal standard, police check as an **optional badge** ("some carers", never "all"). The per-carer badge label in carer profiles stays — that one is accurate.

## Verified

- Both pages render correctly in local preview (screenshot-checked); privacy content assertions all pass (ABN, Stripe, Resend, lockbox, delete-on-opt-out, 7 years, no placeholders, no dead links) ✓
- Final `police.check` sweep: only the optional-badge framing remains ✓

**For your review**: the retention numbers, privacy@ contact address, and any copy taste. Per the ticket, if you edit the vetting copy here, mirror it back into the Notion vetting policy. TRU-96 (marketing) still lists police checks as standard — flagged there, not actioned.

Closes TRU-130. Closes TRU-155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)