### PR TITLE
TRU-157: carer setup — travel-time signup, finish-setup checklist, read gates, bio editing

### DIFF
--- a/carer-guidelines/emergencies-and-safety/index.html
+++ b/carer-guidelines/emergencies-and-safety/index.html
@@ -122,6 +122,23 @@
         showDone(now);
       } catch(e){ btn.disabled=false; btn.textContent='I\'ve read this and I understand'; }
     }
+    // TRU-157: enforce actually reading — the agree button stays locked until the
+    // carer has been on the page 20 seconds AND scrolled to the bottom. The button
+    // counts down so it never looks broken.
+    const READ_SECONDS=20, ACK_LABEL="I've read this and I understand";
+    const gateStart=Date.now(); let gateScrolled=false, gateDone=false;
+    function atBottom(){ return window.innerHeight+window.scrollY >= document.body.scrollHeight-80; }
+    function gateTick(){
+      if(gateDone) return;
+      const btn=document.getElementById('ackBtn');
+      if(!btn || btn.style.display==='none'){ gateDone=true; return; } // already acknowledged
+      if(atBottom()) gateScrolled=true;
+      const left=Math.ceil((READ_SECONDS*1000-(Date.now()-gateStart))/1000);
+      if(left<=0 && gateScrolled){ gateDone=true; btn.disabled=false; btn.textContent=ACK_LABEL; return; }
+      btn.disabled=true;
+      btn.textContent = left>0 ? `Keep reading — ${left}s` : 'Scroll to the end to agree';
+      setTimeout(gateTick,500);
+    }
     (async function(){
       try { const s=localStorage.getItem('truffl_session'); if(s) session=JSON.parse(s); } catch(e){}
       if(!session || session.role!=='provider') return;
@@ -129,8 +146,9 @@
       try {
         const r=await fetch(`${SUPABASE_URL}/rest/v1/provider_profiles?user_id=eq.${session.user_id}&select=${ACK_COLUMN}`,{headers:{'apikey':SUPABASE_ANON_KEY,'Authorization':`Bearer ${session.access_token}`}});
         const rows=await r.json();
-        if(rows[0] && rows[0][ACK_COLUMN]) showDone(rows[0][ACK_COLUMN]);
+        if(rows[0] && rows[0][ACK_COLUMN]) { showDone(rows[0][ACK_COLUMN]); return; }
       } catch(e){}
+      gateTick();
     })();
   </script>
 </body>

--- a/carer-guidelines/your-commitments/index.html
+++ b/carer-guidelines/your-commitments/index.html
@@ -109,6 +109,23 @@
         showDone(now);
       } catch(e){ btn.disabled=false; btn.textContent='I\'ve read this and I agree'; }
     }
+    // TRU-157: enforce actually reading — the agree button stays locked until the
+    // carer has been on the page 20 seconds AND scrolled to the bottom. The button
+    // counts down so it never looks broken.
+    const READ_SECONDS=20, ACK_LABEL="I've read this and I agree";
+    const gateStart=Date.now(); let gateScrolled=false, gateDone=false;
+    function atBottom(){ return window.innerHeight+window.scrollY >= document.body.scrollHeight-80; }
+    function gateTick(){
+      if(gateDone) return;
+      const btn=document.getElementById('ackBtn');
+      if(!btn || btn.style.display==='none'){ gateDone=true; return; } // already acknowledged
+      if(atBottom()) gateScrolled=true;
+      const left=Math.ceil((READ_SECONDS*1000-(Date.now()-gateStart))/1000);
+      if(left<=0 && gateScrolled){ gateDone=true; btn.disabled=false; btn.textContent=ACK_LABEL; return; }
+      btn.disabled=true;
+      btn.textContent = left>0 ? `Keep reading — ${left}s` : 'Scroll to the end to agree';
+      setTimeout(gateTick,500);
+    }
     (async function(){
       try { const s=localStorage.getItem('truffl_session'); if(s) session=JSON.parse(s); } catch(e){}
       if(!session || session.role!=='provider') return; // only carers see the acknowledge box
@@ -116,8 +133,9 @@
       try {
         const r=await fetch(`${SUPABASE_URL}/rest/v1/provider_profiles?user_id=eq.${session.user_id}&select=${ACK_COLUMN}`,{headers:{'apikey':SUPABASE_ANON_KEY,'Authorization':`Bearer ${session.access_token}`}});
         const rows=await r.json();
-        if(rows[0] && rows[0][ACK_COLUMN]) showDone(rows[0][ACK_COLUMN]);
+        if(rows[0] && rows[0][ACK_COLUMN]) { showDone(rows[0][ACK_COLUMN]); return; }
       } catch(e){}
+      gateTick();
     })();
   </script>
 </body>

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -535,31 +535,38 @@ function requireGuidelines() {
   window.scrollTo({ top: 0, behavior: 'smooth' });
   return false;
 }
-function ackGateBannerHtml() {
-  if (guidelinesAcknowledged()) return '';
-  const c = !!providerProfile.acknowledged_commitments_at, s = !!providerProfile.acknowledged_safety_at;
-  const done = (c ? 1 : 0) + (s ? 1 : 0);
-  const item = (ok, href, label) => `<a class="ack-gate-item ${ok ? 'done' : ''}" href="${href}">${ok
-    ? '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg>'
-    : '<span class="ack-gate-dot"></span>'} ${label}</a>`;
-  return `<div class="ack-gate">
-    <div class="ack-gate-title">Before you can accept bookings</div>
-    <p>Read and acknowledge these two pages — ${done} of 2 done.</p>
-    <div class="ack-gate-links">
-      ${item(c, '/carer-guidelines/your-commitments/', 'Your commitments')}
-      ${item(s, '/carer-guidelines/emergencies-and-safety/', 'Emergencies and safety')}
-    </div>
-  </div>`;
-}
-
 /* ── TRU-143: Stripe Connect payouts ── */
 function payoutsEnabled() { return !!(providerProfile && providerProfile.payouts_enabled); }
-// Slim top-of-dashboard nudge once the carer is past the guidelines gate but hasn't set up payouts.
-function payoutBannerHtml() {
-  if (payoutsEnabled() || !guidelinesAcknowledged()) return '';
-  return `<div class="ack-gate" style="cursor:pointer;" onclick="switchTab('earnings')">
-    <div class="ack-gate-title">Set up payouts to get paid</div>
-    <p>Add your bank details with Stripe so we can pay you after each booking — see the Earnings tab.</p>
+
+/* ── TRU-157: "Finish setting up" checklist — one card absorbing the old guidelines
+   and payouts banners, plus the two silent gaps signup leaves behind (no photo, no
+   prices). Each step links straight to where it's done; the card disappears once
+   the account is customer-ready. ── */
+function servicesPriced() {
+  const offered = providerServices.filter(s => s.is_available !== false);
+  if (!offered.length) return false;
+  const types = [...new Set(offered.map(s => s.service_type))];
+  return types.every(t => offered.some(s => s.service_type === t && s.price_cents != null));
+}
+function setupChecklistHtml() {
+  const c = !!(providerProfile && providerProfile.acknowledged_commitments_at);
+  const s = !!(providerProfile && providerProfile.acknowledged_safety_at);
+  const steps = [
+    { ok: !!(userData && userData.avatar_url), label: 'Add a profile photo', href: '/profile/' },
+    { ok: servicesPriced(), label: 'Set your walk lengths & prices', onclick: "switchTab('services')" },
+    { ok: c, label: 'Your commitments', href: '/carer-guidelines/your-commitments/' },
+    { ok: s, label: 'Emergencies and safety', href: '/carer-guidelines/emergencies-and-safety/' },
+    { ok: payoutsEnabled(), label: 'Connect payouts', onclick: "switchTab('earnings')" },
+  ];
+  const done = steps.filter(st => st.ok).length;
+  if (done === steps.length) return '';
+  const tick = '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg>';
+  const item = st => `<a class="ack-gate-item ${st.ok ? 'done' : ''}" ${st.href ? `href="${st.href}"` : `href="javascript:void(0)" onclick="${st.onclick}"`}>${st.ok ? tick : '<span class="ack-gate-dot"></span>'} ${st.label}</a>`;
+  const gateNote = guidelinesAcknowledged() ? '' : ' The two guideline pages must be read before you can accept bookings.';
+  return `<div class="ack-gate">
+    <div class="ack-gate-title">Finish setting up — ${done} of ${steps.length} done</div>
+    <p>Complete these so owners see a bookable, priced profile.${gateNote}</p>
+    <div class="ack-gate-links">${steps.map(item).join('')}</div>
   </div>`;
 }
 // Payout status card shown in the Earnings tab.
@@ -1336,9 +1343,7 @@ function renderDashboard() {
 
     ${activeWalkBarHtml()}
 
-    ${ackGateBannerHtml()}
-
-    ${payoutBannerHtml()}
+    ${setupChecklistHtml()}
 
     <div class="tabs">
       <button class="tab active" data-tab="bookings" onclick="switchTab('bookings')">Bookings${pending.length > 0 ? ` (${pending.length})` : ''}</button>
@@ -1621,7 +1626,7 @@ async function init() {
 
   try {
     // Check role
-    const users = await sbGet('users', `id=eq.${authUid}&select=first_name,last_name,role`);
+    const users = await sbGet('users', `id=eq.${authUid}&select=first_name,last_name,role,avatar_url`);
     if (!users.length) { logout(); return; }
     userData = users[0];
 
@@ -1649,13 +1654,18 @@ async function init() {
     providerServices = svcRows;
 
     // Returning from Stripe Connect onboarding? refresh payout readiness before first paint.
-    const payoutsParam = new URLSearchParams(location.search).get('payouts');
+    const bootParams = new URLSearchParams(location.search);
+    const payoutsParam = bootParams.get('payouts');
+    const tabParam = bootParams.get('tab');
     if (payoutsParam === 'return' || payoutsParam === 'refresh') {
       await refreshPayoutStatus();
       history.replaceState(null, '', location.pathname);
     }
 
     renderDashboard();
+    // TRU-157: deep-link a tab (Stripe onboarding returns to ?tab=earnings so the
+    // carer lands on the payout confirmation instead of the default bookings view).
+    if (tabParam && document.querySelector(`.tab[data-tab="${tabParam}"]`)) switchTab(tabParam);
     refreshMsgBadge();
     setInterval(refreshMsgBadge, 10000);
   } catch(e) {

--- a/profile/index.html
+++ b/profile/index.html
@@ -170,8 +170,9 @@
   .field{margin-bottom:1rem;}
   .field:last-child{margin-bottom:0;}
   .field label{display:block;font-size:0.78rem;font-weight:500;color:var(--text-secondary);margin-bottom:5px;}
-  .field input{width:100%;padding:10px 12px;border:1px solid var(--border);border-radius:8px;font-family:'DM Sans',sans-serif;font-size:0.9rem;color:var(--text-primary);background:var(--warm-white);outline:none;transition:border-color 0.2s;}
-  .field input:focus{border-color:var(--border-focus);}
+  .field input,.field textarea,.field select{width:100%;padding:10px 12px;border:1px solid var(--border);border-radius:8px;font-family:'DM Sans',sans-serif;font-size:0.9rem;color:var(--text-primary);background:var(--warm-white);outline:none;transition:border-color 0.2s;}
+  .field textarea{resize:vertical;min-height:90px;}
+  .field input:focus,.field textarea:focus,.field select:focus{border-color:var(--border-focus);}
   .field input.invalid{border-color:var(--error);background:var(--error-bg);}
   .field .field-hint{font-size:0.74rem;color:var(--text-muted);margin-top:5px;}
   .field .field-error{font-size:0.74rem;color:var(--error);margin-top:5px;display:none;}
@@ -642,6 +643,22 @@ function detailsFormHtml() {
         <input id="f-postcode" type="text" value="${esc(postcode)}" autocomplete="postal-code" placeholder="e.g. 2130">
         <div class="field-error" id="err-postcode"></div>
       </div>` : '';
+  // TRU-157: bio + experience were set once at signup with no way to change them —
+  // everything a customer sees on the public carer page is now editable here.
+  const EXP_OPTIONS = ['0-1', '1-3', '3-5', '5+'];
+  const EXP_LABELS = { '0-1': 'Less than 1 year', '1-3': '1–3 years', '3-5': '3–5 years', '5+': '5+ years' };
+  const providerFields = !isCustomer && profileRow ? `
+      <div class="field">
+        <label for="f-bio">About you <span style="font-weight:400;color:var(--text-muted);">(shown on your public profile)</span></label>
+        <textarea id="f-bio" rows="4" placeholder="A few sentences about your experience with animals, why you love what you do, and what makes you great at it.">${esc(profileRow.bio || '')}</textarea>
+      </div>
+      <div class="field">
+        <label for="f-experience">Experience with animals</label>
+        <select id="f-experience">
+          <option value="">Select...</option>
+          ${EXP_OPTIONS.map(v => `<option value="${v}" ${profileRow.experience_years === v ? 'selected' : ''}>${EXP_LABELS[v]}</option>`).join('')}
+        </select>
+      </div>` : '';
   return `
     <div class="details-card">
       <div class="row-2">
@@ -672,7 +689,7 @@ function detailsFormHtml() {
         <input id="f-suburb" type="text" value="${esc(suburb)}" autocomplete="address-level2" placeholder="e.g. Summer Hill">
         <div class="field-error" id="err-suburb"></div>
       </div>
-      ${addressFields}
+      ${addressFields}${providerFields}
       <div class="form-actions">
         <button class="pf-save" id="saveBtn" onclick="saveProfile()">Save changes</button>
         <button class="pf-discard" onclick="resetDetails()">Reset</button>
@@ -741,12 +758,21 @@ async function saveProfile() {
         const postcode = document.getElementById('f-postcode').value.trim();
         profilePatch.address = address || null;
         profilePatch.postcode = postcode || null;
+      } else {
+        // TRU-157: carers can now edit their public bio + experience
+        const bioEl = document.getElementById('f-bio');
+        const expEl = document.getElementById('f-experience');
+        if (bioEl) profilePatch.bio = bioEl.value.trim() || null;
+        if (expEl && expEl.value) profilePatch.experience_years = expEl.value;
       }
       await sbPatch(profileTable, 'user_id', authUid, profilePatch);
       profileRow.suburb = suburb || null;
       if (userData.role === 'customer') {
         profileRow.address = profilePatch.address;
         profileRow.postcode = profilePatch.postcode;
+      } else {
+        if ('bio' in profilePatch) profileRow.bio = profilePatch.bio;
+        if ('experience_years' in profilePatch) profileRow.experience_years = profilePatch.experience_years;
       }
     }
 
@@ -1535,7 +1561,7 @@ async function init() {
 
     if (userData.role === 'provider') {
       profileTable = 'provider_profiles';
-      const profiles = await sbGet('provider_profiles', `user_id=eq.${authUid}&select=id,suburb,radius_km,travel_time_mins`);
+      const profiles = await sbGet('provider_profiles', `user_id=eq.${authUid}&select=id,suburb,radius_km,travel_time_mins,bio,experience_years`);
       profileRow = profiles.length ? profiles[0] : null;
       renderNav();
       renderProviderProfile();

--- a/register/index.html
+++ b/register/index.html
@@ -257,6 +257,11 @@
     margin-top: 4px;
   }
 
+  /* ─── Service-area mode toggle (TRU-157, mirrors the profile editor) ─── */
+  .sa-seg { display: flex; padding: 3px; background: var(--cream); border: 1px solid var(--border); border-radius: 999px; margin: 4px 0 10px; max-width: 320px; }
+  .sa-seg button { flex: 1; border: 0; background: transparent; padding: 8px 12px; font: inherit; font-size: 0.85rem; color: var(--text-muted); border-radius: 999px; cursor: pointer; }
+  .sa-seg button.active { background: #fff; color: var(--brown); font-weight: 600; box-shadow: 0 1px 3px rgba(61,43,31,0.12); }
+
   /* ─── Checkbox Group ─── */
   .checkbox-grid {
     display: grid;
@@ -534,15 +539,21 @@
         <div class="field-hint">The area you're based in — we'll use this for matching with local pet owners</div>
       </div>
 
-      <div class="field-row">
-        <div class="field">
-          <label>Service radius <span class="optional">(km)</span></label>
-          <input type="number" id="radius" placeholder="e.g. 10" min="1" max="50" value="10">
+      <!-- TRU-157: service area in the same terms as the profile editor — travel time
+           (isochrone, TRU-156) or a simple distance circle. No more orphan radius-km. -->
+      <div class="field">
+        <label>How far will you go for a job?</label>
+        <div class="sa-seg">
+          <button type="button" id="saModeRadius" onclick="setSignupAreaMode('radius')">Distance</button>
+          <button type="button" id="saModeTravel" class="active" onclick="setSignupAreaMode('travel')">Travel time</button>
         </div>
-        <div class="field">
-          <label>ABN <span class="optional">(optional)</span></label>
-          <input type="text" id="abn" placeholder="If you have one">
-        </div>
+        <select id="saValue"></select>
+        <div class="field-hint" id="saHint">Travel time follows real roads — you won't be shown jobs across the harbour unless you'd actually drive it.</div>
+      </div>
+
+      <div class="field">
+        <label>ABN <span class="optional">(optional)</span></label>
+        <input type="text" id="abn" placeholder="If you have one">
       </div>
 
       <div class="btn-row">
@@ -646,6 +657,28 @@ const supabase = {
 // ─── State ───
 let currentStep = 1;
 let userData = {};
+
+// ─── Service area picker (TRU-157) — same options as the profile editor ───
+const AREA_KM = [3, 5, 8, 10, 15, 20];
+const AREA_MINS = [10, 15, 20, 30, 45, 60];
+let signupAreaMode = 'travel';
+function renderSaOptions() {
+  const sel = document.getElementById('saValue');
+  if (!sel) return;
+  sel.innerHTML = signupAreaMode === 'travel'
+    ? AREA_MINS.map(m => `<option value="${m}" ${m === 30 ? 'selected' : ''}>${m} minutes' drive</option>`).join('')
+    : AREA_KM.map(k => `<option value="${k}" ${k === 10 ? 'selected' : ''}>${k} km</option>`).join('');
+  const hint = document.getElementById('saHint');
+  if (hint) hint.textContent = signupAreaMode === 'travel'
+    ? "Travel time follows real roads — you won't be shown jobs across the harbour unless you'd actually drive it."
+    : 'A simple circle around your suburb. You can switch to travel time anytime in your profile.';
+}
+function setSignupAreaMode(m) {
+  signupAreaMode = m;
+  document.getElementById('saModeRadius').classList.toggle('active', m === 'radius');
+  document.getElementById('saModeTravel').classList.toggle('active', m === 'travel');
+  renderSaOptions();
+}
 
 // ─── Services & Attributes Config ───
 const SERVICES = [
@@ -802,7 +835,7 @@ async function submitStep2() {
   const bio = document.getElementById('bio').value.trim();
   const experience = document.getElementById('experience').value;
   const suburb = document.getElementById('suburb').value.trim();
-  const radius = parseInt(document.getElementById('radius').value) || 10;
+  const saValue = parseInt(document.getElementById('saValue').value, 10) || (signupAreaMode === 'travel' ? 30 : 10);
   const abn = document.getElementById('abn').value.trim();
 
   if (!bio || !experience || !suburb) {
@@ -818,13 +851,27 @@ async function submitStep2() {
       bio: bio,
       experience_years: experience,
       suburb: suburb,
-      // radius_km is what search matches against (TRU-154). This previously wrote
-      // service_radius_km, which nothing read — a new carer's radius was ignored.
-      radius_km: radius,
+      // radius_km is the search fallback when no isochrone exists (TRU-156). In travel
+      // mode we keep a sane default here; the isochrone below is what search prefers.
+      radius_km: signupAreaMode === 'radius' ? saValue : 10,
       abn: abn || null,
       is_verified: false,
       is_active: true
     });
+
+    // TRU-157: compute the service area right away — same geo-api call as the profile
+    // editor. The insert trigger has already set location from the suburb centroid.
+    // Non-fatal: if it hiccups (e.g. routing API down), the radius fallback still
+    // matches searches and the carer can redo it from their profile.
+    try {
+      await fetch(`${SUPABASE_URL}/functions/v1/geo-api`, {
+        method: 'POST',
+        headers: supabase.headers(),
+        body: JSON.stringify(signupAreaMode === 'travel'
+          ? { action: 'set_service_area', mode: 'travel', minutes: saValue }
+          : { action: 'set_service_area', mode: 'radius', radius_km: saValue }),
+      });
+    } catch (e) { /* fallback radius already saved */ }
 
     userData.bio = bio;
     userData.suburb = suburb;
@@ -880,6 +927,7 @@ async function submitStep3() {
 document.addEventListener('DOMContentLoaded', () => {
   renderCheckboxes('servicesGrid', SERVICES);
   renderCheckboxes('attribGrid', ATTRIBUTES);
+  renderSaOptions(); // TRU-157: service-area picker options
 });
 </script>
 

--- a/supabase/functions/stripe-api/index.ts
+++ b/supabase/functions/stripe-api/index.ts
@@ -135,8 +135,10 @@ Deno.serve(async (req) => {
       const link = await stripe('account_links', 'POST', {
         account: acctId,
         type: 'account_onboarding',
-        refresh_url: `${SITE}/dashboard/?payouts=refresh`,
-        return_url: `${SITE}/dashboard/?payouts=return`,
+        // TRU-157: land back on the Earnings tab so the carer sees the payout
+        // confirmation card instead of the default bookings view.
+        refresh_url: `${SITE}/dashboard/?payouts=refresh&tab=earnings`,
+        return_url: `${SITE}/dashboard/?payouts=return&tab=earnings`,
       });
       return json({ url: link.url });
     }


### PR DESCRIPTION
Closes TRU-157. All seven items from Tom's carer-signup test pass.

## Signup service area = travel time (was orphan radius-km)
Signup now uses the same **Distance / Travel time** selector as the profile editor (default: 30-min drive) and calls `geo-api` right after the profile insert, so the isochrone exists from minute one. `radius_km` is kept as the search fallback. **Verified end-to-end on prod:** a test carer signup stored the polygon + `travel_time_mins=15` + suburb-centroid location.

## "Finish setting up" dashboard checklist
The separate guidelines and payouts banners are replaced by one card: **photo → walk lengths & prices → commitments → safety → payouts**, "N of 5 done", each step linking straight to where it's fixed, gone when complete. This also covers the "push them to set a photo more" ask and attacks the root cause of the booking-page null chip (unpriced signup stubs). Verified live: test carer showed "1 of 5 done" with exactly the right states.

## Stripe onboarding
- The "Opening Stripe…" loading state already existed (TRU-143) — the slow open is Stripe account creation + a cold edge fn, and the button reflects it.
- Return/refresh URLs now land on `/dashboard/?payouts=return&tab=earnings`; the dashboard honours `?tab=` deep links. ⚠️ **stripe-api needs a redeploy** for the return URL (blocked in-session for review — dashboard side ships regardless and is backwards-compatible).

## Commitments/safety read gate (scroll + 20s)
Both acknowledge buttons stay locked until the carer has scrolled to the bottom **and** been on the page 20 seconds, with a live countdown ("Keep reading — 12s" → "Scroll to the end to agree"). Both paths browser-verified, and the acknowledge still writes the same timestamps.

## Carer bio editing
Bio + experience were write-once at signup with no way back in. The profile page's "My details" now includes **About you** (bio + experience), saving to `provider_profiles` (and the page select now fetches those columns so the form prefills). Verified: edit → save → DB row updated → prefill on reload.

Test data note: carer `tomfarmery17+tru157test@googlemail.com` (Testy TRU157, Summer Hill) was created on prod for verification — safe to delete, or keep to eyeball the checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)