### PR TITLE
TRU-215 (B): suburb prefill, live search updates, homepage service-cycling + widget alignment

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -98,12 +98,14 @@
     }
     .nav-search-pill:hover { box-shadow: 0 4px 14px -6px rgba(61,43,31,0.14); border-color: var(--terracotta); }
     .nsp-svc { display: flex; align-items: center; gap: 8px; min-width: 0; }
-    .nsp-svc-emoji { display: inline-flex; line-height: 1; color: var(--terracotta); }
+    .nsp-svc-emoji { display: inline-flex; line-height: 1; color: var(--terracotta); transition: opacity 0.35s ease; }
     .nsp-svc-emoji svg { width: 17px; height: 17px; display: block; }
-    .nsp-svc-label { font-size: 13px; font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    /* TRU-215: fixed min-width so the cycling service label doesn't shift the rest of the pill */
+    .nsp-svc-label { font-size: 13px; font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 86px; transition: opacity 0.35s ease; }
     .nsp-divider { width: 1px; height: 22px; background: var(--border); }
     .nsp-field { min-width: 0; }
-    .nsp-eyebrow { font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-light); display: block; line-height: 1; margin-bottom: 3px; }
+    /* TRU-215: clip the eyebrow so "Where"/"When" can't overflow their column into the divider */
+    .nsp-eyebrow { font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-light); display: block; line-height: 1; margin-bottom: 3px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .nsp-value { font-size: 13px; color: var(--text-mid); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .nsp-go { width: 38px; height: 38px; border-radius: 999px; background: var(--terracotta); color: #fff; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
 
@@ -138,7 +140,7 @@
     .svc-chip .svc-icon-emoji svg { width: 18px; height: 18px; display: block; }
     .svc-chip .svc-sub { color: var(--text-light); font-size: 12px; opacity: 0.85; }
     .svc-chip.active .svc-sub { color: var(--terracotta-dark); }
-    .when-row { display: grid; grid-template-columns: 1.1fr 1.4fr auto; gap: 14px; margin-top: 22px; align-items: end; }
+    .when-row { display: grid; grid-template-columns: 1.1fr 1.4fr auto; gap: 20px; margin-top: 22px; align-items: end; }
     .field-eyebrow { font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--text-light); margin-bottom: 8px; font-weight: 500; }
     .when-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; }
     .seg { display: inline-flex; background: var(--cream); padding: 3px; border-radius: 999px; border: 1px solid var(--border); }
@@ -791,9 +793,40 @@
       document.getElementById('pillWhen').textContent = when;
     }
 
+    /* ── TRU-215: cycle the collapsed pill's service as a hint that several exist.
+       Purely cosmetic — state.service stays 'dog_walking' until the user picks one. ── */
+    let svcCycleTimer = null, svcCycleStopped = false;
+    function startServiceCycle() {
+      if (svcCycleStopped || svcCycleTimer) return;
+      if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+      const keys = Object.keys(SERVICE_META);
+      let i = Math.max(0, keys.indexOf(state.service));
+      const emoji = document.getElementById('pillSvcEmoji'), label = document.getElementById('pillSvcLabel');
+      svcCycleTimer = setInterval(() => {
+        i = (i + 1) % keys.length;
+        const meta = SERVICE_META[keys[i]];
+        emoji.style.opacity = label.style.opacity = '0';
+        setTimeout(() => {
+          if (svcCycleStopped) return;
+          emoji.innerHTML = icon(meta.icon);
+          label.textContent = meta.label;
+          emoji.style.opacity = label.style.opacity = '1';
+        }, 350);
+      }, 2200);
+    }
+    function stopServiceCycle() {
+      svcCycleStopped = true;
+      if (svcCycleTimer) { clearInterval(svcCycleTimer); svcCycleTimer = null; }
+      const emoji = document.getElementById('pillSvcEmoji'), label = document.getElementById('pillSvcLabel');
+      if (emoji) emoji.style.opacity = '1';
+      if (label) label.style.opacity = '1';
+      updatePillSummary();
+    }
+
     const scrim = document.getElementById('popoverScrim');
     const pop = document.getElementById('searchPopover');
     function openPopover() {
+      stopServiceCycle();
       scrim.classList.add('open'); scrim.setAttribute('aria-hidden', 'false');
       pop.classList.add('open');   pop.setAttribute('aria-hidden', 'false');
       document.getElementById('searchPill').setAttribute('aria-expanded', 'true');
@@ -816,6 +849,7 @@
     document.getElementById('svcRow').addEventListener('click', e => {
       const btn = e.target.closest('.svc-chip');
       if (!btn) return;
+      stopServiceCycle();
       state.service = btn.dataset.svc;
       document.querySelectorAll('.svc-chip').forEach(c => {
         const on = c === btn;
@@ -936,6 +970,7 @@
     });
 
     updatePillSummary();
+    startServiceCycle(); // TRU-215: begin the collapsed-pill service hint
   })();
 
   /* When signed in, swap the "Sign in" nav link for "My account". */

--- a/index.html
+++ b/index.html
@@ -87,12 +87,14 @@
     }
     .nav-search-pill:hover { box-shadow: 0 4px 14px -6px rgba(61,43,31,0.14); border-color: var(--terracotta); }
     .nsp-svc { display: flex; align-items: center; gap: 8px; min-width: 0; }
-    .nsp-svc-emoji { display: inline-flex; line-height: 1; color: var(--terracotta); }
+    .nsp-svc-emoji { display: inline-flex; line-height: 1; color: var(--terracotta); transition: opacity 0.35s ease; }
     .nsp-svc-emoji svg { width: 17px; height: 17px; display: block; }
-    .nsp-svc-label { font-size: 13px; font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    /* TRU-215: fixed min-width so the cycling service label doesn't shift the rest of the pill */
+    .nsp-svc-label { font-size: 13px; font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 86px; transition: opacity 0.35s ease; }
     .nsp-divider { width: 1px; height: 22px; background: var(--border); }
     .nsp-field { min-width: 0; }
-    .nsp-eyebrow { font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-light); display: block; line-height: 1; margin-bottom: 3px; }
+    /* TRU-215: clip the eyebrow so "Where"/"When" can't overflow their column into the divider */
+    .nsp-eyebrow { font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-light); display: block; line-height: 1; margin-bottom: 3px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .nsp-value { font-size: 13px; color: var(--text-mid); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .nsp-go { width: 38px; height: 38px; border-radius: 999px; background: var(--terracotta); color: #fff; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
 
@@ -159,7 +161,7 @@
     .svc-chip .svc-sub { color: var(--text-light); font-size: 12px; opacity: 0.85; }
     .svc-chip.active .svc-sub { color: var(--terracotta-dark); }
 
-    .when-row { display: grid; grid-template-columns: 1.1fr 1.4fr auto; gap: 14px; margin-top: 22px; align-items: end; }
+    .when-row { display: grid; grid-template-columns: 1.1fr 1.4fr auto; gap: 20px; margin-top: 22px; align-items: end; }
     .field-eyebrow { font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--text-light); margin-bottom: 8px; font-weight: 500; }
     .when-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; }
     .seg { display: inline-flex; background: var(--cream); padding: 3px; border-radius: 999px; border: 1px solid var(--border); }
@@ -560,10 +562,41 @@
       document.getElementById('pillWhen').textContent = when;
     }
 
+    /* ── TRU-215: cycle the collapsed pill's service as a hint that several exist.
+       Purely cosmetic — state.service stays 'dog_walking' until the user picks one. ── */
+    let svcCycleTimer = null, svcCycleStopped = false;
+    function startServiceCycle() {
+      if (svcCycleStopped || svcCycleTimer) return;
+      if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+      const keys = Object.keys(SERVICE_META);
+      let i = Math.max(0, keys.indexOf(state.service));
+      const emoji = document.getElementById('pillSvcEmoji'), label = document.getElementById('pillSvcLabel');
+      svcCycleTimer = setInterval(() => {
+        i = (i + 1) % keys.length;
+        const meta = SERVICE_META[keys[i]];
+        emoji.style.opacity = label.style.opacity = '0';
+        setTimeout(() => {
+          if (svcCycleStopped) return;
+          emoji.innerHTML = icon(meta.icon);
+          label.textContent = meta.label;
+          emoji.style.opacity = label.style.opacity = '1';
+        }, 350);
+      }, 2200);
+    }
+    function stopServiceCycle() {
+      svcCycleStopped = true;
+      if (svcCycleTimer) { clearInterval(svcCycleTimer); svcCycleTimer = null; }
+      const emoji = document.getElementById('pillSvcEmoji'), label = document.getElementById('pillSvcLabel');
+      if (emoji) emoji.style.opacity = '1';
+      if (label) label.style.opacity = '1';
+      updatePillSummary(); // restore the real (selected) service
+    }
+
     /* ── Open / close popover ── */
     const scrim = document.getElementById('popoverScrim');
     const pop = document.getElementById('searchPopover');
     function openPopover() {
+      stopServiceCycle(); // user engaged — stop the hint and show their real service
       scrim.classList.add('open'); scrim.setAttribute('aria-hidden', 'false');
       pop.classList.add('open');   pop.setAttribute('aria-hidden', 'false');
       document.getElementById('searchPill').setAttribute('aria-expanded', 'true');
@@ -587,6 +620,7 @@
     document.getElementById('svcRow').addEventListener('click', e => {
       const btn = e.target.closest('.svc-chip');
       if (!btn) return;
+      stopServiceCycle();
       state.service = btn.dataset.svc;
       document.querySelectorAll('.svc-chip').forEach(c => {
         const on = c === btn;
@@ -714,6 +748,7 @@
     });
 
     updatePillSummary();
+    startServiceCycle(); // TRU-215: begin the collapsed-pill service hint
   })();
 
   /* When signed in, swap the "Sign in" nav link for "My account". */

--- a/search/index.html
+++ b/search/index.html
@@ -152,6 +152,8 @@
   .btn-update { width: 100%; padding: 12px; border-radius: 999px; background: var(--terracotta); color: white; border: 0; font-family: 'DM Sans', sans-serif; font-size: 0.9rem; font-weight: 500; cursor: pointer; transition: background 0.2s, transform 0.1s; margin-top: 6px; }
   .btn-update:hover { background: var(--terracotta-light); }
   .btn-update:active { transform: translateY(1px); }
+  /* TRU-215: desktop sidebar updates live, so no button needed there. */
+  #filterCard .btn-update { display: none; }
 
   /* ── Results column ── */
   .results-header { display: flex; justify-content: space-between; align-items: flex-end; gap: 1rem; margin-bottom: 1.25rem; flex-wrap: wrap; }
@@ -245,6 +247,8 @@
     .sheet { display: block; position: fixed; left: 0; right: 0; bottom: 0; background: var(--warm-white); border-radius: 24px 24px 0 0; padding: 1.25rem; max-height: 88vh; overflow-y: auto; transform: translateY(100%); transition: transform 0.28s cubic-bezier(.2,.7,.3,1); z-index: 201; box-shadow: 0 -10px 40px rgba(61,43,31,0.18); }
     .sheet.open { transform: translateY(0); }
     .sheet-handle { width: 40px; height: 4px; background: var(--border); border-radius: 999px; margin: 0 auto 1rem; }
+    /* TRU-215: pin the "Show results" CTA to the bottom of the sheet so it's never scrolled off-screen. */
+    .sheet .btn-update { position: sticky; bottom: 0; margin-top: 14px; box-shadow: 0 -12px 16px -4px var(--warm-white); }
     .sheet-close { position: absolute; top: 12px; right: 12px; background: transparent; border: 0; padding: 8px; color: var(--text-muted); cursor: pointer; }
 
     .results-heading { font-size: 1.6rem; }
@@ -398,7 +402,7 @@ const DAYS = ['mon','tue','wed','thu','fri','sat','sun'];
 const DAY_LABELS = { mon:'M', tue:'T', wed:'W', thu:'T', fri:'F', sat:'S', sun:'S' };
 const DAY_FULL =  { mon:'Mon', tue:'Tue', wed:'Wed', thu:'Thu', fri:'Fri', sat:'Sat', sun:'Sun' };
 
-let authToken = null, authUid = null;
+let authToken = null, authUid = null, sessionRole = null;
 let providers = [];
 let allAttrMap = null;
 let renderedProviders = [];
@@ -615,7 +619,7 @@ function renderFilterForm() {
       </div>
     </div>
 
-    <button type="button" class="btn-update" id="btnUpdate">Update results</button>
+    <button type="button" class="btn-update" id="btnUpdate">Show results</button>
   `;
   return html;
 }
@@ -720,9 +724,17 @@ function mountFilterForm() {
   syncWhenSection();
 }
 
+// TRU-215: results update live as filters change (no "Update results" button to hunt for).
+// Debounced so text typing and slider drags don't fire a request per keystroke/tick.
+let searchTimer = null;
+function scheduleSearch(delay = 350) {
+  clearTimeout(searchTimer);
+  searchTimer = setTimeout(() => { runSearch(); }, delay);
+}
+
 function wireFilterForm(root) {
   const suburb = root.querySelector('#inputSuburb');
-  if (suburb) suburb.addEventListener('input', e => { state.suburb = e.target.value; });
+  if (suburb) suburb.addEventListener('input', e => { state.suburb = e.target.value; scheduleSearch(); });
   // TRU-154: suburb autocomplete from the seeded suburbs table (public read).
   if (suburb && !document.getElementById('suburbList')) {
     suburb.setAttribute('list', 'suburbList');
@@ -748,6 +760,7 @@ function wireFilterForm(root) {
       document.querySelectorAll('.service-tile').forEach(t => t.classList.toggle('active', t.dataset.svc === state.service));
       // Re-render when fields — multi-day vs single-date depends on service
       syncWhenSection();
+      scheduleSearch();
     });
   });
 
@@ -757,6 +770,7 @@ function wireFilterForm(root) {
       document.querySelectorAll('.segmented button').forEach(b => b.classList.toggle('active', (b.dataset.rec === 'true') === state.recurring));
       document.querySelectorAll('#whenFields').forEach(el => el.innerHTML = renderWhenFields());
       wireWhenFields();
+      scheduleSearch();
     });
   });
 
@@ -767,15 +781,17 @@ function wireFilterForm(root) {
       const v = btn.dataset.size;
       state.size = (state.size === v) ? '' : v;
       document.querySelectorAll('[data-size]').forEach(b => b.classList.toggle('active', b.dataset.size === state.size));
+      scheduleSearch();
     });
   });
   const puppy = root.querySelector('#puppyChk');
-  if (puppy) puppy.addEventListener('change', e => { state.puppy = !!e.target.checked; document.querySelectorAll('#puppyChk').forEach(c => c.checked = state.puppy); });
+  if (puppy) puppy.addEventListener('change', e => { state.puppy = !!e.target.checked; document.querySelectorAll('#puppyChk').forEach(c => c.checked = state.puppy); scheduleSearch(); });
   root.querySelectorAll('[data-pet]').forEach(btn => {
     btn.addEventListener('click', () => {
       const v = btn.dataset.pet;
       state.petId = (state.petId === v) ? '' : v;
       document.querySelectorAll('[data-pet]').forEach(b => b.classList.toggle('active', b.dataset.pet === state.petId));
+      scheduleSearch();
     });
   });
 
@@ -786,6 +802,7 @@ function wireFilterForm(root) {
       if (idx >= 0) state.attributes.splice(idx, 1);
       else state.attributes.push(v);
       document.querySelectorAll(`[data-attr="${v}"]`).forEach(b => b.classList.toggle('active', state.attributes.includes(v)));
+      scheduleSearch();
     });
   });
   const head = root.querySelector('.expander-head');
@@ -793,10 +810,13 @@ function wireFilterForm(root) {
     document.querySelectorAll('.expander').forEach(ex => ex.classList.toggle('open'));
   });
 
+  // TRU-215: results now update live, so this is just the mobile sheet's "done" CTA.
+  // Flush any pending debounce so results are current the instant the sheet closes.
   const update = root.querySelector('#btnUpdate');
   if (update) update.addEventListener('click', () => {
-    closeSheet();
+    clearTimeout(searchTimer);
     runSearch();
+    closeSheet();
   });
 }
 
@@ -812,13 +832,13 @@ function updateWinWrap(wrap, s, e) {
 function wireWhenFields(root) {
   const scope = root || document;
   scope.querySelectorAll('#inputDate').forEach(input => {
-    input.addEventListener('change', e => { state.date = e.target.value; });
+    input.addEventListener('change', e => { state.date = e.target.value; scheduleSearch(); });
   });
   scope.querySelectorAll('#inputDateEnd').forEach(input => {
-    input.addEventListener('change', e => { state.dateEnd = e.target.value; });
+    input.addEventListener('change', e => { state.dateEnd = e.target.value; scheduleSearch(); });
   });
   scope.querySelectorAll('#inputTime').forEach(input => {
-    input.addEventListener('change', e => { state.time = e.target.value; });
+    input.addEventListener('change', e => { state.time = e.target.value; scheduleSearch(); });
   });
   scope.querySelectorAll('.win-wrap').forEach(wrap => {
     const sEl = wrap.querySelector('.winStart'), eEl = wrap.querySelector('.winEnd');
@@ -832,6 +852,7 @@ function wireWhenFields(root) {
       if (s === WIN_MIN && e === WIN_MAX) { state.windowStart = ''; state.windowEnd = ''; }
       else { state.windowStart = winIdxToHHMM(s); state.windowEnd = winIdxToHHMM(e); }
       updateWinWrap(wrap, s, e);
+      scheduleSearch();
     };
     sEl.addEventListener('input', () => onIn('start'));
     eEl.addEventListener('input', () => onIn('end'));
@@ -841,6 +862,7 @@ function wireWhenFields(root) {
     btn.addEventListener('click', () => {
       state.length = (state.length === btn.dataset.len) ? '' : btn.dataset.len;
       document.querySelectorAll('[data-len]').forEach(b => b.classList.toggle('active', b.dataset.len === state.length));
+      scheduleSearch();
     });
   });
   scope.querySelectorAll('[data-day]').forEach(btn => {
@@ -854,6 +876,7 @@ function wireWhenFields(root) {
         b.classList.toggle('active', active);
         b.setAttribute('aria-pressed', active ? 'true' : 'false');
       });
+      scheduleSearch();
     });
   });
 }
@@ -1298,6 +1321,7 @@ async function init() {
       const s = JSON.parse(stored);
       authToken = s.access_token;
       authUid = s.user_id;
+      sessionRole = s.role || 'customer';
     }
   } catch (e) {
     // No session or parse error — continue as guest, authToken stays null
@@ -1308,14 +1332,22 @@ async function init() {
   // TRU-158: snapshot the loading skeletons while they still exist in the DOM.
   SKELETON_HTML = document.getElementById('initialSkeletons').outerHTML;
 
-  // Saved pets — only attempted when logged in, using sbGet (auth required)
+  // Saved pets + suburb prefill — only when logged in (sbGet needs auth).
   if (authUid) {
     try {
-      const cp = await sbGet('customer_profiles', `user_id=eq.${authUid}&select=id`);
-      if (cp.length) {
-        myPets = await sbGet('pets', `customer_id=eq.${cp[0].id}&is_active=eq.true&select=id,name,breed`);
+      if (sessionRole === 'provider') {
+        // TRU-215: prefill the search suburb from the provider's own suburb (editable).
+        const pp = await sbGet('provider_profiles', `user_id=eq.${authUid}&select=suburb`);
+        if (!state.suburb && pp.length && pp[0].suburb) state.suburb = pp[0].suburb;
+      } else {
+        const cp = await sbGet('customer_profiles', `user_id=eq.${authUid}&select=id,suburb`);
+        if (cp.length) {
+          // TRU-215: prefill from the customer's suburb unless the URL already set one.
+          if (!state.suburb && cp[0].suburb) state.suburb = cp[0].suburb;
+          myPets = await sbGet('pets', `customer_id=eq.${cp[0].id}&is_active=eq.true&select=id,name,breed`);
+        }
       }
-    } catch (e) { /* ignore — pet chips just won't show */ }
+    } catch (e) { /* ignore — pet chips / prefill just won't show */ }
   }
 
   mountFilterForm();


### PR DESCRIPTION
Second of two PRs for TRU-215 (search/discovery theme). Onboarding theme is [#88](https://github.com/tomfarmery93/truffl/pull/88). No file overlap — either can merge first.

## Prefill suburb for logged-in users (editable)
Search now prefills the suburb from the signed-in user's own suburb — customers from `customer_profiles.suburb`, providers from `provider_profiles.suburb` — while staying a normal editable field, and a `?suburb=` URL param still wins. **Verified:** provider session prefilled "Summer Hill"; `?suburb=Newington` overrode it; logged-out unaffected.

## Live search updates (Tom's preferred option — replaces the off-screen button)
The "Update results" button sat at the bottom of the mobile refine sheet's scroll region and dropped below the fold. Results now update **live** as filters change: a 350ms-debounced `runSearch()` is hooked into every state mutation (suburb typing, service/size/pet/attribute toggles, when-mode, date, time, window sliders, walk length, recurring days). 
- **Desktop:** button removed (updates live).
- **Mobile:** the button becomes a **sticky "Show results"** CTA pinned to the bottom of the sheet, so it's always reachable; tapping it flushes any pending search and closes the sheet.
**Verified:** desktop toggle 19→10, debounced typing "Newington"→4, in-sheet toggle updates live, sticky button confirmed `position:sticky; bottom:0`, no `isLoading` wedge, console clean.

## Homepage search widget (index + about-us)
- **Service cycling:** the collapsed pill gently fades through all five services (Dog walking → boarding → sitting → daycare → drop-in, ~2.2s) as a hint that multiple exist. It stops on the first interaction (open or chip select) and restores the real service. **Purely cosmetic** — `state.service` stays `dog_walking`, so a submit-without-opening still sends `service=dog_walking` (verified). Respects `prefers-reduced-motion`.
- **Where/When overlap:** fixed by clipping the pill eyebrows so "Where"/"When" can't overflow into the divider, stabilising the service-label width so cycling doesn't shift the layout, and widening the popover column gap. Field boxes now measure cleanly non-overlapping.
- Both changes mirrored to the duplicated widget in `about-us/`.

Static HTML/JS only — no migrations, no edge-function changes. Live on merge + Pages deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)