### PR TITLE
TRU-172/173: Stripe webhook idempotency + reaper for stranded charges

### DIFF
--- a/supabase/functions/charge-booking/index.ts
+++ b/supabase/functions/charge-booking/index.ts
@@ -52,7 +52,7 @@ async function stripe(path: string, method: 'GET' | 'POST', body?: Record<string
 
 async function markFailed(bookingId: string, piId?: string) {
   await sb.from('bookings')
-    .update({ payment_status: 'failed', ...(piId ? { stripe_payment_intent_id: piId } : {}) })
+    .update({ payment_status: 'failed', payment_processing_at: null, ...(piId ? { stripe_payment_intent_id: piId } : {}) })
     .eq('id', bookingId);
 }
 
@@ -78,8 +78,10 @@ Deno.serve(async (req) => {
     const covered = b.cover_status === 'reassigned';
 
     // Atomic claim: only one invocation may move unpaid/failed -> processing.
+    // TRU-173: stamp the claim time so the reaper cron can detect bookings stranded in
+    // 'processing' (e.g. if this function crashes after the claim) and retry them.
     const { data: claimed } = await sb.from('bookings')
-      .update({ payment_status: 'processing' })
+      .update({ payment_status: 'processing', payment_processing_at: new Date().toISOString() })
       .eq('id', bookingId).in('payment_status', ['unpaid', 'failed'])
       .select('id');
     if (!claimed || !claimed.length) return json({ skipped: 'already processing or paid' });
@@ -124,12 +126,13 @@ Deno.serve(async (req) => {
         stripe_payment_intent_id: pi.id,
         application_fee_cents: fee,
         charged_at: new Date().toISOString(),
+        payment_processing_at: null,
       }).eq('id', bookingId);
       return json({ ok: true, payment_intent: pi.id, amount: b.total_cents, application_fee_cents: fee, covered });
     }
 
     // requires_action etc. — an off-session charge can't complete; flag for follow-up.
-    await sb.from('bookings').update({ payment_status: 'failed', stripe_payment_intent_id: pi.id }).eq('id', bookingId);
+    await sb.from('bookings').update({ payment_status: 'failed', stripe_payment_intent_id: pi.id, payment_processing_at: null }).eq('id', bookingId);
     return json({ ok: false, status: pi.status, payment_intent: pi.id });
   } catch (e) {
     console.error('charge-booking error', bookingId, e);

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -51,6 +51,22 @@ Deno.serve(async (req) => {
 
   const type = String(evt.type || '');
   const obj = ((evt.data as Record<string, unknown>)?.object || {}) as Record<string, unknown>;
+  const eventId = String(evt.id || '');
+  const eventCreated = Number(evt.created) || 0;
+
+  // TRU-172: dedupe on Stripe's event.id. Short-circuit events we've already fully processed
+  // so replays are no-ops. We only *record* the id after the handler succeeds (below), so a
+  // transient handler failure is safely reprocessed on Stripe's retry rather than swallowed.
+  if (eventId) {
+    const { data: seen, error: seenErr } = await sb.rpc('stripe_event_seen', { p_event_id: eventId });
+    if (seenErr) {
+      console.error('stripe-webhook stripe_event_seen failed', eventId, seenErr);
+      return new Response(JSON.stringify({ error: 'dedupe check failed' }), { status: 500, headers: { 'Content-Type': 'application/json' } });
+    }
+    if (seen === true) {
+      return new Response(JSON.stringify({ received: true, duplicate: true }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+  }
 
   try {
     if (type === 'payment_intent.succeeded') {
@@ -68,10 +84,17 @@ Deno.serve(async (req) => {
           .eq('id', bid).neq('payment_status', 'paid');
       }
     } else if (type === 'account.updated') {
-      await sb.from('provider_profiles')
-        .update({ payouts_enabled: !!obj.payouts_enabled, charges_enabled: !!obj.charges_enabled })
-        .eq('stripe_account_id', obj.id as string);
+      // TRU-172: apply only if this event is newer than the last one we applied for the
+      // account — an out-of-order/replayed event must not flip readiness flags backwards.
+      await sb.rpc('apply_stripe_account_update', {
+        p_account_id: obj.id as string,
+        p_payouts: !!obj.payouts_enabled,
+        p_charges: !!obj.charges_enabled,
+        p_created: eventCreated,
+      });
     }
+    // Mark processed only now that the handler ran cleanly (see dedupe note above).
+    if (eventId) await sb.rpc('record_stripe_event', { p_event_id: eventId, p_type: type, p_created: eventCreated });
     return new Response(JSON.stringify({ received: true }), { status: 200, headers: { 'Content-Type': 'application/json' } });
   } catch (e) {
     console.error('stripe-webhook error', type, e);

--- a/supabase/migrations/20260710000000_tru172_webhook_idempotency.sql
+++ b/supabase/migrations/20260710000000_tru172_webhook_idempotency.sql
@@ -1,0 +1,67 @@
+-- TRU-172: Stripe webhook idempotency + account.updated ordering guard.
+--
+-- Two correctness bugs in supabase/functions/stripe-webhook:
+--   1. No dedupe on Stripe's event.id — a replayed event re-ran its handler.
+--   2. account.updated blindly wrote whatever the event said, so an out-of-order or
+--      replayed event could flip a carer's payouts_enabled/charges_enabled BACKWARDS.
+--
+-- DB logic lives in SECURITY DEFINER RPCs (matches the codebase pattern) so the dedupe
+-- store can stay in `private` and PostgREST never needs the private schema exposed. The
+-- webhook (service-role client) calls these via sb.rpc(...), hence the explicit
+-- grant to service_role after revoking the public/anon/authenticated defaults.
+--
+-- Applied to the live DB via apply_migration (Supabase branching is broken on this repo);
+-- committed here for version control. The "Supabase Preview" PR check is expected to fail
+-- and is non-blocking (see TRU-145).
+
+-- 1. Dedupe store: one row per processed Stripe event id. Written only by the RPC below.
+create table if not exists private.stripe_processed_events (
+  event_id      text primary key,
+  type          text,
+  event_created timestamptz,
+  processed_at  timestamptz not null default now()
+);
+
+-- 2. High-water mark for account.updated ordering.
+alter table public.provider_profiles
+  add column if not exists last_account_event_at timestamptz;
+
+-- 3a. Has this event already been fully processed? Read-only pre-check so the webhook can
+--     short-circuit a replay before running any handler.
+create or replace function public.stripe_event_seen(p_event_id text)
+returns boolean language sql security definer set search_path = '' stable as $$
+  select exists (select 1 from private.stripe_processed_events where event_id = p_event_id);
+$$;
+
+-- 3b. Record an event id AFTER its handler succeeds. Idempotent (on conflict do nothing) so a
+--     retry that races is harmless. Recording only on success means a transient handler failure
+--     is safely reprocessed on Stripe's retry rather than being permanently swallowed.
+create or replace function public.record_stripe_event(p_event_id text, p_type text, p_created bigint)
+returns void language plpgsql security definer set search_path = '' as $$
+begin
+  insert into private.stripe_processed_events (event_id, type, event_created)
+  values (p_event_id, p_type, to_timestamp(p_created))
+  on conflict (event_id) do nothing;
+end; $$;
+
+-- 4. Apply account.updated only if strictly newer than the last applied event for this
+--    account. Atomic monotonic guard — replayed/out-of-order events are no-ops.
+create or replace function public.apply_stripe_account_update(
+  p_account_id text, p_payouts boolean, p_charges boolean, p_created bigint)
+returns void language plpgsql security definer set search_path = '' as $$
+begin
+  update public.provider_profiles
+     set payouts_enabled       = p_payouts,
+         charges_enabled       = p_charges,
+         last_account_event_at = to_timestamp(p_created)
+   where stripe_account_id = p_account_id
+     and (last_account_event_at is null or last_account_event_at < to_timestamp(p_created));
+end; $$;
+
+-- 5. Reachable only via the service-role webhook, never over the public API.
+revoke execute on function public.stripe_event_seen(text) from public, anon, authenticated;
+grant  execute on function public.stripe_event_seen(text) to service_role;
+revoke execute on function public.record_stripe_event(text, text, bigint) from public, anon, authenticated;
+grant  execute on function public.record_stripe_event(text, text, bigint) to service_role;
+revoke execute on function public.apply_stripe_account_update(text, boolean, boolean, bigint) from public, anon, authenticated;
+grant  execute on function public.apply_stripe_account_update(text, boolean, boolean, bigint) to service_role;

--- a/supabase/migrations/20260710000001_tru173_charge_reaper.sql
+++ b/supabase/migrations/20260710000001_tru173_charge_reaper.sql
@@ -1,0 +1,62 @@
+-- TRU-173: reaper for bookings stranded in payment_status = 'processing'.
+--
+-- charge-booking atomically claims a booking (unpaid/failed -> processing) before calling
+-- Stripe. If the function crashes after the claim, the booking is stuck in 'processing'
+-- forever — no retry, no sweep, nothing surfaces it, so that booking silently never charges.
+--
+-- Fix: stamp when the claim happened (bookings.payment_processing_at, set by the edge fn),
+-- then a pg_cron sweep RETRIES anything stale past a timeout via private.charge_booking.
+-- Retry (not mark-failed) is deliberate:
+--   * charge-booking uses idempotency key charge_<booking_id>, so if the original attempt had
+--     actually succeeded at Stripe before crashing, the retry returns the same succeeded
+--     PaymentIntent and the booking settles to 'paid' — no double charge.
+--   * marking a booking 'failed' would fire private.tg_payment_failed (TRU-149) and email the
+--     customer about a failure that may never have really happened.
+--
+-- Applied to the live DB via apply_migration; committed here for version control. The
+-- "Supabase Preview" PR check is expected to fail and is non-blocking (see TRU-145).
+
+-- 1. When the booking was claimed into 'processing' — lets the sweep measure staleness.
+alter table public.bookings
+  add column if not exists payment_processing_at timestamptz;
+
+-- 2. Retry bookings stuck in 'processing' longer than the timeout. Returns how many it retried.
+--    A null stamp is treated as stale (legacy rows claimed before this column existed).
+create or replace function private.reap_stranded_charges(p_timeout interval default '15 minutes')
+returns integer language plpgsql security definer set search_path = '' as $$
+declare
+  r record;
+  n int := 0;
+begin
+  for r in
+    select id from public.bookings
+    where payment_status = 'processing'
+      and (payment_processing_at is null or payment_processing_at < now() - p_timeout)
+  loop
+    -- Release the stuck claim so charge-booking can re-claim (unpaid/failed -> processing).
+    update public.bookings
+       set payment_status = 'unpaid', payment_processing_at = null
+     where id = r.id;
+    -- Re-dispatch the charge (idempotency-keyed, so a prior success is not double-charged).
+    perform private.charge_booking(r.id);
+    n := n + 1;
+  end loop;
+  if n > 0 then
+    raise log 'reap_stranded_charges: retried % stranded booking(s)', n;
+  end if;
+  return n;
+end; $$;
+
+-- Runs only from cron (definer context); never reachable over the public API.
+revoke execute on function private.reap_stranded_charges(interval) from public, anon, authenticated;
+
+-- 3. Sweep every 10 minutes via pg_cron (default 15-minute staleness window).
+create extension if not exists pg_cron;
+
+do $$
+begin
+  perform cron.unschedule('reap-stranded-charges')
+  where exists (select 1 from cron.job where jobname = 'reap-stranded-charges');
+end $$;
+
+select cron.schedule('reap-stranded-charges', '*/10 * * * *', $$select private.reap_stranded_charges();$$);


### PR DESCRIPTION
Closes TRU-172 and TRU-173 — the two lowest-risk Urgent money-path bugs from Epic A of the July 2026 Engx code review. Both are already applied to the live DB (via `apply_migration` + edge-function deploy); the migrations here are the version-controlled record.

## TRU-172 — Webhook idempotency + `account.updated` ordering
The webhook never deduped on Stripe's `event.id`, and `account.updated` blindly wrote whatever the event said — so a replayed or out-of-order event could flip a carer's `payouts_enabled`/`charges_enabled` **backwards**.

- New `private.stripe_processed_events` dedupe store. The webhook short-circuits any event id it has already fully processed. It records the id **only after the handler succeeds**, so a transient handler failure is safely reprocessed on Stripe's retry rather than permanently swallowed (important for the `payment_intent.succeeded` path).
- `account.updated` now applies through `apply_stripe_account_update`, a monotonic guard keyed on `event.created` vs a new `provider_profiles.last_account_event_at` high-water mark — older/replayed events are no-ops.
- New SECURITY DEFINER RPCs are revoked from `public/anon/authenticated` and granted to `service_role` only.

## TRU-173 — Reaper for bookings stranded in `payment_status='processing'`
`charge-booking` atomically claims a booking into `processing` before calling Stripe; a crash after the claim left it stuck forever with no retry or visibility.

- `charge-booking` now stamps `bookings.payment_processing_at` at claim time (cleared on terminal writes).
- `private.reap_stranded_charges()` runs via pg_cron every 10 min (15-min staleness window), resets stale rows to `unpaid`, and **retries** via `private.charge_booking`. Retry (not mark-failed) is deliberate: the `charge_<id>` idempotency key means a prior success settles to `paid` with no double charge, and it avoids firing the TRU-149 `payment_failed` email for a failure that never really happened.

## Verification (live, test mode)
- Dedupe: first call records, replay returns `{duplicate:true}` no-op.
- Ordering: older `account.updated` blocked, newer applied (run in a rolled-back txn — no carer data mutated).
- Reaper: a 30-min-stale `processing` booking reaped to `unpaid` (2-min-old one left alone), no spurious `failed` email; cron job `reap-stranded-charges` registered and active.

## Files
- `supabase/migrations/20260710000000_tru172_webhook_idempotency.sql`
- `supabase/migrations/20260710000001_tru173_charge_reaper.sql`
- `supabase/functions/stripe-webhook/index.ts` (deployed v3, `verify_jwt=false`)
- `supabase/functions/charge-booking/index.ts` (deployed v4, `verify_jwt=false`)

The "Supabase Preview" check is expected to fail and is non-blocking (see TRU-145).

🤖 Generated with [Claude Code](https://claude.com/claude-code)