### PR TITLE
TRU-174: select Stripe publishable key by environment

### DIFF
--- a/profile/index.html
+++ b/profile/index.html
@@ -254,8 +254,16 @@
 const SUPABASE_URL = 'https://gadflsntbnbnnxbpiral.supabase.co';
 const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdhZGZsc250Ym5ibm54YnBpcmFsIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzUwNjcwNTcsImV4cCI6MjA5MDY0MzA1N30.g5ZrqeAX9U5l7oDZEbQFrU5j10828dUF0QuJ0ZlHXK8';
 
-// Stripe publishable (test) key — public by design, safe to ship client-side (TRU-144).
-const STRIPE_PK = 'pk_test_51TlHff1Sh4qkQvUZOXzfEFJzZcGilXp5JjaDQc3ksDFiF7iJSYSmanteWT9nDpVFiLtshU92hFucVAZzNyFvXgPX00z34gWOQA';
+// Stripe publishable key — public by design, safe to ship client-side (TRU-144).
+// It MUST match the mode of the backend STRIPE_SECRET_KEY (stripe-api / charge-booking edge-fn
+// env). The backend is currently in TEST mode, so we ship the test key everywhere. At go-live
+// (TRU-174): set STRIPE_PK_LIVE to the pk_live_… key AND switch the backend secret key to live in
+// the same change — the domain check then serves the live key on trufflpets.com (web + the
+// Capacitor app, which loads from that origin) and the test key everywhere else (local/preview).
+const STRIPE_PK_TEST = 'pk_test_51TlHff1Sh4qkQvUZOXzfEFJzZcGilXp5JjaDQc3ksDFiF7iJSYSmanteWT9nDpVFiLtshU92hFucVAZzNyFvXgPX00z34gWOQA';
+const STRIPE_PK_LIVE = ''; // pk_live_… — set at go-live; must match the backend secret-key mode
+const STRIPE_IS_PROD = /(^|\.)trufflpets\.com$/i.test(location.hostname);
+const STRIPE_PK = (STRIPE_IS_PROD && STRIPE_PK_LIVE) ? STRIPE_PK_LIVE : STRIPE_PK_TEST;
 
 const SERVICE_LABELS = {
   dog_walking:'Dog walking', dog_sitting:'Dog sitting', dog_boarding:'Dog boarding',


### PR DESCRIPTION
## Why

`profile/index.html` hardcoded a single **`pk_test`** Stripe publishable key (TRU-174, Engx Epic A). The publishable key shipped to the client must match the mode of the backend `STRIPE_SECRET_KEY` (the `stripe-api` / `charge-booking` edge-function env). If they mismatch, Stripe rejects card setup outright. The backend is currently in **test** mode, so today test PK + test SK are consistent — but the key was hardcoded with no way to serve a live key when going live.

## What changed

`profile/index.html` — the sole Stripe PK definition (used at the two `Stripe(STRIPE_PK)` call sites) now selects by environment:

```js
const STRIPE_PK_TEST = 'pk_test_…';
const STRIPE_PK_LIVE = ''; // pk_live_… — set at go-live; must match the backend secret-key mode
const STRIPE_IS_PROD = /(^|\.)trufflpets\.com$/i.test(location.hostname);
const STRIPE_PK = (STRIPE_IS_PROD && STRIPE_PK_LIVE) ? STRIPE_PK_LIVE : STRIPE_PK_TEST;
```

- **No behaviour change today**: `STRIPE_PK_LIVE` is empty, so every environment (prod, local, preview) ships the test key — matching the test backend.
- **Go-live is a one-line change in one place**: set `STRIPE_PK_LIVE` to the `pk_live_…` key, done together with switching the backend secret key to live so the modes stay matched. The domain check then serves the live key on `trufflpets.com` — which covers both the website and the Capacitor mobile app, since it loads from that origin (`capacitor.config.json` `server.url`) — and the test key everywhere else.

## Scope note

This is the immediate correctness fix + go-live scaffold. A general per-environment config-injection mechanism (Supabase + Stripe keys) is separate future work (Epic D / TRU-188); this deliberately stays a minimal, static-site-friendly change with no build step.

## Verification
- Backend mode confirmed test (per code comments + owner); test PK + test SK are consistent.
- Only Stripe PK usage in the repo is in `profile/index.html`; both `Stripe(STRIPE_PK)` call sites unchanged. Inline JS syntax-checks clean.

Closes TRU-174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nx5aDGa5xtABLoA2ox7BCB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nx5aDGa5xtABLoA2ox7BCB)_