### PR TITLE
TRU-158: search-update fix, dogs-only signup, booking null chip, 8am–5pm default window

### DIFF
--- a/book/index.html
+++ b/book/index.html
@@ -262,12 +262,17 @@ function recurringAllowed(svcType) { return !MULTI_DAY_SERVICES.includes(svcType
 /* Time window — a "between X and Y" range the carer fits the walk into.
    Slider works in 30-min indices over 6:00am–9:00pm. */
 const WIN_MIN = 12, WIN_MAX = 42; // 6:00 .. 21:00 in half-hours
-const win = { start: 18, end: 24 }; // default 9:00am–12:00pm
+const win = { start: 16, end: 34 }; // TRU-158: default 8:00am–5:00pm (working-day window)
 function idxToHHMM(i) { return String(Math.floor(i / 2)).padStart(2, '0') + ':' + ((i % 2) ? '30' : '00'); }
 function idxToLabel(i) { const h = Math.floor(i / 2), m = (i % 2) ? 30 : 0; return ((h % 12) || 12) + ':' + String(m).padStart(2, '0') + ' ' + (h < 12 ? 'AM' : 'PM'); }
 function durationsForType(svcType) {
-  return providerServices.filter(s => s.service_type === svcType && s.is_available !== false)
+  const rows = providerServices.filter(s => s.service_type === svcType && s.is_available !== false)
     .sort((a, b) => (a.duration_mins || 0) - (b.duration_mins || 0));
+  // TRU-158: registration creates a bare stub row (no duration, no price). Once the carer
+  // has added real priced durations, the stub is an unbookable leftover — hide it. If it's
+  // the only row, keep it so the service is still bookable ("Standard" label).
+  const real = rows.filter(s => s.duration_mins != null || s.price_cents != null);
+  return real.length ? real : rows;
 }
 function selectedDurationMins() {
   const svc = providerServices.find(s => s.id === selectedServiceId);
@@ -363,7 +368,7 @@ function renderLengthPicker(svcType) {
     <div class="field" style="margin-bottom:14px;">
       <label>Walk length</label>
       <div class="len-row">
-        ${durs.map(d => `<button type="button" class="len-chip ${d.id === selectedServiceId ? 'active' : ''}" onclick="selectLength('${d.id}')">${d.duration_mins} min${d.price_cents != null ? ` · ${fmtPrice(d.price_cents)}` : ''}</button>`).join('')}
+        ${durs.map(d => `<button type="button" class="len-chip ${d.id === selectedServiceId ? 'active' : ''}" onclick="selectLength('${d.id}')">${d.duration_mins ? `${d.duration_mins} min` : 'Standard'}${d.price_cents != null ? ` · ${fmtPrice(d.price_cents)}` : ''}</button>`).join('')}
       </div>
     </div>`;
 }

--- a/login/index.html
+++ b/login/index.html
@@ -373,12 +373,12 @@
         <div style="text-align:center;margin-bottom:1.2rem;color:var(--terracotta);"><svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="8" cy="8" rx="1.5" ry="2"/><ellipse cx="16" cy="8" rx="1.5" ry="2"/><ellipse cx="5" cy="13" rx="1.3" ry="1.6"/><ellipse cx="19" cy="13" rx="1.3" ry="1.6"/><path d="M8.5 17.5c0-2.2 1.6-3.5 3.5-3.5s3.5 1.3 3.5 3.5-1.6 3-3.5 3-3.5-.8-3.5-3z"/></svg></div>
         <h2 style="text-align:center;">Tell us about your dog</h2>
         <p style="text-align:center;">The more we know, the better we can match you.</p>
+        <!-- TRU-158: dogs only for launch — species stays 'dog' (selectSpecies untouched for when cats & co. return) -->
         <div class="field"><label>What kind of pet?</label>
-          <div class="species-grid">
+          <div class="species-grid" style="grid-template-columns:1fr;">
             <label class="species-card selected" onclick="selectSpecies(this,'dog')"><input type="radio" name="species" value="dog" checked><span class="species-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="8" cy="8" rx="1.5" ry="2"/><ellipse cx="16" cy="8" rx="1.5" ry="2"/><ellipse cx="5" cy="13" rx="1.3" ry="1.6"/><ellipse cx="19" cy="13" rx="1.3" ry="1.6"/><path d="M8.5 17.5c0-2.2 1.6-3.5 3.5-3.5s3.5 1.3 3.5 3.5-1.6 3-3.5 3-3.5-.8-3.5-3z"/></svg></span><span class="species-name">Dog</span></label>
-            <label class="species-card" onclick="selectSpecies(this,'cat')"><input type="radio" name="species" value="cat"><span class="species-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M5 8l1-3 3 2.5M19 8l-1-3-3 2.5"/><path d="M5 8c-.5 2-.5 4 0 6 1 3 4 5 7 5s6-2 7-5c.5-2 .5-4 0-6"/><path d="M10 13h.01M14 13h.01M11 16c.5.4 1.5.4 2 0"/></svg></span><span class="species-name">Cat</span></label>
-            <label class="species-card" onclick="selectSpecies(this,'other')"><input type="radio" name="species" value="other"><span class="species-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="8" cy="8" rx="1.5" ry="2"/><ellipse cx="16" cy="8" rx="1.5" ry="2"/><ellipse cx="5" cy="13" rx="1.3" ry="1.6"/><ellipse cx="19" cy="13" rx="1.3" ry="1.6"/><path d="M8.5 17.5c0-2.2 1.6-3.5 3.5-3.5s3.5 1.3 3.5 3.5-1.6 3-3.5 3-3.5-.8-3.5-3z"/></svg></span><span class="species-name">Other</span></label>
           </div>
+          <p style="font-size:0.82rem;color:var(--text-muted);margin:6px 0 0;">Dogs only for launch — more pets coming soon.</p>
         </div>
         <div class="field"><label>Pet's name</label><input type="text" id="cPetName" placeholder="e.g. Flick"></div>
         <div class="field"><label>Breed <span class="optional">(optional)</span></label><input type="text" id="cPetBreed" placeholder="e.g. Springer Spaniel"></div>

--- a/search/index.html
+++ b/search/index.html
@@ -406,6 +406,7 @@ let myPets = [];
 let isLoading = false;
 const loggedMisses = new Set(); // TRU-121: dedupe passive zero-result signals per session
 let requestSubmitted = false;   // TRU-121: switch the empty-state CTA to a thank-you once sent
+let SKELETON_HTML = '';         // TRU-158: captured once at boot — the source element is destroyed by the first render
 
 const state = {
   suburb: '', service: '', recurring: false, date: '', dateEnd: '', time: '',
@@ -420,11 +421,14 @@ function isWindowService() { return WINDOW_SERVICES.includes(state.service); }
 
 /* Time-window slider — 30-min indices over 6:00am–9:00pm; minimum 2-hour window. */
 const WIN_MIN = 12, WIN_MAX = 42, WIN_GAP = 4;
+// TRU-158: the sliders open at 8am–5pm (a sensible working-day default) but state stays
+// empty — "any time" — until the user actually drags a handle.
+const WIN_DEF_START = 16, WIN_DEF_END = 34;
 function winIdxToHHMM(i) { return String(Math.floor(i / 2)).padStart(2, '0') + ':' + ((i % 2) ? '30' : '00'); }
 function winIdxToLabel(i) { const h = Math.floor(i / 2), m = (i % 2) ? 30 : 0; return ((h % 12) || 12) + ':' + String(m).padStart(2, '0') + ' ' + (h < 12 ? 'AM' : 'PM'); }
 function winHHMMToIdx(s) { const [h, m] = (s || '').split(':').map(Number); return h * 2 + (m >= 30 ? 1 : 0); }
-function winStartIdx() { return state.windowStart ? winHHMMToIdx(state.windowStart) : WIN_MIN; }
-function winEndIdx() { return state.windowEnd ? winHHMMToIdx(state.windowEnd) : WIN_MAX; }
+function winStartIdx() { return state.windowStart ? winHHMMToIdx(state.windowStart) : WIN_DEF_START; }
+function winEndIdx() { return state.windowEnd ? winHHMMToIdx(state.windowEnd) : WIN_DEF_END; }
 function winLabelFor(hhmm) { return hhmm ? winIdxToLabel(winHHMMToIdx(hhmm)) : 'any'; }
 
 /* ── Inline line-icon set (stroke=currentColor so they recolour with the tile) ── */
@@ -1255,12 +1259,14 @@ function renderError(err) {
 async function runSearch() {
   if (isLoading) return;
   isLoading = true;
-  writeUrlParams();
-  renderMobileSummary();
-
-  document.getElementById('resultsArea').innerHTML = document.getElementById('initialSkeletons').outerHTML;
-
+  // TRU-158: everything below lives inside try/finally. Previously the skeleton swap ran
+  // before the try and re-queried #initialSkeletons — an element the first render destroys
+  // (it lives inside #resultsArea) — so search #2 threw and isLoading wedged true, silently
+  // swallowing every later "Update results" click until a page refresh.
   try {
+    writeUrlParams();
+    renderMobileSummary();
+    document.getElementById('resultsArea').innerHTML = SKELETON_HTML;
     // Always refetch: suburb + date now shape the server-side query (TRU-154).
     providers = await fetchProviders();
     await ensureAttributesLoaded();
@@ -1298,6 +1304,9 @@ async function init() {
   }
 
   readUrlParams();
+
+  // TRU-158: snapshot the loading skeletons while they still exist in the DOM.
+  SKELETON_HTML = document.getElementById('initialSkeletons').outerHTML;
 
   // Saved pets — only attempted when logged in, using sbGet (auth required)
   if (authUid) {


### PR DESCRIPTION
Closes TRU-158. Four customer-facing fixes from Tom's signup/booking test pass.

## 1. Search results never updated without a refresh (root-caused)
`#initialSkeletons` is a child of `#resultsArea`, so the first render destroys it. The next `runSearch()` hit `document.getElementById('initialSkeletons').outerHTML` **before** the try/finally → TypeError → `isLoading` wedged `true` → every later "Update results" click silently swallowed. `writeUrlParams()` had already run, so refreshing re-ran the search with the new params — exactly the reported symptom.
**Fix:** snapshot the skeleton markup once at boot; run the whole search body inside try/finally so no throw can wedge the guard again.
**Verified in preview:** Surry Hills (10) → Newington (3) → Homebush (5), three consecutive in-place updates, console clean.

## 2. Dogs-only signup
Customer signup offered Dog/Cat/Other. Now Dog only with a "more pets coming soon" note; `species` column and `selectSpecies` untouched for when other pets return.

## 3. Booking page rendered "null"
Registration creates a bare `provider_services` stub (null duration, null price). On the reported provider (22ce1d18…, confirmed in prod data) the stub rendered a **"null min"** walk-length chip and could even be the default selection. Fix: stubs are hidden when priced durations exist (kept as "Standard" if it's the carer's only row, so booking still works), and the label is null-guarded. Logic unit-tested against the real data shape.

## 4. Default preferred window → 8:00am–5:00pm
Booking slider default was 9am–12pm; search slider opened at the 6am–9pm extremes. Both now open at 8am–5pm. Search state still stays "any time" until the user drags a handle.

No migrations, no edge-function changes — static HTML/JS only; live on merge + deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)