### PR TITLE
TRU-121: "Can't find a carer" service — request submission + passive signal

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -131,7 +131,7 @@ async function onLogin(e) {
 }
 
 // ── Console shell ──
-const SECTIONS = [ { id:'refunds', label:'Refunds' }, { id:'cover', label:'Cover' } ];
+const SECTIONS = [ { id:'refunds', label:'Refunds' }, { id:'cover', label:'Cover' }, { id:'requests', label:'Requests' } ];
 function showConsole() {
   currentSection = SECTIONS.some(s => s.id === currentSection) ? currentSection : 'refunds';
   app().innerHTML = `
@@ -154,6 +154,7 @@ function renderSection(name) {
   const c = document.getElementById('adm-content');
   if (name === 'refunds') return renderRefunds(c);
   if (name === 'cover') return renderCover(c);
+  if (name === 'requests') return renderRequests(c);
   c.innerHTML = '<p class="empty">Coming soon.</p>';
 }
 
@@ -241,6 +242,111 @@ async function creditRedeem(id) {
     await sbFn('stripe-api', { action:'credit_redeem', credit_id:id, note });
     admMsg('Credit marked applied ✓', 'ok');
     renderCover(document.getElementById('adm-content'));
+  } catch (e) { admMsg(e.message, 'error'); }
+}
+
+// ── Requests section (TRU-121: "can't find a carer") ──
+const SVC_LABELS = { dog_walking:'Dog walking', dog_sitting:'Dog sitting', dog_boarding:'Dog boarding', dog_daycare:'Dog daycare', drop_in:'Drop-in visit', pet_sitting:'Pet sitting' };
+function svcLabel(t) { return t ? (SVC_LABELS[t] || t) : 'Any service'; }
+function reqWhen(rq) {
+  const bits = [];
+  if (rq.wanted_date) bits.push(rq.wanted_date);
+  else if (rq.recurring) bits.push('Recurring');
+  else bits.push('Flexible date');
+  if (rq.window_start) bits.push(rq.window_start + (rq.window_end ? '–' + rq.window_end : ''));
+  return bits.join(' · ');
+}
+function requestCard(rq) {
+  const dog = [rq.dog_size, rq.puppy ? 'puppy' : ''].filter(Boolean).join(' · ');
+  const acct = rq.can_assign ? '<span class="badge b-paid">assignable</span>'
+    : rq.customer_id ? '<span class="badge b-refunded">no pet</span>'
+    : '<span class="badge b-refunded">guest</span>';
+  const dtVal = rq.wanted_date ? (rq.wanted_date + 'T' + (rq.window_start || '09:00')) : '';
+  const assignUi = rq.can_assign ? `
+    <div class="actions">
+      <label style="font-size:0.8rem;color:var(--muted);">Start</label>
+      <input class="reason" id="reqdt-${rq.id}" type="datetime-local" value="${dtVal}" style="flex:0 1 auto;min-width:0;">
+      <button class="btn" onclick="reqFindCarers('${rq.id}')">Find carers</button>
+    </div>
+    <div id="reqcarers-${rq.id}"></div>` : '';
+  return `<div class="card" id="reqcard-${rq.id}">
+    <div class="row-top"><div><b>${esc(svcLabel(rq.service_type))}</b> in ${esc(rq.suburb || '—')} ${acct}</div><div class="meta">${when(rq.created_at)}</div></div>
+    <div class="meta">${esc(rq.contact)}${rq.email ? ' · ' + esc(rq.email) : ''}${rq.pet ? ' · pet: ' + esc(rq.pet) : ''}</div>
+    <div class="meta">${esc(reqWhen(rq))}${dog ? ' · ' + esc(dog) : ''}</div>
+    ${rq.note ? `<div class="meta">“${esc(rq.note)}”</div>` : ''}
+    ${rq.status === 'onboarding' ? '<div class="meta"><b>Onboarding a new carer</b></div>' : ''}
+    ${assignUi}
+    <div class="actions">
+      <input class="reason" id="reqnote-${rq.id}" placeholder="Admin note (optional)" value="${esc(rq.admin_note || '')}">
+      <button class="btn" style="background:#fff;color:var(--terracottaDark);" onclick="reqUpdate('${rq.id}','onboarding')">Onboarding</button>
+      <button class="btn" style="background:#fff;color:var(--terracottaDark);" onclick="reqUpdate('${rq.id}','closed')">Close</button>
+    </div>
+  </div>`;
+}
+function signalRow(s) {
+  return `<div class="meta">${esc(s.suburb)} · ${esc(svcLabel(s.service_type).toLowerCase())} <b>×${s.count}</b></div>`;
+}
+async function renderRequests(c) {
+  c.innerHTML = '<div id="adm-msg" class="msg"></div><p class="empty">Loading…</p>';
+  try {
+    const { requests, signal } = await sbFn('stripe-api', { action:'requests_list' });
+    const reqHtml = (requests && requests.length) ? requests.map(requestCard).join('') : '<p class="empty">No open requests.</p>';
+    const sigHtml = (signal && signal.length) ? signal.map(signalRow).join('') : '<p class="empty">No unmet searches in the last 30 days.</p>';
+    c.innerHTML = `
+      <p class="sub" style="margin-bottom:14px;">Customers who couldn't find a carer. "Find carers" surfaces nearby matches you can assign — this creates a pending booking request the carer accepts and messages the customer. Guest requests (no linked pet) can't be auto-assigned — reply by email, or mark onboarding/closed.</p>
+      <div id="adm-msg" class="msg"></div>
+      ${reqHtml}
+      <h1 style="font-size:1.2rem;margin:22px 0 8px;">Unmet searches (30d)</h1>
+      <p class="sub" style="margin-bottom:10px;">Zero-result searches — demand even when nobody submitted a request.</p>
+      ${sigHtml}`;
+  } catch (e) {
+    if (e.message === 'Not authenticated') return signOut();
+    c.innerHTML = `<p class="empty">${esc(e.message)}</p>`;
+  }
+}
+function carerCandidate(reqId, cr) {
+  const dist = (cr.distance_km != null) ? cr.distance_km + ' km' : '';
+  const rating = cr.avg_rating ? '★' + (+cr.avg_rating).toFixed(1) : 'new';
+  const svcBtns = (cr.services || []).map(s => {
+    const label = svcLabel(s.service_type) + (s.price_cents != null ? ' ' + money(s.price_cents) : '') + (s.duration_mins ? ' / ' + s.duration_mins + 'm' : '');
+    return `<button class="btn" onclick="reqAssign('${reqId}','${cr.provider_id}','${s.id}')">Assign · ${esc(label)}</button>`;
+  }).join(' ');
+  return `<div class="card" style="margin:8px 0 0;background:var(--cream);">
+    <div class="row-top"><div><b>${esc(cr.name)}</b>${cr.is_verified ? ' <span class="badge b-paid">verified</span>' : ''}</div><div class="meta">${esc(cr.suburb || '')}${dist ? ' · ' + dist : ''} · ${rating}</div></div>
+    <div class="actions">${svcBtns || '<span class="meta">No matching service</span>'}</div>
+  </div>`;
+}
+async function reqFindCarers(id) {
+  const box = document.getElementById('reqcarers-' + id);
+  box.innerHTML = '<p class="meta">Searching…</p>';
+  try {
+    const { carers } = await sbFn('stripe-api', { action:'request_find_carers', request_id:id });
+    box.innerHTML = (carers && carers.length)
+      ? carers.map(cr => carerCandidate(id, cr)).join('')
+      : '<p class="meta">No matching carers nearby — onboarding may be the move.</p>';
+  } catch (e) { box.innerHTML = `<p class="meta" style="color:var(--error);">${esc(e.message)}</p>`; }
+}
+async function reqAssign(reqId, providerId, serviceId) {
+  const dtEl = document.getElementById('reqdt-' + reqId);
+  const dt = dtEl && dtEl.value ? dtEl.value : '';
+  if (!dt) { admMsg('Set a start date/time first.', 'error'); return; }
+  if (!confirm('Assign this carer? It creates a pending booking request they can accept, and messages the customer.')) return;
+  admMsg('');
+  try {
+    const iso = new Date(dt).toISOString(); // datetime-local (browser local) → UTC ISO
+    await sbFn('stripe-api', { action:'request_assign', request_id:reqId, provider_id:providerId, service_id:serviceId, scheduled_at:iso });
+    admMsg('Carer assigned ✓ — booking request created and customer notified.', 'ok');
+    renderRequests(document.getElementById('adm-content'));
+  } catch (e) { admMsg(e.message, 'error'); }
+}
+async function reqUpdate(reqId, status) {
+  const note = (document.getElementById('reqnote-' + reqId) || {}).value || '';
+  if (status === 'closed' && !confirm('Close this request?')) return;
+  admMsg('');
+  try {
+    await sbFn('stripe-api', { action:'request_update', request_id:reqId, status, admin_note:note });
+    admMsg(status === 'closed' ? 'Request closed ✓' : 'Marked onboarding ✓', 'ok');
+    renderRequests(document.getElementById('adm-content'));
   } catch (e) { admMsg(e.message, 'error'); }
 }
 

--- a/search/index.html
+++ b/search/index.html
@@ -208,6 +208,20 @@
   .empty-state p, .error-state p { color: var(--text-muted); font-size: 0.9rem; max-width: 420px; margin: 0 auto 1.25rem; line-height: 1.55; }
   .btn-secondary { padding: 10px 20px; background: transparent; border: 1px solid var(--border); border-radius: 999px; color: var(--text-secondary); font-family: 'DM Sans', sans-serif; font-size: 0.85rem; cursor: pointer; transition: border-color 0.2s, color 0.2s; }
   .btn-secondary:hover { border-color: var(--text-muted); color: var(--text-primary); }
+  /* ── TRU-121: "can't find a carer" request box ── */
+  .request-box { text-align: center; margin-top: 1rem; padding: 2rem 1.75rem; background: var(--terracotta-soft); border: 1px solid var(--blush); border-radius: 14px; }
+  .request-box h3 { font-family: 'Cormorant Garamond', serif; font-size: 1.35rem; font-weight: 500; color: var(--brown); margin: 0 0 0.5rem; }
+  .request-box p { color: var(--text-secondary); font-size: 0.9rem; max-width: 440px; margin: 0 auto 1.1rem; line-height: 1.55; }
+  .request-box.request-done { background: var(--success-bg); border-color: var(--sage-light); }
+  .btn-primary { padding: 11px 24px; background: var(--terracotta); border: 1px solid var(--terracotta); border-radius: 999px; color: #fff; font-family: 'DM Sans', sans-serif; font-size: 0.88rem; font-weight: 500; cursor: pointer; transition: background 0.2s; }
+  .btn-primary:hover { background: var(--terracotta-light); }
+  .btn-primary:disabled { opacity: 0.6; cursor: default; }
+  .req-lbl { display: block; font-size: 0.82rem; font-weight: 500; color: var(--text-secondary); margin: 12px 0 5px; }
+  .req-fld { width: 100%; padding: 10px 12px; border: 1px solid var(--border); border-radius: 10px; font-family: 'DM Sans', sans-serif; font-size: 0.9rem; color: var(--text-primary); background: var(--warm-white); }
+  .req-fld:focus { outline: none; border-color: var(--border-focus); }
+  .req-msg { font-size: 0.84rem; min-height: 1em; margin: 10px 0; color: var(--text-muted); }
+  .req-msg.error { color: var(--terracotta); }
+  #reqForm .btn-primary { margin-top: 8px; }
 
   /* ── Mobile ── */
   @media (max-width: 768px) {
@@ -390,6 +404,8 @@ let allAttrMap = null;
 let renderedProviders = [];
 let myPets = [];
 let isLoading = false;
+const loggedMisses = new Set(); // TRU-121: dedupe passive zero-result signals per session
+let requestSubmitted = false;   // TRU-121: switch the empty-state CTA to a thank-you once sent
 
 const state = {
   suburb: '', service: '', recurring: false, date: '', dateEnd: '', time: '',
@@ -1086,6 +1102,100 @@ function renderCard(p) {
   `;
 }
 
+/* ── TRU-121: "can't find a carer" — passive signal + request form ── */
+function sbRpc(fn, body) {
+  // Works for guests (anon key) and signed-in users (their token) alike.
+  return fetch(`${SUPABASE_URL}/rest/v1/rpc/${fn}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'apikey': SUPABASE_ANON_KEY, 'Authorization': `Bearer ${authToken || SUPABASE_ANON_KEY}` },
+    body: JSON.stringify(body),
+  });
+}
+function logSearchMiss() {
+  if (!state.suburb) return; // no suburb = no useful signal
+  const key = state.suburb + '|' + (state.service || '');
+  if (loggedMisses.has(key)) return; // once per distinct suburb+service this session
+  loggedMisses.add(key);
+  sbRpc('log_search_miss', { p_suburb: state.suburb, p_service: state.service || null }).catch(() => {});
+}
+function requestCtaHtml() {
+  if (requestSubmitted) {
+    return `<div class="request-box request-done fade-in">
+      <h3>We're on it 🐾</h3>
+      <p>Thanks — we've got your request and we'll be in touch as soon as we've lined up a carer for you.</p>
+    </div>`;
+  }
+  const loggedIn = !!authUid;
+  const petPicker = (loggedIn && myPets.length)
+    ? `<label class="req-lbl">Which pet?</label>
+       <select class="req-fld" id="reqPet">${myPets.map(p => `<option value="${esc(p.id)}">${esc(p.name)}${p.breed ? ' · ' + esc(p.breed) : ''}</option>`).join('')}</select>`
+    : '';
+  const contactFields = loggedIn ? '' : `
+       <label class="req-lbl">Your name</label>
+       <input class="req-fld" id="reqName" type="text" placeholder="First name" autocomplete="given-name">
+       <label class="req-lbl">Email</label>
+       <input class="req-fld" id="reqEmail" type="email" placeholder="you@example.com" autocomplete="email" required>`;
+  return `
+    <div class="request-box fade-in">
+      <h3>Can't find the right carer?</h3>
+      <p>Tell us what you need and we'll find one for you — from our carers, or someone new we go and vet.</p>
+      <button class="btn-primary" id="btnReqOpen" type="button">Let us find you a carer →</button>
+      <form id="reqForm" style="display:none;margin-top:14px;text-align:left;max-width:440px;margin-left:auto;margin-right:auto;">
+        ${petPicker}${contactFields}
+        <label class="req-lbl">Anything else? <span style="color:var(--text-muted);font-weight:400;">(optional)</span></label>
+        <textarea class="req-fld" id="reqNote" rows="2" placeholder="Dates, your dog, what matters to you…"></textarea>
+        <div id="reqMsg" class="req-msg"></div>
+        <button class="btn-primary" id="btnReqSubmit" type="submit">Send request</button>
+      </form>
+    </div>`;
+}
+function wireRequestCta() {
+  const openBtn = document.getElementById('btnReqOpen');
+  if (openBtn) openBtn.addEventListener('click', () => {
+    document.getElementById('reqForm').style.display = 'block';
+    openBtn.style.display = 'none';
+  });
+  const form = document.getElementById('reqForm');
+  if (form) form.addEventListener('submit', submitCarerRequest);
+}
+async function submitCarerRequest(e) {
+  e.preventDefault();
+  const msg = document.getElementById('reqMsg');
+  const btn = document.getElementById('btnReqSubmit');
+  const emailEl = document.getElementById('reqEmail');
+  const nameEl = document.getElementById('reqName');
+  const petEl = document.getElementById('reqPet');
+  const noteEl = document.getElementById('reqNote');
+  if (!authUid && emailEl && !emailEl.value.trim()) {
+    msg.textContent = 'Please leave an email so we can reach you.'; msg.className = 'req-msg error'; return;
+  }
+  btn.disabled = true; btn.textContent = 'Sending…'; msg.textContent = ''; msg.className = 'req-msg';
+  const body = {
+    p_suburb: state.suburb || null,
+    p_service_type: state.service || null,
+    p_wanted_date: (!state.recurring && state.date) ? state.date : null,
+    p_recurring: !!state.recurring,
+    p_window_start: state.windowStart || null,
+    p_window_end: state.windowEnd || null,
+    p_dog_size: state.size || null,
+    p_puppy: !!state.puppy,
+    p_pet_id: (authUid && petEl) ? petEl.value : null,
+    p_contact_name: nameEl ? nameEl.value.trim() : null,
+    p_contact_email: emailEl ? emailEl.value.trim() : null,
+    p_note: noteEl ? noteEl.value.trim() : null,
+    p_search_params: state,
+  };
+  try {
+    const r = await sbRpc('submit_carer_request', body);
+    if (!r.ok) { const d = await r.json().catch(() => ({})); throw new Error(d.message || 'Could not send (' + r.status + ')'); }
+    requestSubmitted = true;
+    renderResults(renderedProviders); // re-render the empty state → thank-you
+  } catch (err) {
+    msg.textContent = err.message || 'Something went wrong — please try again.'; msg.className = 'req-msg error';
+    btn.disabled = false; btn.textContent = 'Send request';
+  }
+}
+
 /* ── Render results ── */
 function renderResults(list) {
   const area = document.getElementById('resultsArea');
@@ -1099,6 +1209,7 @@ function renderResults(list) {
   if (sortSel.value !== state.sort) sortSel.value = state.sort;
 
   if (list.length === 0) {
+    logSearchMiss(); // TRU-121: passive demand signal for a zero-result search
     area.innerHTML = `
       <div class="empty-state fade-in">
         <div class="empty-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="6.5"></circle><path d="M16 16l4 4"></path></svg></div>
@@ -1106,8 +1217,10 @@ function renderResults(list) {
         <p>Try expanding your search area, choosing a different service, or removing some filters.</p>
         <button class="btn-secondary" id="btnEmptyClear">Clear filters</button>
       </div>
+      ${requestCtaHtml()}
     `;
     document.getElementById('btnEmptyClear').addEventListener('click', clearFilters);
+    wireRequestCta();
     return;
   }
 

--- a/supabase/functions/send-notification/index.ts
+++ b/supabase/functions/send-notification/index.ts
@@ -112,7 +112,7 @@ async function loadBooking(bookingId: string) {
 
 // ── Build the email for an event → { to[], subject, html } messages ──
 async function buildMessages(type: string, payload: Record<string, unknown>) {
-  const out: { to: string; subject: string; html: string }[] = [];
+  const out: { to: string; subject: string; html: string; replyTo?: string }[] = [];
 
   if (type === 'booking_request') {
     const d = await loadBooking(payload.booking_id as string);
@@ -231,6 +231,70 @@ async function buildMessages(type: string, payload: Record<string, unknown>) {
         }),
       });
     }
+  } else if (type === 'carer_request') {
+    // TRU-121: a customer (or guest) couldn't find a carer and asked us to find one.
+    // Page every admin with the request details; reply-to is the requester so an admin can
+    // respond straight from their inbox.
+    const { data: rq } = await sb.from('carer_requests').select('*').eq('id', payload.request_id as string).single();
+    if (!rq) return out;
+    const { data: admins } = await sb.from('users').select('email,first_name').eq('is_admin', true);
+    if (!admins?.length) return out;
+
+    // Contact details come from the linked account when signed in, else the guest fields.
+    let contactName: string | null = rq.contact_name;
+    let contactEmail: string | null = rq.contact_email;
+    let petName: string | null = null;
+    if (rq.customer_id) {
+      const { data: cp } = await sb.from('customer_profiles').select('user_id').eq('id', rq.customer_id).single();
+      if (cp?.user_id) {
+        const { data: u } = await sb.from('users').select('email,first_name,last_name').eq('id', cp.user_id).single();
+        contactName = contactName || `${u?.first_name || ''} ${u?.last_name || ''}`.trim() || null;
+        contactEmail = contactEmail || u?.email || null;
+      }
+    }
+    if (rq.pet_id) {
+      const { data: pet } = await sb.from('pets').select('name').eq('id', rq.pet_id).single();
+      petName = pet?.name || null;
+    }
+
+    const serviceLabel = rq.service_type ? (SERVICE_LABELS[rq.service_type] || rq.service_type) : 'Any service';
+    const whenStr = rq.wanted_date
+      ? new Date(`${rq.wanted_date}T00:00:00`).toLocaleDateString('en-AU', { weekday: 'short', day: 'numeric', month: 'short', timeZone: 'Australia/Sydney' })
+      : (rq.recurring ? 'Recurring' : 'Flexible');
+    const windowStr = rq.window_start ? `${rq.window_start}${rq.window_end ? '–' + rq.window_end : ''}` : '—';
+    const canAssign = !!(rq.customer_id && rq.pet_id);
+
+    const rows: [string, string][] = [
+      ['Suburb', rq.suburb || '—'],
+      ['Service', serviceLabel],
+      ['When', whenStr],
+      ['Time window', windowStr],
+      ['Dog', [rq.dog_size, rq.puppy ? 'puppy' : ''].filter(Boolean).join(' · ') || '—'],
+      ['From', contactName || (rq.customer_id ? 'Registered customer' : 'Guest')],
+      ['Email', contactEmail || '—'],
+      ['Account', rq.customer_id ? `Signed-in${rq.pet_id ? ` · pet: ${petName || 'selected'}` : ' · no pet selected'}` : 'Guest (not signed up)'],
+    ];
+
+    const requester = contactName || 'Someone';
+    for (const admin of admins) {
+      if (!admin.email) continue;
+      out.push({
+        to: admin.email,
+        replyTo: contactEmail || undefined,
+        subject: `🔎 Carer request — ${serviceLabel} in ${rq.suburb || 'unknown suburb'}`,
+        html: layout({
+          preview: `${requester} couldn't find a carer in ${rq.suburb || 'their area'}`,
+          heading: 'Someone needs a carer',
+          body: p(`${esc(requester)} searched and couldn't find the right carer. Here's what they're after:`) +
+            detailsTable(rows) +
+            (rq.note ? p(`<b>Their note:</b> ${esc(rq.note)}`) : '') +
+            p(canAssign
+              ? 'You can assign an existing carer straight from the console, or go find and onboard someone new.'
+              : 'Reply to this email to reach them, or work it from the console.'),
+          cta: { label: 'Open the admin console', href: `${SITE}/admin/` },
+        }),
+      });
+    }
   } else if (type === 'walk_started') {
     const { data: ws } = await sb.from('walk_sessions').select('booking_id').eq('id', payload.walk_session_id as string).single();
     if (!ws) return out;
@@ -310,12 +374,12 @@ async function buildMessages(type: string, payload: Record<string, unknown>) {
 }
 
 // ── Resend send with retry on 429 ──
-async function sendEmail(msg: { to: string; subject: string; html: string }) {
+async function sendEmail(msg: { to: string; subject: string; html: string; replyTo?: string }) {
   for (let attempt = 0; attempt < 4; attempt++) {
     const res = await fetch('https://api.resend.com/emails', {
       method: 'POST',
       headers: { Authorization: `Bearer ${RESEND_API_KEY}`, 'Content-Type': 'application/json' },
-      body: JSON.stringify({ from: FROM, reply_to: REPLY_TO, to: msg.to, subject: msg.subject, html: msg.html }),
+      body: JSON.stringify({ from: FROM, reply_to: msg.replyTo || REPLY_TO, to: msg.to, subject: msg.subject, html: msg.html }),
     });
     if (res.status !== 429) {
       const data = await res.json().catch(() => ({}));

--- a/supabase/functions/stripe-api/index.ts
+++ b/supabase/functions/stripe-api/index.ts
@@ -18,6 +18,10 @@
 //   cover_reassign  - (admin) take over a covered cancelled booking (TRU-139)
 //   cover_fell_through - (admin) mark cover as failed; issue a manual credit + owner message
 //   credit_redeem   - (admin) mark a manual credit as applied
+//   requests_list   - (admin) open "can't find a carer" requests + unmet-search signal (TRU-121)
+//   request_find_carers - (admin) candidate carers near a request (reuses search_carers)
+//   request_assign  - (admin) assign an existing carer -> creates a pending booking request
+//   request_update  - (admin) set a request's status + admin note (guest / onboarding path)
 //
 // Required function secrets (Supabase → Edge Functions → Secrets):
 //   STRIPE_SECRET_KEY   - sk_test_… (platform secret key)
@@ -446,6 +450,163 @@ Deno.serve(async (req) => {
         .update({ redeemed_at: new Date().toISOString(), redeemed_note: note || null })
         .eq('id', creditId).is('redeemed_at', null).select('id');
       if (upd.error || !upd.data?.length) return json({ error: 'Credit not found or already applied' }, 409);
+      return json({ ok: true });
+    }
+
+    // ── "Can't find a carer" requests (TRU-121) — admin actions ──
+
+    if (action === 'requests_list') {
+      if (!(await isAdmin(user.id))) return json({ error: 'Not authorised' }, 403);
+      const NONE = ['00000000-0000-0000-0000-000000000000'];
+      const { data: reqs } = await sb.from('carer_requests')
+        .select('*')
+        .in('status', ['open', 'onboarding'])
+        .order('created_at', { ascending: false })
+        .limit(50);
+      const rows = reqs || [];
+      const custIds = [...new Set(rows.map((r) => r.customer_id).filter(Boolean))] as string[];
+      const petIds = [...new Set(rows.map((r) => r.pet_id).filter(Boolean))] as string[];
+      const [{ data: cps }, { data: petsData }] = await Promise.all([
+        sb.from('customer_profiles').select('id,user_id').in('id', custIds.length ? custIds : NONE),
+        sb.from('pets').select('id,name').in('id', petIds.length ? petIds : NONE),
+      ]);
+      const custUser = Object.fromEntries((cps || []).map((c) => [c.id, c.user_id]));
+      const petName = Object.fromEntries((petsData || []).map((p) => [p.id, p.name]));
+      const uIds = [...new Set(Object.values(custUser))] as string[];
+      const { data: us } = await sb.from('users').select('id,first_name,last_name,email').in('id', uIds.length ? uIds : NONE);
+      const userBy = Object.fromEntries((us || []).map((u) => [u.id, u]));
+
+      // Passive signal — unmet searches over the last 30 days, aggregated by suburb + service.
+      const since = new Date(Date.now() - 30 * 864e5).toISOString();
+      const { data: misses } = await sb.from('search_misses').select('suburb,service_type').gte('created_at', since).limit(2000);
+      const aggMap: Record<string, number> = {};
+      (misses || []).forEach((m) => {
+        const k = `${m.suburb}||${m.service_type || ''}`;
+        aggMap[k] = (aggMap[k] || 0) + 1;
+      });
+      const signal = Object.entries(aggMap)
+        .map(([k, count]) => { const [suburb, service_type] = k.split('||'); return { suburb, service_type, count }; })
+        .sort((a, b) => b.count - a.count)
+        .slice(0, 20);
+
+      return json({
+        requests: rows.map((r) => {
+          const u = userBy[custUser[r.customer_id]];
+          return {
+            ...r,
+            contact: r.contact_name || (u ? `${u.first_name || ''} ${u.last_name || ''}`.trim() : '') || (r.customer_id ? 'Customer' : 'Guest'),
+            email: r.contact_email || (u ? u.email : '') || '',
+            pet: r.pet_id ? (petName[r.pet_id] || 'Dog') : '',
+            can_assign: !!(r.customer_id && r.pet_id),
+          };
+        }),
+        signal,
+      });
+    }
+
+    if (action === 'request_find_carers') {
+      if (!(await isAdmin(user.id))) return json({ error: 'Not authorised' }, 403);
+      const NONE = ['00000000-0000-0000-0000-000000000000'];
+      const { data: rq } = await sb.from('carer_requests')
+        .select('id,suburb,service_type,wanted_date,window_start')
+        .eq('id', String(payload.request_id || '')).maybeSingle();
+      if (!rq) return json({ error: 'Request not found' }, 404);
+      const { data: carers, error } = await sb.rpc('search_carers', { p_suburb: rq.suburb, p_date: rq.wanted_date });
+      if (error) return json({ error: error.message }, 500);
+      const list = (carers || []) as Record<string, unknown>[];
+      // Attach each carer's matching provider_services (id/price/duration) for the assign step.
+      // Note: provider_services.provider_id references users.id (the carer's user_id).
+      const userIds = list.map((c) => c.user_id as string).filter(Boolean);
+      const { data: svcs } = await sb.from('provider_services')
+        .select('id,provider_id,service_type,price_cents,duration_mins')
+        .in('provider_id', userIds.length ? userIds : NONE)
+        .eq('is_available', true);
+      const svcByUser: Record<string, Record<string, unknown>[]> = {};
+      (svcs || []).forEach((s) => { (svcByUser[s.provider_id] ||= []).push(s); });
+      const carersOut = list.map((c) => {
+        let services = svcByUser[c.user_id as string] || [];
+        if (rq.service_type) services = services.filter((s) => s.service_type === rq.service_type);
+        return {
+          provider_id: c.id, user_id: c.user_id,
+          name: `${c.first_name || ''} ${c.last_name || ''}`.trim() || 'Carer',
+          suburb: c.suburb, distance_km: c.distance_km, is_verified: c.is_verified,
+          avg_rating: c.avg_rating, total_reviews: c.total_reviews,
+          services: services.map((s) => ({ id: s.id, service_type: s.service_type, price_cents: s.price_cents, duration_mins: s.duration_mins })),
+        };
+      }).filter((c) => !rq.service_type || c.services.length > 0);
+      return json({ request: rq, carers: carersOut });
+    }
+
+    if (action === 'request_assign') {
+      if (!(await isAdmin(user.id))) return json({ error: 'Not authorised' }, 403);
+      const reqId = String(payload.request_id || '');
+      const providerId = String(payload.provider_id || ''); // provider_profiles.id
+      const serviceId = String(payload.service_id || '');   // provider_services.id
+      const scheduledAt = String(payload.scheduled_at || ''); // ISO timestamp
+      if (!providerId || !serviceId || !scheduledAt) return json({ error: 'Missing carer, service or time' }, 400);
+      const { data: rq } = await sb.from('carer_requests').select('*').eq('id', reqId).maybeSingle();
+      if (!rq) return json({ error: 'Request not found' }, 404);
+      if (rq.status !== 'open' && rq.status !== 'onboarding') return json({ error: 'Request already resolved' }, 409);
+      if (!rq.customer_id || !rq.pet_id) return json({ error: 'This request has no linked customer/pet to assign' }, 400);
+
+      const { data: svc } = await sb.from('provider_services').select('id,duration_mins').eq('id', serviceId).maybeSingle();
+      if (!svc) return json({ error: 'Service not found' }, 404);
+
+      // Mirror the customer's single-booking insert (book/index.html): status 'pending',
+      // total_cents 0 (single bookings price on completion; series carry locked_price_cents).
+      // The carer still accepts and the customer still confirms — nothing is forced. The
+      // existing trg_email_booking_request trigger notifies the carer on insert.
+      const ins = await sb.from('bookings').insert({
+        customer_id: rq.customer_id,
+        provider_id: providerId,
+        pet_id: rq.pet_id,
+        service_id: serviceId,
+        status: 'pending',
+        scheduled_at: scheduledAt,
+        duration_mins: svc.duration_mins ?? null,
+        total_cents: 0,
+      }).select('id').single();
+      if (ins.error || !ins.data) return json({ error: 'Could not create booking: ' + (ins.error?.message || '') }, 500);
+      const bookingId = ins.data.id;
+      await sb.from('booking_pets').insert({ booking_id: bookingId, pet_id: rq.pet_id });
+
+      await sb.from('carer_requests').update({
+        status: 'matched',
+        assigned_provider_id: providerId,
+        assigned_booking_id: bookingId,
+        resolved_at: new Date().toISOString(),
+        resolved_by: user.id,
+      }).eq('id', reqId);
+
+      // Tell the customer in-app (the carer's booking-request email is fired by the DB trigger).
+      const { data: cp } = await sb.from('customer_profiles').select('user_id').eq('id', rq.customer_id).single();
+      const { data: pp } = await sb.from('provider_profiles').select('user_id').eq('id', providerId).single();
+      const { data: cu } = pp?.user_id ? await sb.from('users').select('first_name').eq('id', pp.user_id).single() : { data: null };
+      if (cp?.user_id) {
+        await sb.from('system_messages').insert({
+          recipient_user_id: cp.user_id,
+          body: `Good news — we found you a carer${cu?.first_name ? ` (${cu.first_name})` : ''} for your request. They'll confirm shortly.`,
+          link_url: '/profile/',
+          link_label: 'View my bookings',
+        });
+      }
+      return json({ ok: true, booking_id: bookingId });
+    }
+
+    if (action === 'request_update') {
+      if (!(await isAdmin(user.id))) return json({ error: 'Not authorised' }, 403);
+      const reqId = String(payload.request_id || '');
+      const status = String(payload.status || '');
+      const adminNote = String(payload.admin_note || '').slice(0, 500);
+      if (!['open', 'onboarding', 'closed'].includes(status)) return json({ error: 'Invalid status' }, 400);
+      const resolved = status === 'closed';
+      const upd = await sb.from('carer_requests').update({
+        status,
+        admin_note: adminNote || null,
+        resolved_at: resolved ? new Date().toISOString() : null,
+        resolved_by: resolved ? user.id : null,
+      }).eq('id', reqId).select('id');
+      if (upd.error || !upd.data?.length) return json({ error: 'Request not found' }, 404);
       return json({ ok: true });
     }
 

--- a/supabase/migrations/20260704000001_tru121_carer_requests.sql
+++ b/supabase/migrations/20260704000001_tru121_carer_requests.sql
@@ -1,0 +1,174 @@
+-- TRU-121: "Can't find a carer" service.
+--
+-- Two capture surfaces for unmet demand when carer search returns nothing:
+--   • carer_requests — an explicit, actionable lead a customer (or guest) submits from the
+--     zero-result empty state. Admin works it from the console (assign an existing carer, or
+--     go find + onboard a new one). Inserted via a SECURITY DEFINER RPC so guests/anon never
+--     need a broad INSERT grant — mirrors public.cancel_my_booking / public.search_carers.
+--   • search_misses — a passive, anonymous signal: one row per zero-result search so we can
+--     see demand even when nobody submits. No PII (suburb + service only).
+--
+-- On insert, carer_requests fires the existing email pipeline (private.notify_email ->
+-- send-notification, type 'carer_request') to page every admin — the same mechanism as the
+-- TRU-138 covered-cancellation alert.
+--
+-- Applied to the live DB via apply_migration (Supabase branching is broken on this repo);
+-- committed here for version control (see TRU-145). 14-digit unique prefix.
+
+-- ── carer_requests: the actionable lead ──────────────────────────────────────
+create table if not exists public.carer_requests (
+  id                   uuid primary key default gen_random_uuid(),
+  -- null for a guest (search is public); set from auth.uid() when signed in.
+  customer_id          uuid references public.customer_profiles(id) on delete set null,
+  -- captured when a signed-in customer picks a pet; required for the in-app assign path.
+  pet_id               uuid references public.pets(id) on delete set null,
+  contact_name         text,
+  contact_email        text,           -- required for guests (see submit RPC)
+  suburb               text,
+  service_type         text,
+  wanted_date          date,
+  recurring            boolean not null default false,
+  window_start         text,           -- 'HH:MM'
+  window_end           text,           -- 'HH:MM'
+  dog_size             text,
+  puppy                boolean not null default false,
+  note                 text,           -- free-text "anything else"
+  search_params        jsonb,          -- full snapshot of the search state (future-proof)
+  status               text not null default 'open'
+                         check (status in ('open','matched','onboarding','closed')),
+  assigned_provider_id uuid references public.provider_profiles(id) on delete set null,
+  assigned_booking_id  uuid references public.bookings(id) on delete set null,
+  admin_note           text,
+  resolved_at          timestamptz,
+  resolved_by          uuid references public.users(id) on delete set null,
+  created_at           timestamptz not null default now()
+);
+create index if not exists idx_carer_requests_status on public.carer_requests (status, created_at desc);
+create index if not exists idx_carer_requests_customer on public.carer_requests (customer_id);
+
+alter table public.carer_requests enable row level security;
+-- Owners can read their own submitted requests; all writes go through the definer RPC (submit)
+-- or the admin edge function (service_role). Mirrors public.customer_credits (TRU-139).
+drop policy if exists carer_requests_owner_read on public.carer_requests;
+create policy carer_requests_owner_read on public.carer_requests
+  for select to authenticated
+  using (exists (
+    select 1 from public.customer_profiles cp
+    where cp.id = carer_requests.customer_id and cp.user_id = (select auth.uid())
+  ));
+revoke insert, update, delete on public.carer_requests from anon, authenticated;
+grant select on public.carer_requests to authenticated;
+grant select, insert, update, delete on public.carer_requests to service_role;
+
+-- ── search_misses: the passive anonymous signal ──────────────────────────────
+create table if not exists public.search_misses (
+  id           uuid primary key default gen_random_uuid(),
+  suburb       text not null,
+  service_type text,
+  customer_id  uuid,          -- best-effort attribution when signed in; nullable
+  created_at   timestamptz not null default now()
+);
+create index if not exists idx_search_misses_agg on public.search_misses (suburb, service_type, created_at desc);
+
+alter table public.search_misses enable row level security;
+-- No client reads; admin aggregates it via service_role. Written only through the RPC below.
+revoke select, insert, update, delete on public.search_misses from anon, authenticated;
+grant select, insert on public.search_misses to service_role;
+
+-- ── submit_carer_request: public/guest-safe insert (SECURITY DEFINER) ─────────
+create or replace function public.submit_carer_request(
+  p_suburb        text    default null,
+  p_service_type  text    default null,
+  p_wanted_date   date    default null,
+  p_recurring     boolean default false,
+  p_window_start  text    default null,
+  p_window_end    text    default null,
+  p_dog_size      text    default null,
+  p_puppy         boolean default false,
+  p_pet_id        uuid    default null,
+  p_contact_name  text    default null,
+  p_contact_email text    default null,
+  p_note          text    default null,
+  p_search_params jsonb   default null
+) returns uuid
+language plpgsql security definer set search_path = public as $$
+declare
+  v_customer_id uuid;
+  v_pet_id      uuid := null;
+  v_id          uuid;
+begin
+  -- Tie to the caller's customer profile when signed in; otherwise it's a guest lead.
+  select cp.id into v_customer_id
+  from public.customer_profiles cp
+  where cp.user_id = auth.uid();
+
+  -- Guests must leave a contact email so we can reach them.
+  if v_customer_id is null and coalesce(trim(p_contact_email), '') = '' then
+    raise exception 'contact_email is required for guest requests';
+  end if;
+
+  -- Only accept a pet_id that actually belongs to the caller (defends the assign path).
+  if p_pet_id is not null and v_customer_id is not null then
+    select pt.id into v_pet_id
+    from public.pets pt
+    where pt.id = p_pet_id and pt.customer_id = v_customer_id;
+  end if;
+
+  insert into public.carer_requests (
+    customer_id, pet_id, contact_name, contact_email, suburb, service_type,
+    wanted_date, recurring, window_start, window_end, dog_size, puppy, note, search_params
+  ) values (
+    v_customer_id, v_pet_id,
+    nullif(trim(coalesce(p_contact_name, '')), ''),
+    nullif(trim(coalesce(p_contact_email, '')), ''),
+    nullif(trim(coalesce(p_suburb, '')), ''),
+    nullif(trim(coalesce(p_service_type, '')), ''),
+    p_wanted_date, coalesce(p_recurring, false),
+    nullif(trim(coalesce(p_window_start, '')), ''),
+    nullif(trim(coalesce(p_window_end, '')), ''),
+    nullif(trim(coalesce(p_dog_size, '')), ''),
+    coalesce(p_puppy, false),
+    nullif(trim(coalesce(p_note, '')), ''),
+    p_search_params
+  ) returning id into v_id;
+
+  return v_id;
+end; $$;
+
+revoke all on function public.submit_carer_request(text,text,date,boolean,text,text,text,boolean,uuid,text,text,text,jsonb) from public;
+grant execute on function public.submit_carer_request(text,text,date,boolean,text,text,text,boolean,uuid,text,text,text,jsonb) to anon, authenticated;
+
+-- ── log_search_miss: fire-and-forget passive signal (SECURITY DEFINER) ────────
+create or replace function public.log_search_miss(
+  p_suburb  text,
+  p_service text default null
+) returns void
+language plpgsql security definer set search_path = public as $$
+begin
+  if coalesce(trim(p_suburb), '') = '' then return; end if;
+  insert into public.search_misses (suburb, service_type, customer_id)
+  values (
+    trim(p_suburb),
+    nullif(trim(coalesce(p_service, '')), ''),
+    (select cp.id from public.customer_profiles cp where cp.user_id = auth.uid())
+  );
+end; $$;
+
+revoke all on function public.log_search_miss(text, text) from public;
+grant execute on function public.log_search_miss(text, text) to anon, authenticated;
+
+-- ── founder alert on insert (reuses the TRU-118 email pipeline) ───────────────
+create or replace function private.tg_carer_request() returns trigger
+language plpgsql security definer set search_path = '' as $$
+begin
+  -- Wrapped so an email hiccup can never roll back the request insert.
+  begin
+    perform private.notify_email(jsonb_build_object('type', 'carer_request', 'request_id', NEW.id));
+  exception when others then null;
+  end;
+  return NEW;
+end; $$;
+
+drop trigger if exists trg_email_carer_request on public.carer_requests;
+create trigger trg_email_carer_request after insert on public.carer_requests
+  for each row execute function private.tg_carer_request();


### PR DESCRIPTION
Closes TRU-121.

When a customer's carer search returns **zero results**, today they hit a dead-end empty state and the demand signal is lost. This captures unmet demand two ways and gives admin a console to act on it — assign a carer we already have, or go find and onboard a new one.

## What's included
- **Migration** `20260704000001_tru121_carer_requests.sql`
  - `carer_requests` — actionable lead. `submit_carer_request(...)` (SECURITY DEFINER, guest-safe, mirrors `cancel_my_booking`/`search_carers`) so guests/anon insert without a broad grant. RLS: owners read their own; writes only via RPC / admin edge fn.
  - `search_misses` — passive, anonymous zero-result signal (suburb + service only, no PII). `log_search_miss(...)` fire-and-forget.
  - Insert trigger → `private.notify_email('carer_request')`, reusing the TRU-118 pipeline / TRU-138 admin fan-out.
- **`send-notification`** — new `carer_request` email type: pages every admin with the request details, `reply_to` set to the requester. Added optional per-message `replyTo` (existing types unchanged).
- **`stripe-api`** — 4 admin actions (all `isAdmin`-gated): `requests_list` (+ 30-day unmet-search aggregate), `request_find_carers` (reuses `search_carers` + `provider_services` join), `request_assign` (creates a `pending` booking request — carer accepts, customer confirms), `request_update` (onboarding/close for guest leads).
- **`search/index.html`** — empty-state "Let us find you a carer" form (guest: name+email; signed-in: pet picker) + client-deduped passive signal log.
- **`admin/index.html`** — new **Requests** tab mirroring the Cover tab: open requests, find/assign carers, unmet-search panel.

## Rollout
Backend already applied to prod (branching is broken here — see TRU-146): migration applied, `send-notification` v8, `stripe-api` v9 (both `verify_jwt:false` preserved). **Frontend (`search`/`admin` HTML) goes live on merge + deploy to trufflpets.com.**

## Verification (prod, end-to-end)
- Guest submit → row inserted (customer_id null) → trigger → `send-notification` v8 returned **200** (founder email sent, reply-to the guest).
- Passive signal: 2 `log_search_miss` calls → 2 rows; 30-day aggregate renders `suburb · service ×N`.
- `request_find_carers` path: `search_carers("Surry Hills")` → 10 candidates with per-carer service counts.
- `stripe-api` unauthenticated → **401**.
- `get_advisors`: no new errors (only intentional WARNs matching `search_carers`, and `search_misses` deny-all RLS INFO). Test data cleaned up.

## Notes / conscious decisions
- **Meet-and-greet gate:** an admin assign inserts a normal `status='pending'` booking request (carer still accepts, customer still confirms/pays) — this bypasses the customer-side M&G routing, consistent with admin's existing service_role authority (backup-cover reassigns providers directly). Assign is only offered for signed-in customers with a linked pet; guest leads use reply-by-email / onboarding.
- One real verification email was sent to the founder inbox during testing (expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)