### PR TITLE
TRU-170/171: derive booking price server-side

### DIFF
--- a/book/index.html
+++ b/book/index.html
@@ -300,6 +300,16 @@ async function sbInsert(table, row, token) {
   return await r.json();
 }
 
+// Call a Postgres RPC. Booking/series creation goes through server-side definer RPCs that
+// derive price from provider_services (the client can no longer set or tamper with price).
+async function sbRpc(fn, body, token) {
+  const r = await fetch(`${SUPABASE_URL}/rest/v1/rpc/${fn}`, {
+    method: 'POST', headers: headers(token), body: JSON.stringify(body)
+  });
+  if (!r.ok) { const e = await r.json().catch(() => ({})); throw new Error(e.message || 'Request failed'); }
+  return await r.json();
+}
+
 async function sbPatch(table, params, row, token) {
   const r = await fetch(`${SUPABASE_URL}/rest/v1/${table}?${params}`, {
     method: 'PATCH', headers: { ...headers(token), 'Prefer': 'return=minimal' }, body: JSON.stringify(row)
@@ -772,41 +782,23 @@ async function createMeetGreetSeries() {
   const btn = document.getElementById('mgConfirmBtn');
   setLoading(btn, true);
   try {
-    const seriesIns = await sbInsert('booking_series', {
-      customer_id: customerProfile.id,
-      provider_id: providerProfile.id,
-      service_id: intent.serviceId,
-      booking_kind: intent.kind,
-      frequency_type: intent.frequency_type,
-      days_of_week: intent.days_of_week,
-      time_of_day: intent.time_of_day,
-      window_end_time: intent.window_end_time,
-      start_date: intent.start_date,
-      end_date: intent.end_date,
-      status: 'pending_meet_greet',
-      locked_price_cents: intent.lockedPrice
-    }, authToken);
-    const series = Array.isArray(seriesIns) ? seriesIns[0] : seriesIns;
-    await sbInsert('series_pets', intent.petIds.map(pid => ({ series_id: series.id, pet_id: pid })), authToken);
-
-    // Placeholder time — the real timing is arranged in the messages thread.
+    // Price is derived server-side; the RPC creates the pending_meet_greet series, its pets,
+    // and the free flagged M&G booking (+ its pets) atomically. Placeholder M&G time — the real
+    // timing is arranged in the messages thread.
     const mgScheduled = new Date(`${intent.start_date}T12:00:00`).toISOString();
-    const mgIns = await sbInsert('bookings', {
-      customer_id: customerProfile.id,
-      provider_id: providerProfile.id,
-      pet_id: intent.petIds[0],
-      service_id: intent.serviceId,
-      status: 'confirmed',
-      scheduled_at: mgScheduled,
-      duration_mins: 30,
-      total_cents: 0,
-      is_meet_and_greet: true,
-      series_id: series.id
+    await sbRpc('create_booking_series', {
+      p_service_id: intent.serviceId,
+      p_pet_ids: intent.petIds,
+      p_booking_kind: intent.kind,
+      p_frequency_type: intent.frequency_type,
+      p_days_of_week: intent.days_of_week,
+      p_time_of_day: intent.time_of_day,
+      p_window_end_time: intent.window_end_time,
+      p_start_date: intent.start_date,
+      p_end_date: intent.end_date,
+      p_is_meet_greet: true,
+      p_mg_scheduled_at: mgScheduled
     }, authToken);
-    const mg = Array.isArray(mgIns) ? mgIns[0] : mgIns;
-    if (mg && mg.id) {
-      await sbInsert('booking_pets', intent.petIds.map(pid => ({ booking_id: mg.id, pet_id: pid })), authToken);
-    }
     closeMgModal();
     showMeetGreetSuccess(intent);
   } catch (e) {
@@ -887,40 +879,31 @@ async function submitBooking() {
     // First booking with this carer? Route into the meet & greet flow: the intended
     // booking is wrapped in a pending_meet_greet series and gated on the M&G.
     if (!(await hasCompletedMeetGreet())) {
-      const lockedPrice = lockedPriceFor(selectedSvc, selectedPetIds.length);
       const intent = isMultiDay ? {
         kind: 'multiday', svcType: selectedSvc.service_type, serviceId: selectedServiceId, petIds: selectedPetIds.slice(),
         frequency_type: 'daily', days_of_week: [], time_of_day: '12:00', window_end_time: null,
-        start_date: date, end_date: document.getElementById('bookDateEnd')?.value, lockedPrice
+        start_date: date, end_date: document.getElementById('bookDateEnd')?.value
       } : {
         kind: 'oneoff', svcType: selectedSvc.service_type, serviceId: selectedServiceId, petIds: selectedPetIds.slice(),
         frequency_type: 'daily', days_of_week: [], time_of_day: idxToHHMM(win.start), window_end_time: idxToHHMM(win.end),
-        start_date: date, end_date: null, lockedPrice
+        start_date: date, end_date: null
       };
       setLoading(btn, false);
       return enterMeetGreetFlow(intent);
     }
 
-    // pet_id keeps the first selected pet as the "primary" for backward compat;
-    // every selected pet (including the primary) is recorded in booking_pets.
-    const inserted = await sbInsert('bookings', {
-      customer_id: customerProfile.id,
-      provider_id: providerProfile.id,
-      pet_id: selectedPetIds[0],
-      service_id: selectedServiceId,
-      status: 'pending',
-      scheduled_at: scheduledAt,
-      ends_at: endsAt,
-      window_end_at: windowEndAt,
-      duration_mins: durationMins,
-      total_cents: 0,
-      customer_notes: notes || null
+    // Server-side RPC derives total_cents from provider_services + pet count, records the primary
+    // pet and every selected pet in booking_pets, and returns the new booking id. The client no
+    // longer sends a price (TRU-170/171).
+    await sbRpc('create_booking', {
+      p_service_id: selectedServiceId,
+      p_pet_ids: selectedPetIds,
+      p_scheduled_at: scheduledAt,
+      p_ends_at: endsAt,
+      p_window_end_at: windowEndAt,
+      p_duration_mins: durationMins,
+      p_customer_notes: notes || null
     }, authToken);
-
-    const booking = Array.isArray(inserted) ? inserted[0] : inserted;
-    if (booking && booking.id) {
-      await sbInsert('booking_pets', selectedPetIds.map(pid => ({ booking_id: booking.id, pet_id: pid })), authToken);
-    }
 
     document.getElementById('bookingContent').innerHTML = `
       <div class="form-card success-card fade-in">
@@ -960,11 +943,6 @@ async function submitSeries() {
   }
   if (!computeUpcomingDates(1).length) return showMsg('That schedule has no upcoming walks — check the dates.', 'error');
 
-  // Lock the per-walk price (base + extra-pet fees) at series creation.
-  const base = selectedSvc.price_cents;
-  const extraFee = selectedSvc.additional_pet_price_cents || 0;
-  const lockedPrice = base != null ? base + Math.max(0, selectedPetIds.length - 1) * extraFee : null;
-
   const btn = document.querySelector('.btn-primary');
   setLoading(btn, true);
   try {
@@ -979,30 +957,25 @@ async function submitSeries() {
         frequency_type: recurring.frequency,
         days_of_week: recurring.frequency === 'specific_days' ? recurring.days.slice().sort((a, b) => a - b) : [],
         time_of_day: idxToHHMM(win.start), window_end_time: idxToHHMM(win.end),
-        start_date: recurring.startDate, end_date: recurring.endMode === 'until' ? recurring.endDate : null,
-        lockedPrice
+        start_date: recurring.startDate, end_date: recurring.endMode === 'until' ? recurring.endDate : null
       };
       setLoading(btn, false);
       return enterMeetGreetFlow(intent);
     }
 
-    const inserted = await sbInsert('booking_series', {
-      customer_id: customerProfile.id,
-      provider_id: providerProfile.id,
-      service_id: selectedServiceId,
-      frequency_type: recurring.frequency,
-      days_of_week: recurring.frequency === 'specific_days' ? recurring.days.slice().sort((a, b) => a - b) : [],
-      time_of_day: idxToHHMM(win.start),
-      window_end_time: idxToHHMM(win.end),
-      start_date: recurring.startDate,
-      end_date: recurring.endMode === 'until' ? recurring.endDate : null,
-      status: 'pending',
-      locked_price_cents: lockedPrice
+    // Server-side RPC derives locked_price_cents from provider_services + pet count and records
+    // series_pets atomically. The client no longer sends a price (TRU-171).
+    await sbRpc('create_booking_series', {
+      p_service_id: selectedServiceId,
+      p_pet_ids: selectedPetIds,
+      p_booking_kind: 'recurring',
+      p_frequency_type: recurring.frequency,
+      p_days_of_week: recurring.frequency === 'specific_days' ? recurring.days.slice().sort((a, b) => a - b) : [],
+      p_time_of_day: idxToHHMM(win.start),
+      p_window_end_time: idxToHHMM(win.end),
+      p_start_date: recurring.startDate,
+      p_end_date: recurring.endMode === 'until' ? recurring.endDate : null
     }, authToken);
-    const series = Array.isArray(inserted) ? inserted[0] : inserted;
-    if (series && series.id) {
-      await sbInsert('series_pets', selectedPetIds.map(pid => ({ series_id: series.id, pet_id: pid })), authToken);
-    }
 
     const endText = recurring.endMode === 'until' ? ` until ${new Date(recurring.endDate + 'T00:00:00').toLocaleDateString('en-AU', { day: 'numeric', month: 'short', year: 'numeric' })}` : ', ongoing';
     document.getElementById('bookingContent').innerHTML = `

--- a/supabase/migrations/20260710000002_tru170_171_server_side_pricing.sql
+++ b/supabase/migrations/20260710000002_tru170_171_server_side_pricing.sql
@@ -9,10 +9,11 @@
 --
 -- Fix: create SECURITY DEFINER RPCs as the ONLY trusted path to create bookings/series. They
 -- derive price server-side from provider_services + pet count, ignoring anything the client
--- sends. Then revoke the client's privilege to write the price columns, so the old direct-insert
--- path can no longer set a price at all. Series were already priced server-side (the tru14/tru13
--- materialize functions copy locked_price_cents -> total_cents), so making locked_price_cents
--- trustworthy at series-creation time makes every materialized booking trustworthy too.
+-- sends. BEFORE triggers then block any client-role attempt to create a booking/series directly
+-- or to change the price column, so the old direct-insert path can no longer set a price. Series
+-- were already priced server-side (the tru14/tru13 materialize functions copy locked_price_cents
+-- -> total_cents), so making locked_price_cents trustworthy at creation makes every materialized
+-- booking trustworthy too.
 --
 -- Applied to the live DB via apply_migration (Supabase branching is broken on this repo);
 -- committed here for version control. The "Supabase Preview" check on the PR is expected to
@@ -88,10 +89,15 @@ declare
   v_booking_id  uuid;
 begin
   v_customer_id := private.assert_customer_owns_pets(p_pet_ids);
-  -- provider is derived from the service, never trusted from the client.
-  select provider_id into v_provider_id from public.provider_services where id = p_service_id;
+  -- Provider is derived from the service, never trusted from the client. Note the id spaces
+  -- differ: provider_services.provider_id references auth.users.id, but bookings.provider_id
+  -- references provider_profiles.id — so we map through provider_profiles.user_id.
+  select pp.id into v_provider_id
+    from public.provider_services ps
+    join public.provider_profiles pp on pp.user_id = ps.provider_id
+   where ps.id = p_service_id;
   if v_provider_id is null then
-    raise exception 'Service % not found', p_service_id;
+    raise exception 'Service % not found or has no provider profile', p_service_id;
   end if;
   v_total_cents := private.compute_service_price(p_service_id, cardinality(p_pet_ids));
 
@@ -111,6 +117,7 @@ begin
   return v_booking_id;
 end; $$;
 
+revoke execute on function public.create_booking(uuid, uuid[], timestamptz, timestamptz, timestamptz, int, text) from public, anon;
 grant execute on function public.create_booking(uuid, uuid[], timestamptz, timestamptz, timestamptz, int, text) to authenticated;
 
 -- ── 3. create_booking_series: recurring + first-time M&G, priced server-side ────
@@ -137,9 +144,13 @@ declare
   v_mg_id       uuid;
 begin
   v_customer_id := private.assert_customer_owns_pets(p_pet_ids);
-  select provider_id into v_provider_id from public.provider_services where id = p_service_id;
+  -- provider_services.provider_id is an auth.users.id; map it to provider_profiles.id.
+  select pp.id into v_provider_id
+    from public.provider_services ps
+    join public.provider_profiles pp on pp.user_id = ps.provider_id
+   where ps.id = p_service_id;
   if v_provider_id is null then
-    raise exception 'Service % not found', p_service_id;
+    raise exception 'Service % not found or has no provider profile', p_service_id;
   end if;
   v_locked := private.compute_service_price(p_service_id, cardinality(p_pet_ids));
 
@@ -176,15 +187,55 @@ begin
   return v_series_id;
 end; $$;
 
+revoke execute on function public.create_booking_series(uuid, uuid[], text, public.series_frequency, int[], time, time, date, date, boolean, timestamptz) from public, anon;
 grant execute on function public.create_booking_series(uuid, uuid[], text, public.series_frequency, int[], time, time, date, date, boolean, timestamptz) to authenticated;
 
--- ── 4. Lock down the price columns ─────────────────────────────────────────────
--- The client can no longer write price on any path. The definer RPCs run as the function owner
--- (bypassing these grants), so they remain the only way to set a price. bookings.total_cents is
--- NOT NULL with no default, so this also forces every client booking through create_booking.
--- RLS insert policies (bookings_customer_create, customers_insert_series) stay as defense in depth.
-revoke insert (total_cents), update (total_cents) on public.bookings from authenticated, anon;
-revoke insert (locked_price_cents), update (locked_price_cents) on public.booking_series from authenticated, anon;
+-- ── 4. Lock down price writes so the RPCs are the only trusted path ────────────
+-- Column-level REVOKE does NOT work here: Supabase grants anon/authenticated table-level
+-- INSERT/UPDATE, and a column-level revoke cannot subtract from a table-level grant. Enforce
+-- with BEFORE triggers instead. The guard functions are SECURITY INVOKER (default) so
+-- current_user reflects the real writer: 'postgres' inside the SECURITY DEFINER RPCs (allowed),
+-- vs 'authenticated'/'anon' for direct PostgREST writes (blocked). Providers keep updating
+-- their bookings (status/notes) — only a change to the price column is rejected.
+create or replace function private.tg_guard_booking_price()
+returns trigger language plpgsql set search_path = '' as $$
+begin
+  if current_user in ('anon','authenticated') then
+    if tg_op = 'INSERT' then
+      raise exception 'Bookings must be created via create_booking() / create_booking_series()'
+        using errcode = 'insufficient_privilege';
+    elsif tg_op = 'UPDATE' and new.total_cents is distinct from old.total_cents then
+      raise exception 'total_cents cannot be changed directly'
+        using errcode = 'insufficient_privilege';
+    end if;
+  end if;
+  return new;
+end; $$;
+
+drop trigger if exists trg_guard_booking_price on public.bookings;
+create trigger trg_guard_booking_price
+  before insert or update on public.bookings
+  for each row execute function private.tg_guard_booking_price();
+
+create or replace function private.tg_guard_series_price()
+returns trigger language plpgsql set search_path = '' as $$
+begin
+  if current_user in ('anon','authenticated') then
+    if tg_op = 'INSERT' then
+      raise exception 'Series must be created via create_booking_series()'
+        using errcode = 'insufficient_privilege';
+    elsif tg_op = 'UPDATE' and new.locked_price_cents is distinct from old.locked_price_cents then
+      raise exception 'locked_price_cents cannot be changed directly'
+        using errcode = 'insufficient_privilege';
+    end if;
+  end if;
+  return new;
+end; $$;
+
+drop trigger if exists trg_guard_series_price on public.booking_series;
+create trigger trg_guard_series_price
+  before insert or update on public.booking_series
+  for each row execute function private.tg_guard_series_price();
 
 -- ── 5. TRU-170 recovery report (run manually; backfill is a founder decision) ──
 -- Completed, chargeable bookings that were never charged under the old total_cents = 0 bug.

--- a/supabase/migrations/20260710000002_tru170_171_server_side_pricing.sql
+++ b/supabase/migrations/20260710000002_tru170_171_server_side_pricing.sql
@@ -1,0 +1,199 @@
+-- TRU-171 (+ TRU-170): Move booking price computation server-side.
+--
+-- Problem: book/index.html computed prices in browser JS and wrote bookings.total_cents /
+-- booking_series.locked_price_cents directly via PostgREST under RLS. The server never
+-- recomputed or validated against provider_services, so a tampered client could book at any
+-- price (TRU-171). Single (non-series) bookings were inserted with total_cents = 0 and nothing
+-- ever priced them, so the completion-charge trigger (tru146) skipped them and they were never
+-- charged (TRU-170).
+--
+-- Fix: create SECURITY DEFINER RPCs as the ONLY trusted path to create bookings/series. They
+-- derive price server-side from provider_services + pet count, ignoring anything the client
+-- sends. Then revoke the client's privilege to write the price columns, so the old direct-insert
+-- path can no longer set a price at all. Series were already priced server-side (the tru14/tru13
+-- materialize functions copy locked_price_cents -> total_cents), so making locked_price_cents
+-- trustworthy at series-creation time makes every materialized booking trustworthy too.
+--
+-- Applied to the live DB via apply_migration (Supabase branching is broken on this repo);
+-- committed here for version control. The "Supabase Preview" check on the PR is expected to
+-- fail and is non-blocking (see TRU-145 and the tru146/tru172 migration headers).
+
+-- ── 1. Single source of truth for price ───────────────────────────────────────
+-- base + (extra pets * per-extra-pet fee), read straight from provider_services.
+create or replace function private.compute_service_price(p_service_id uuid, p_pet_count int)
+returns integer language plpgsql security definer set search_path = '' as $$
+declare
+  svc public.provider_services;
+begin
+  if p_pet_count is null or p_pet_count < 1 then
+    raise exception 'At least one pet is required';
+  end if;
+  select * into svc from public.provider_services where id = p_service_id;
+  if not found then
+    raise exception 'Service % not found', p_service_id;
+  end if;
+  if not svc.is_available then
+    raise exception 'Service % is not available', p_service_id;
+  end if;
+  if svc.price_cents is null then
+    raise exception 'Service % has no price set', p_service_id;
+  end if;
+  return svc.price_cents + greatest(0, p_pet_count - 1) * coalesce(svc.additional_pet_price_cents, 0);
+end; $$;
+
+revoke execute on function private.compute_service_price(uuid, int) from public, anon, authenticated;
+
+-- ── shared guard: resolve + validate the calling customer and their pets ───────
+-- Returns the caller's customer_profiles.id; raises if the caller isn't a customer, the pet
+-- list is empty, or any pet isn't theirs. Keeps the two public RPCs DRY.
+create or replace function private.assert_customer_owns_pets(p_pet_ids uuid[])
+returns uuid language plpgsql security definer set search_path = '' as $$
+declare
+  v_customer_id uuid;
+  v_owned int;
+begin
+  if p_pet_ids is null or array_length(p_pet_ids, 1) is null then
+    raise exception 'At least one pet is required';
+  end if;
+  select id into v_customer_id from public.customer_profiles where user_id = auth.uid();
+  if v_customer_id is null then
+    raise exception 'No customer profile for the current user';
+  end if;
+  select count(*) into v_owned
+    from public.pets
+   where id = any(p_pet_ids) and customer_id = v_customer_id;
+  if v_owned <> cardinality(p_pet_ids) then
+    raise exception 'One or more pets do not belong to you';
+  end if;
+  return v_customer_id;
+end; $$;
+
+revoke execute on function private.assert_customer_owns_pets(uuid[]) from public, anon, authenticated;
+
+-- ── 2. create_booking: single (non-series) booking, priced server-side ─────────
+-- Replaces the client insert that shipped total_cents = 0. Fixes TRU-170 + TRU-171 for singles.
+create or replace function public.create_booking(
+  p_service_id     uuid,
+  p_pet_ids        uuid[],
+  p_scheduled_at   timestamptz,
+  p_ends_at        timestamptz default null,
+  p_window_end_at  timestamptz default null,
+  p_duration_mins  int         default null,
+  p_customer_notes text        default null
+) returns uuid language plpgsql security definer set search_path = public as $$
+declare
+  v_customer_id uuid;
+  v_provider_id uuid;
+  v_total_cents int;
+  v_booking_id  uuid;
+begin
+  v_customer_id := private.assert_customer_owns_pets(p_pet_ids);
+  -- provider is derived from the service, never trusted from the client.
+  select provider_id into v_provider_id from public.provider_services where id = p_service_id;
+  if v_provider_id is null then
+    raise exception 'Service % not found', p_service_id;
+  end if;
+  v_total_cents := private.compute_service_price(p_service_id, cardinality(p_pet_ids));
+
+  insert into public.bookings (
+    customer_id, provider_id, pet_id, service_id, status,
+    scheduled_at, ends_at, window_end_at, duration_mins,
+    total_cents, customer_notes, is_meet_and_greet
+  ) values (
+    v_customer_id, v_provider_id, p_pet_ids[1], p_service_id, 'pending',
+    p_scheduled_at, p_ends_at, p_window_end_at, p_duration_mins,
+    v_total_cents, nullif(btrim(coalesce(p_customer_notes, '')), ''), false
+  ) returning id into v_booking_id;
+
+  insert into public.booking_pets (booking_id, pet_id)
+  select v_booking_id, unnest(p_pet_ids);
+
+  return v_booking_id;
+end; $$;
+
+grant execute on function public.create_booking(uuid, uuid[], timestamptz, timestamptz, timestamptz, int, text) to authenticated;
+
+-- ── 3. create_booking_series: recurring + first-time M&G, priced server-side ────
+-- locked_price_cents is computed server-side. For the M&G case (p_is_meet_greet), the series is
+-- pending_meet_greet and the free flagged M&G booking is created atomically. Returns the series id.
+create or replace function public.create_booking_series(
+  p_service_id       uuid,
+  p_pet_ids          uuid[],
+  p_booking_kind     text,
+  p_frequency_type   public.series_frequency,
+  p_days_of_week     int[],
+  p_time_of_day      time,
+  p_window_end_time  time        default null,
+  p_start_date       date        default null,
+  p_end_date         date        default null,
+  p_is_meet_greet    boolean     default false,
+  p_mg_scheduled_at  timestamptz default null
+) returns uuid language plpgsql security definer set search_path = public as $$
+declare
+  v_customer_id uuid;
+  v_provider_id uuid;
+  v_locked      int;
+  v_series_id   uuid;
+  v_mg_id       uuid;
+begin
+  v_customer_id := private.assert_customer_owns_pets(p_pet_ids);
+  select provider_id into v_provider_id from public.provider_services where id = p_service_id;
+  if v_provider_id is null then
+    raise exception 'Service % not found', p_service_id;
+  end if;
+  v_locked := private.compute_service_price(p_service_id, cardinality(p_pet_ids));
+
+  insert into public.booking_series (
+    customer_id, provider_id, service_id, booking_kind,
+    frequency_type, days_of_week, time_of_day, window_end_time,
+    start_date, end_date, status, locked_price_cents
+  ) values (
+    v_customer_id, v_provider_id, p_service_id, coalesce(p_booking_kind, 'recurring'),
+    p_frequency_type, coalesce(p_days_of_week, '{}'::int[]), p_time_of_day, p_window_end_time,
+    p_start_date, p_end_date,
+    case when p_is_meet_greet then 'pending_meet_greet' else 'pending' end::public.series_status,
+    v_locked
+  ) returning id into v_series_id;
+
+  insert into public.series_pets (series_id, pet_id)
+  select v_series_id, unnest(p_pet_ids);
+
+  -- First-time booking with this carer: the intended booking is gated behind a free meet & greet.
+  if p_is_meet_greet then
+    insert into public.bookings (
+      customer_id, provider_id, pet_id, service_id, status,
+      scheduled_at, duration_mins, total_cents, is_meet_and_greet, series_id
+    ) values (
+      v_customer_id, v_provider_id, p_pet_ids[1], p_service_id, 'confirmed',
+      coalesce(p_mg_scheduled_at, (p_start_date::timestamp + time '12:00') at time zone 'Australia/Sydney'),
+      30, 0, true, v_series_id
+    ) returning id into v_mg_id;
+
+    insert into public.booking_pets (booking_id, pet_id)
+    select v_mg_id, unnest(p_pet_ids);
+  end if;
+
+  return v_series_id;
+end; $$;
+
+grant execute on function public.create_booking_series(uuid, uuid[], text, public.series_frequency, int[], time, time, date, date, boolean, timestamptz) to authenticated;
+
+-- ── 4. Lock down the price columns ─────────────────────────────────────────────
+-- The client can no longer write price on any path. The definer RPCs run as the function owner
+-- (bypassing these grants), so they remain the only way to set a price. bookings.total_cents is
+-- NOT NULL with no default, so this also forces every client booking through create_booking.
+-- RLS insert policies (bookings_customer_create, customers_insert_series) stay as defense in depth.
+revoke insert (total_cents), update (total_cents) on public.bookings from authenticated, anon;
+revoke insert (locked_price_cents), update (locked_price_cents) on public.booking_series from authenticated, anon;
+
+-- ── 5. TRU-170 recovery report (run manually; backfill is a founder decision) ──
+-- Completed, chargeable bookings that were never charged under the old total_cents = 0 bug.
+-- Surfaced for a backfill/recovery decision; not auto-remediated here.
+--
+--   select b.id, b.customer_id, b.provider_id, b.service_id, b.scheduled_at,
+--          b.completed_at, b.total_cents, b.payment_status
+--     from public.bookings b
+--    where b.status = 'completed'
+--      and not b.is_meet_and_greet
+--      and (coalesce(b.total_cents, 0) = 0 or b.payment_status <> 'paid')
+--    order by b.completed_at;


### PR DESCRIPTION
## Why

Two urgent **Engx Epic A** revenue bugs (TRU-159), both rooted in prices being computed in the browser and written straight to the DB by the client:

- **TRU-171** — `book/index.html` computed price in JS and wrote `bookings.total_cents` / `booking_series.locked_price_cents` directly via PostgREST. The server never validated against `provider_services`, so a tampered client could book at any price.
- **TRU-170** — single (non-series) bookings were inserted with `total_cents: 0`; nothing priced them, and the completion-charge trigger skips `total_cents <= 0`, so **single bookings completed without ever being charged**. (Confirmed a bug, not an intentional free period.)

## What changed

**DB** (`supabase/migrations/20260710000002_tru170_171_server_side_pricing.sql`)
- `private.compute_service_price(service, pet_count)` — single source of truth: `price_cents + (extra pets × per-pet fee)` from `provider_services`.
- `private.assert_customer_owns_pets(pet_ids)` — resolves the caller's customer profile and rejects pets that aren't theirs.
- `public.create_booking(...)` and `public.create_booking_series(...)` — `SECURITY DEFINER` RPCs (mirroring the `cancel_my_booking` pattern) that derive price server-side and insert the booking/series + its pets (and the free M&G booking) atomically. `provider_id` is mapped through `provider_profiles.user_id` (the service's `provider_id` is an `auth.users.id`, not a profile id).
- `BEFORE INSERT/UPDATE` guard triggers on `bookings` / `booking_series` (`SECURITY INVOKER`) that reject any client-role attempt to create a booking/series directly or to change the price column, while allowing the definer RPCs and legitimate provider updates. (A column-level `REVOKE` doesn't work under Supabase's table-level grants.)
- `EXECUTE` on the two RPCs revoked from `public`/`anon` (signed-in customers only).
- A documented recovery query for completed-but-uncharged bookings.

**Frontend** (`book/index.html`)
- New `sbRpc` helper; single, recurring, and first-time (M&G-gated) creation all go through the RPCs and no longer send any price. `renderPriceEstimate` stays a display-only estimate.

## Verification (run against the live DB)

- Single / recurring / M&G creation all produce the correct **server-derived** price (`total_cents` / `locked_price_cents` = base + extra-pet fees, non-zero); provider mapped to the right `provider_profiles.id`; pets recorded; M&G booking is free + flagged.
- Guard **blocks** direct client inserts and `total_cents` / `locked_price_cents` tampering; **allows** provider status/notes updates and the definer RPCs.
- The migration has already been applied to the live DB via `apply_migration`; the "Supabase Preview" check is expected to fail and is non-blocking (see the tru146/tru172 migration headers).

## Note
The recovery query surfaces **12** completed single bookings that were never charged under the old bug — backfill/recovery is a founder decision, not automated here.

Closes TRU-170, TRU-171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nx5aDGa5xtABLoA2ox7BCB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nx5aDGa5xtABLoA2ox7BCB)_