### PR TITLE
TRU-156: travel-time service areas (isochrones) + carer service-area editor

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1363,7 +1363,7 @@ function renderDashboard() {
           <div class="pp-avatar">${initials}</div>
           <div>
             <div class="pp-name">${userData.first_name} ${userData.last_name}</div>
-            <div class="pp-suburb">${providerProfile.suburb || 'Sydney'}${providerProfile.radius_km ? ' · ' + providerProfile.radius_km + 'km radius' : ''}</div>
+            <div class="pp-suburb">${providerProfile.suburb || 'Sydney'}${providerProfile.travel_time_mins ? ' · ' + providerProfile.travel_time_mins + ' min service area' : (providerProfile.radius_km ? ' · ' + providerProfile.radius_km + 'km radius' : '')}</div>
             <a href="/carer/?id=${authUid}" class="pp-link">View as customers see it →</a>
           </div>
         </div>

--- a/profile/index.html
+++ b/profile/index.html
@@ -107,6 +107,10 @@
   .cover-check{display:flex;gap:9px;align-items:flex-start;font-size:0.85rem;line-height:1.55;color:var(--text);margin:12px 0;}
   .cover-check input{margin-top:3px;flex-shrink:0;}
   .cover-meta{font-size:0.82rem;color:var(--text-muted);margin:4px 0 10px;}
+  /* TRU-156: service-area mode toggle */
+  .sa-seg{display:flex;padding:3px;background:var(--cream,#F7F3EE);border:1px solid var(--border);border-radius:999px;margin:10px 0;max-width:320px;}
+  .sa-seg button{flex:1;border:0;background:transparent;padding:8px 12px;font:inherit;font-size:0.85rem;color:var(--text-muted);border-radius:999px;cursor:pointer;}
+  .sa-seg button.active{background:#fff;color:var(--brown);font-weight:600;box-shadow:0 1px 3px rgba(61,43,31,0.12);}
   /* TRU-139: fall-through note + manual credit banner */
   .cover-note{margin-bottom:10px;background:#fdf3ec;border:1px solid #f0d9c8;border-radius:8px;padding:8px 12px;font-size:0.82rem;color:#8a5a3b;line-height:1.5;}
   .credit-banner{background:var(--success-bg);border:1px solid #d3e3d2;border-radius:10px;padding:10px 14px;font-size:0.86rem;color:var(--sage-dark);margin-bottom:14px;}
@@ -1136,9 +1140,73 @@ function renderProviderProfile() {
     <hr class="section-divider">
     <div class="section-heading">My details</div>
     ${detailsFormHtml()}
+    <hr class="section-divider">
+    <div class="section-heading">Service area</div>
+    ${serviceAreaHtml()}
     <button class="sign-out-btn" onclick="signOut()">Sign out</button>
   `;
   renderAvatar();
+}
+
+/* ── Service area (TRU-156): travel-time isochrone or simple radius ── */
+let areaMode = null, areaCoverage = null;
+const AREA_KM = [3, 5, 8, 10, 15, 20];
+const AREA_MINS = [10, 15, 20, 30, 45, 60];
+function serviceAreaHtml() {
+  if (!profileRow) return '';
+  const mode = areaMode || (profileRow.travel_time_mins ? 'travel' : 'radius');
+  const current = profileRow.travel_time_mins
+    ? `up to ${profileRow.travel_time_mins} min drive from home`
+    : `${profileRow.radius_km || 5} km from home`;
+  const opts = mode === 'travel'
+    ? AREA_MINS.map(m => `<option value="${m}" ${profileRow.travel_time_mins === m ? 'selected' : ''}>${m} minutes</option>`).join('')
+    : AREA_KM.map(k => `<option value="${k}" ${(profileRow.radius_km || 5) === k ? 'selected' : ''}>${k} km</option>`).join('');
+  return `<div class="cover-card">
+    <p>How far will you go for a job? <b>Travel time</b> follows real roads — no jobs across the harbour unless you'd actually drive it. <b>Distance</b> is a simple circle around your suburb.</p>
+    <div class="sa-seg">
+      <button type="button" class="${mode === 'radius' ? 'active' : ''}" onclick="setAreaMode('radius')">Distance</button>
+      <button type="button" class="${mode === 'travel' ? 'active' : ''}" onclick="setAreaMode('travel')">Travel time</button>
+    </div>
+    <div class="cover-field"><label for="sa-value">${mode === 'travel' ? 'Up to (drive time from home)' : 'Within'}</label>
+      <select id="sa-value">${opts}</select></div>
+    <div id="sa-msg" class="msg"></div>
+    <div class="bc-actions"><button class="btn-primary" id="sa-save" onclick="saveServiceArea('${mode}')">Save service area</button></div>
+    <p class="cover-meta" style="margin-top:12px;">Current setting: ${esc(current)}</p>
+    <div id="sa-coverage" class="cover-meta">${areaCoverage ? coverageLine(areaCoverage) : 'Checking your coverage…'}</div>
+  </div>`;
+}
+function coverageLine(names) {
+  if (!names || !names.length) return 'No suburbs in range yet — make sure your suburb is set in My details.';
+  const shown = names.slice(0, 18);
+  return `Covers ${names.length}${names.length >= 80 ? '+' : ''} suburbs: ${shown.map(esc).join(', ')}${names.length > shown.length ? '…' : ''}`;
+}
+function setAreaMode(m) { areaMode = m; renderProviderProfile(); loadAreaCoverage(); }
+async function loadAreaCoverage() {
+  try {
+    const rows = await sbRpc('my_service_area_suburbs', {});
+    areaCoverage = rows.map(r => r.name);
+  } catch (e) { areaCoverage = []; }
+  const el = document.getElementById('sa-coverage');
+  if (el) el.innerHTML = coverageLine(areaCoverage);
+}
+async function saveServiceArea(mode) {
+  const v = parseInt(document.getElementById('sa-value').value, 10);
+  const btn = document.getElementById('sa-save'); const msg = document.getElementById('sa-msg');
+  btn.disabled = true; btn.textContent = mode === 'travel' ? 'Mapping your area…' : 'Saving…';
+  msg.textContent = ''; msg.className = 'msg';
+  try {
+    const body = mode === 'travel'
+      ? { action: 'set_service_area', mode: 'travel', minutes: v }
+      : { action: 'set_service_area', mode: 'radius', radius_km: v };
+    const r = await sbFn('geo-api', body);
+    if (mode === 'travel') { profileRow.travel_time_mins = v; } else { profileRow.radius_km = v; profileRow.travel_time_mins = null; }
+    areaCoverage = r.covered || [];
+    renderProviderProfile();
+    showMsg('Service area saved — search now matches you to those suburbs.', 'success');
+  } catch (e) {
+    msg.textContent = e.message; msg.className = 'msg error';
+    btn.disabled = false; btn.textContent = 'Save service area';
+  }
 }
 
 /* ── Cancel flow ── */
@@ -1467,10 +1535,11 @@ async function init() {
 
     if (userData.role === 'provider') {
       profileTable = 'provider_profiles';
-      const profiles = await sbGet('provider_profiles', `user_id=eq.${authUid}&select=id,suburb`);
+      const profiles = await sbGet('provider_profiles', `user_id=eq.${authUid}&select=id,suburb,radius_km,travel_time_mins`);
       profileRow = profiles.length ? profiles[0] : null;
       renderNav();
       renderProviderProfile();
+      loadAreaCoverage();
       return;
     }
 

--- a/supabase/functions/geo-api/index.ts
+++ b/supabase/functions/geo-api/index.ts
@@ -1,0 +1,88 @@
+// TRU-156: carer service-area management (travel-time isochrones + radius).
+// verify_jwt is DISABLED (the browser CORS preflight carries no JWT — same
+// reasoning as stripe-api); the caller is authenticated in-function via
+// auth.getUser. The OpenRouteService key lives in private.geo_config and is
+// read through a service_role-only definer fn — the private schema is not
+// REST-exposed (the TRU-138 lesson).
+//
+// The isochrone is computed ONCE per settings save and stored as a polygon on
+// provider_profiles; search_carers does ST_Covers against it with a radius
+// fallback, so search itself never calls a routing API.
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
+const SERVICE_ROLE = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+const sb = createClient(SUPABASE_URL, SERVICE_ROLE);
+
+const CORS: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, content-type, apikey',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { ...CORS, 'Content-Type': 'application/json' } });
+}
+
+const TRAVEL_MINUTES = [10, 15, 20, 30, 45, 60];
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: CORS });
+  if (req.method !== 'POST') return json({ error: 'Method not allowed' }, 405);
+
+  const jwt = (req.headers.get('Authorization') || '').replace(/^Bearer\s+/i, '');
+  const { data: { user }, error: uerr } = await sb.auth.getUser(jwt);
+  if (uerr || !user) return json({ error: 'Not authenticated' }, 401);
+
+  let payload: Record<string, unknown> = {};
+  try { payload = await req.json(); } catch { /* empty body ok */ }
+  const action = String(payload.action || '');
+
+  try {
+    if (action === 'set_service_area') {
+      const mode = String(payload.mode || '');
+
+      if (mode === 'radius') {
+        const km = Math.round(Number(payload.radius_km));
+        if (!(km >= 1 && km <= 30)) return json({ error: 'Radius must be between 1 and 30 km' }, 400);
+        const { data, error } = await sb.rpc('apply_radius_area', { p_user_id: user.id, p_radius_km: km });
+        if (error) return json({ error: error.message }, 500);
+        return json(data);
+      }
+
+      if (mode === 'travel') {
+        const mins = Math.round(Number(payload.minutes));
+        if (!TRAVEL_MINUTES.includes(mins)) {
+          return json({ error: `Travel time must be one of ${TRAVEL_MINUTES.join('/')} minutes` }, 400);
+        }
+        const { data: lnglat } = await sb.rpc('provider_lnglat', { p_user_id: user.id });
+        if (!lnglat) return json({ error: 'Set your suburb first so we know where home is' }, 400);
+        const { data: key } = await sb.rpc('get_geo_config');
+        if (!key) return json({ error: 'Travel-time areas are not configured yet' }, 503);
+
+        const res = await fetch('https://api.openrouteservice.org/v2/isochrones/driving-car', {
+          method: 'POST',
+          headers: { Authorization: key as string, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ locations: [lnglat], range: [mins * 60] }),
+        });
+        const iso = await res.json();
+        const geometry = iso?.features?.[0]?.geometry;
+        if (!res.ok || !geometry) {
+          console.error('ORS error', res.status, JSON.stringify(iso).slice(0, 300));
+          return json({ error: 'Could not compute your travel-time area — try again shortly' }, 502);
+        }
+        const { data, error } = await sb.rpc('apply_service_area', { p_user_id: user.id, p_geojson: geometry, p_minutes: mins });
+        if (error) return json({ error: error.message }, 500);
+        return json(data);
+      }
+
+      return json({ error: 'Unknown mode' }, 400);
+    }
+
+    return json({ error: `Unknown action: ${action}` }, 400);
+  } catch (e) {
+    console.error('geo-api error', action, e);
+    return json({ error: String((e as Error)?.message || e) }, 500);
+  }
+});

--- a/supabase/migrations/20260704000000_tru156_travel_time_areas.sql
+++ b/supabase/migrations/20260704000000_tru156_travel_time_areas.sql
@@ -1,0 +1,183 @@
+-- TRU-156 (search stage 2): travel-time service areas.
+--
+-- A carer can now set "up to N minutes from home" instead of a crow-flies
+-- radius. The isochrone polygon is computed ONCE per settings save (geo-api
+-- edge function → OpenRouteService) and stored on the profile; search stays
+-- pure PostGIS — ST_Covers against the polygon when present, radius fallback
+-- otherwise — so there are no per-search API calls and no search-UI changes.
+-- This fixes the crow-flies failure at Sydney's water crossings (Manly ↔
+-- Watsons Bay: ~5km straight line, 45+ min by road).
+--
+-- The ORS API key lives in private.geo_config, populated OUT OF BAND (not in
+-- git), same pattern as private.email_config / stripe_config:
+--   insert into private.geo_config (id, ors_api_key) values (1, '<key>')
+--   on conflict (id) do update set ors_api_key = excluded.ors_api_key;
+--
+-- Applied to the live DB via apply_migration; committed for version control.
+
+alter table public.provider_profiles
+  add column if not exists travel_time_mins integer,
+  add column if not exists service_area geography(MultiPolygon,4326);
+create index if not exists idx_provider_service_area
+  on public.provider_profiles using gist (service_area);
+
+create table if not exists private.geo_config (
+  id int primary key default 1,
+  ors_api_key text not null,
+  enabled boolean not null default true,
+  constraint geo_config_single_row check (id = 1)
+);
+alter table private.geo_config enable row level security;
+-- no policies: read only via the service_role getter below.
+
+-- If a carer moves suburb, the stored polygon is stale: clear it so search
+-- falls back to the radius until they re-save their service area.
+-- (In the geocode trigger's table this column doesn't exist for customers, so
+-- this is a separate provider-only trigger; plain row trigger because
+-- UPDATE-OF lists don't see columns modified by other BEFORE triggers.)
+create or replace function public.trg_provider_area_stale()
+returns trigger language plpgsql as $$
+begin
+  if NEW.location is distinct from OLD.location then
+    NEW.service_area := null;
+  end if;
+  return NEW;
+end;
+$$;
+revoke execute on function public.trg_provider_area_stale() from public, anon, authenticated;
+drop trigger if exists provider_area_stale on public.provider_profiles;
+create trigger provider_area_stale
+  before update on public.provider_profiles
+  for each row execute function public.trg_provider_area_stale();
+
+-- ── geo-api helpers (service_role only — the edge fn authenticates the carer
+--    itself via auth.getUser, then acts through these) ─────────────────────────
+create or replace function public.get_geo_config()
+returns text language sql stable security definer set search_path = public as $$
+  select ors_api_key from private.geo_config where id = 1 and enabled;
+$$;
+revoke all on function public.get_geo_config() from public, anon, authenticated;
+grant execute on function public.get_geo_config() to service_role;
+
+create or replace function public.provider_lnglat(p_user_id uuid)
+returns jsonb language sql stable security definer set search_path = public as $$
+  select case when location is null then null
+    else jsonb_build_array(st_x(location::geometry), st_y(location::geometry)) end
+  from public.provider_profiles where user_id = p_user_id;
+$$;
+revoke all on function public.provider_lnglat(uuid) from public, anon, authenticated;
+grant execute on function public.provider_lnglat(uuid) to service_role;
+
+-- Store the isochrone and return the covered-suburb preview in one round trip.
+create or replace function public.apply_service_area(p_user_id uuid, p_geojson jsonb, p_minutes integer)
+returns jsonb language plpgsql security definer set search_path = public as $$
+declare
+  g geography;
+  covered jsonb;
+begin
+  g := st_multi(st_setsrid(st_geomfromgeojson(p_geojson::text), 4326))::geography;
+  update public.provider_profiles
+     set service_area = g, travel_time_mins = p_minutes, updated_at = now()
+   where user_id = p_user_id;
+  select coalesce(jsonb_agg(s.name order by st_distance(s.centroid, pp.location)), '[]'::jsonb)
+    into covered
+  from public.provider_profiles pp
+  join public.suburbs s on st_covers(pp.service_area, s.centroid)
+  where pp.user_id = p_user_id;
+  return jsonb_build_object('mode', 'travel', 'minutes', p_minutes, 'covered', covered);
+end;
+$$;
+revoke all on function public.apply_service_area(uuid, jsonb, integer) from public, anon, authenticated;
+grant execute on function public.apply_service_area(uuid, jsonb, integer) to service_role;
+
+create or replace function public.apply_radius_area(p_user_id uuid, p_radius_km integer)
+returns jsonb language plpgsql security definer set search_path = public as $$
+declare covered jsonb;
+begin
+  update public.provider_profiles
+     set radius_km = p_radius_km, travel_time_mins = null, service_area = null, updated_at = now()
+   where user_id = p_user_id;
+  select coalesce(jsonb_agg(s.name order by st_distance(s.centroid, pp.location)), '[]'::jsonb)
+    into covered
+  from public.provider_profiles pp
+  join public.suburbs s on st_dwithin(s.centroid, pp.location, p_radius_km * 1000)
+  where pp.user_id = p_user_id;
+  return jsonb_build_object('mode', 'radius', 'radius_km', p_radius_km, 'covered', covered);
+end;
+$$;
+revoke all on function public.apply_radius_area(uuid, integer) from public, anon, authenticated;
+grant execute on function public.apply_radius_area(uuid, integer) to service_role;
+
+-- Current coverage for the carer's own settings card (works for either mode).
+create or replace function public.my_service_area_suburbs()
+returns table (name text, distance_km numeric)
+language sql stable security definer set search_path = public as $$
+  select s.name, round((st_distance(s.centroid, pp.location) / 1000.0)::numeric, 1)
+  from public.provider_profiles pp
+  join public.suburbs s on (
+    (pp.service_area is not null and st_covers(pp.service_area, s.centroid))
+    or (pp.service_area is null and st_dwithin(s.centroid, pp.location, greatest(coalesce(pp.radius_km, 5), 1) * 1000))
+  )
+  where pp.user_id = (select auth.uid()) and pp.location is not null
+  order by 2
+  limit 80;
+$$;
+revoke all on function public.my_service_area_suburbs() from public, anon;
+grant execute on function public.my_service_area_suburbs() to authenticated;
+
+-- ── Search: polygon first, radius fallback (signature + outputs unchanged) ────
+create or replace function public.search_carers(
+  p_suburb text default null,
+  p_postcode text default null,
+  p_date date default null
+) returns table (
+  id uuid, user_id uuid, first_name text, last_name text, avatar_url text,
+  bio text, suburb text, radius_km integer, is_verified boolean, is_active boolean,
+  avg_rating numeric, total_reviews integer, services json, created_at timestamptz,
+  distance_km numeric, nearby_same_day boolean
+)
+language sql stable security definer set search_path = public as $$
+  with pt as (
+    select public.suburb_centroid(p_suburb, p_postcode) as g
+  )
+  select pp.id, pp.user_id, u.first_name, u.last_name, u.avatar_url,
+    pp.bio, pp.suburb, pp.radius_km, pp.is_verified, pp.is_active,
+    pp.avg_rating, pp.total_reviews,
+    coalesce(json_agg(ps.service_type order by ps.service_type)
+             filter (where ps.service_type is not null), '[]'::json) as services,
+    pp.created_at,
+    case when (select g from pt) is not null and pp.location is not null
+         then round((st_distance(pp.location, (select g from pt)) / 1000.0)::numeric, 1)
+    end as distance_km,
+    case when p_date is not null and (select g from pt) is not null then exists (
+      select 1
+      from public.bookings b
+      join public.customer_profiles cp on cp.id = b.customer_id
+      where b.provider_id = pp.id
+        and b.status in ('confirmed', 'in_progress')
+        and not coalesce(b.is_meet_and_greet, false)
+        and (b.scheduled_at at time zone 'Australia/Sydney')::date = p_date
+        and cp.location is not null
+        and st_dwithin(cp.location, (select g from pt), 3000)
+    ) else false end as nearby_same_day
+  from public.provider_profiles pp
+  join public.users u on u.id = pp.user_id
+  left join public.provider_services ps on ps.provider_id = pp.user_id and ps.is_available = true
+  where pp.is_active = true
+    and (
+      nullif(trim(coalesce(p_suburb, '')), '') is null
+      or ((select g from pt) is not null and pp.location is not null and (
+            (pp.service_area is not null and st_covers(pp.service_area, (select g from pt)))
+            or (pp.service_area is null
+                and st_dwithin(pp.location, (select g from pt), greatest(coalesce(pp.radius_km, 5), 1) * 1000))
+          ))
+      or (((select g from pt) is null or pp.location is null)
+          and pp.suburb ilike '%' || p_suburb || '%')
+    )
+  group by pp.id, pp.user_id, u.first_name, u.last_name, u.avatar_url, pp.bio,
+           pp.suburb, pp.radius_km, pp.is_verified, pp.is_active, pp.avg_rating,
+           pp.total_reviews, pp.created_at, pp.location, pp.service_area
+  order by nearby_same_day desc, distance_km asc nulls last, pp.avg_rating desc nulls last
+$$;
+revoke all on function public.search_carers(text, text, date) from public;
+grant execute on function public.search_carers(text, text, date) to anon, authenticated;


### PR DESCRIPTION
## What

Carers can now set their service area as **"up to N minutes' drive from home"** instead of a crow-flies circle. The isochrone polygon is computed **once** per settings save (new `geo-api` edge fn → OpenRouteService) and stored on the profile — `search_carers` checks `ST_Covers(polygon, point)` first with the radius as fallback, so search itself makes **zero routing-API calls** and needed no UI changes.

Also delivers the **carer service-area editor** deferred from stage 1: Distance/Travel-time toggle + live "covers N suburbs: Cremorne, Neutral Bay, …" preview in the provider profile, with the dashboard header showing "30 min service area".

## The proof (live, test provider placed in Mosman)

| Check | Result |
|---|---|
| 8 km radius coverage | 128 suburbs (circle spans the harbour) |
| 15 min drive coverage | **58 suburbs** — everything close-on-map/far-by-road trimmed |
| Rose Bay (5.6 km crow-flies, across the harbour) | old radius **would match** ❌ → polygon search **correctly doesn't** ✅ |
| Cremorne (same side, short drive) | matches ✅ |
| Regression: `search_carers('Homebush')` | same four carers as stage 1 ✅ |
| Invalid minutes | 400 with allowed values ✅ |

## Notes

- ORS key lives in `private.geo_config` (email/stripe-config pattern, out of band — free tier: ~500 isochrones/day, only consumed on settings saves).
- If a carer changes suburb, the stored polygon is auto-cleared (stale) and search falls back to their radius until they re-save.
- Existing carers are untouched until they open the new editor — pure radius behaviour until then.
- This also upgrades the "covered suburbs" preview honesty story from the TRU-154 discussion: carers see exactly what their setting means on land.

Migration applied via `apply_migration`; `geo-api` deployed (v1). Closes TRU-156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)