### PR TITLE
TRU-165 Epic G: security hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# TRU-202: automated dependency update PRs. Covers the two npm manifests (repo root and the
+# email package) plus GitHub Actions once workflows exist (Epic B / TRU-175).
+# NOTE: secret scanning + push protection are repo-settings toggles (GitHub → Settings → Code
+# security) and cannot be enabled from a committed file — those remain a manual step for TRU-202.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "npm"
+    directory: "/emails"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,0 +1,25 @@
+// Shared CORS config for browser-facing edge functions (TRU-200).
+//
+// Replaces `Access-Control-Allow-Origin: *` with an allow-list. The website and the Capacitor
+// mobile app both load from https://trufflpets.com (capacitor.config.json `server.url`), so that
+// is the primary browser origin; www and the Capacitor localhost shells are included for
+// completeness / local dev. An unknown origin falls back to the apex domain (i.e. it is not
+// reflected), so the browser's origin-protection layer is preserved. `Vary: Origin` keeps caches
+// from serving one origin's ACAO header to another.
+const ALLOWED_ORIGINS = new Set([
+  'https://trufflpets.com',
+  'https://www.trufflpets.com',
+  'capacitor://localhost',
+  'http://localhost',
+]);
+
+export function corsHeaders(req: Request): Record<string, string> {
+  const origin = req.headers.get('Origin') ?? '';
+  const allowOrigin = ALLOWED_ORIGINS.has(origin) ? origin : 'https://trufflpets.com';
+  return {
+    'Access-Control-Allow-Origin': allowOrigin,
+    'Access-Control-Allow-Headers': 'authorization, content-type, apikey',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Vary': 'Origin',
+  };
+}

--- a/supabase/functions/_shared/secret.ts
+++ b/supabase/functions/_shared/secret.ts
@@ -1,0 +1,12 @@
+// Shared helpers for edge functions (seeds TRU-190's supabase/functions/_shared/).
+
+// Constant-time string comparison for shared-secret header checks (TRU-199).
+// Mirrors the constant-time HMAC compare already used in stripe-webhook, replacing the
+// timing-unsafe `!==` checks in send-notification and charge-booking. The length check can
+// leak the secret's length, which is not sensitive for a fixed-length shared secret.
+export function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}

--- a/supabase/functions/charge-booking/index.ts
+++ b/supabase/functions/charge-booking/index.ts
@@ -10,6 +10,7 @@
 //   STRIPE_SECRET_KEY, WEBHOOK_SECRET  (+ SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY injected)
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { timingSafeEqual } from '../_shared/secret.ts';
 
 const STRIPE_SECRET_KEY = Deno.env.get('STRIPE_SECRET_KEY')!;
 const WEBHOOK_SECRET = Deno.env.get('WEBHOOK_SECRET')!;
@@ -58,7 +59,7 @@ async function markFailed(bookingId: string, piId?: string) {
 
 Deno.serve(async (req) => {
   if (req.method !== 'POST') return json({ error: 'Method not allowed' }, 405);
-  if (req.headers.get('x-webhook-secret') !== WEBHOOK_SECRET) return json({ error: 'Unauthorized' }, 401);
+  if (!timingSafeEqual(req.headers.get('x-webhook-secret') ?? '', WEBHOOK_SECRET)) return json({ error: 'Unauthorized' }, 401);
 
   let payload: Record<string, unknown>;
   try { payload = await req.json(); } catch { return json({ error: 'Bad JSON' }, 400); }

--- a/supabase/functions/geo-api/index.ts
+++ b/supabase/functions/geo-api/index.ts
@@ -10,24 +10,20 @@
 // fallback, so search itself never calls a routing API.
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { corsHeaders } from '../_shared/cors.ts';
 
 const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
 const SERVICE_ROLE = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
 const sb = createClient(SUPABASE_URL, SERVICE_ROLE);
 
-const CORS: Record<string, string> = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, content-type, apikey',
-  'Access-Control-Allow-Methods': 'POST, OPTIONS',
-};
-
-function json(body: unknown, status = 200) {
-  return new Response(JSON.stringify(body), { status, headers: { ...CORS, 'Content-Type': 'application/json' } });
-}
-
 const TRAVEL_MINUTES = [10, 15, 20, 30, 45, 60];
 
 Deno.serve(async (req) => {
+  // Per-request CORS (origin allow-list) — TRU-200. Local `json` closes over it.
+  const CORS = corsHeaders(req);
+  const json = (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), { status, headers: { ...CORS, 'Content-Type': 'application/json' } });
+
   if (req.method === 'OPTIONS') return new Response('ok', { headers: CORS });
   if (req.method !== 'POST') return json({ error: 'Method not allowed' }, 405);
 

--- a/supabase/functions/send-notification/index.ts
+++ b/supabase/functions/send-notification/index.ts
@@ -9,6 +9,7 @@
 //   (SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY are injected automatically)
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { timingSafeEqual } from '../_shared/secret.ts';
 
 const RESEND_API_KEY = Deno.env.get('RESEND_API_KEY')!;
 const WEBHOOK_SECRET = Deno.env.get('WEBHOOK_SECRET')!;
@@ -392,7 +393,7 @@ async function sendEmail(msg: { to: string; subject: string; html: string; reply
 
 Deno.serve(async (req) => {
   if (req.method !== 'POST') return new Response('Method not allowed', { status: 405 });
-  if (req.headers.get('x-webhook-secret') !== WEBHOOK_SECRET) {
+  if (!timingSafeEqual(req.headers.get('x-webhook-secret') ?? '', WEBHOOK_SECRET)) {
     return new Response('Unauthorized', { status: 401 });
   }
   let payload: Record<string, unknown>;

--- a/supabase/functions/stripe-api/index.ts
+++ b/supabase/functions/stripe-api/index.ts
@@ -28,6 +28,7 @@
 //   (SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY are injected automatically)
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { corsHeaders } from '../_shared/cors.ts';
 
 const STRIPE_SECRET_KEY = Deno.env.get('STRIPE_SECRET_KEY')!;
 const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
@@ -37,16 +38,6 @@ const SITE = 'https://trufflpets.com';
 const PLATFORM_FEE_BPS = 1500;
 
 const sb = createClient(SUPABASE_URL, SERVICE_ROLE);
-
-const CORS: Record<string, string> = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, content-type, apikey',
-  'Access-Control-Allow-Methods': 'POST, OPTIONS',
-};
-
-function json(body: unknown, status = 200) {
-  return new Response(JSON.stringify(body), { status, headers: { ...CORS, 'Content-Type': 'application/json' } });
-}
 
 // Form-encode with Stripe's nested-bracket convention (e.g. capabilities[transfers][requested]).
 function encode(obj: Record<string, unknown>, prefix = ''): string {
@@ -98,6 +89,11 @@ async function isAdmin(userId: string) {
 }
 
 Deno.serve(async (req) => {
+  // Per-request CORS (origin allow-list) — TRU-200. Local `json` closes over it.
+  const CORS = corsHeaders(req);
+  const json = (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), { status, headers: { ...CORS, 'Content-Type': 'application/json' } });
+
   if (req.method === 'OPTIONS') return new Response('ok', { headers: CORS });
   if (req.method !== 'POST') return json({ error: 'Method not allowed' }, 405);
 

--- a/supabase/migrations/20260714000000_tru165_db_security_hardening.sql
+++ b/supabase/migrations/20260714000000_tru165_db_security_hardening.sql
@@ -1,0 +1,42 @@
+-- TRU-165 Epic G — DB security & payment-path hardening.
+--
+-- TRU-198: public.handle_new_user() is SECURITY DEFINER with an UNPINNED search_path
+--          (baseline 00000000000000_baseline.sql:42-56) and runs on every auth signup — the
+--          classic Supabase mutable-search-path lint, on the most-executed definer function in
+--          the system. tru153 hardened the rest of the definer surface but missed this one. Pin
+--          it to '' (the body already fully-qualifies public.users).
+-- TRU-201: no indexes exist on the payment columns the webhook / charge / reaper paths filter on
+--          (bookings.payment_status, bookings.stripe_payment_intent_id). Add them. (The separate
+--          ~50 cold-table initplan/duplicate-policy advisor lints from TRU-142 are NOT addressed
+--          here — tracked as remaining scope on TRU-201.)
+--
+-- Applied to the live DB via apply_migration (Supabase branching is broken on this repo);
+-- committed here for version control. The "Supabase Preview" PR check is expected to fail and is
+-- non-blocking (see TRU-145 and prior migration headers).
+
+-- ── TRU-198: pin search_path on the signup trigger function ────────────────────
+create or replace function public.handle_new_user()
+returns trigger language plpgsql security definer set search_path = '' as $function$
+begin
+  insert into public.users (id, auth_id, email, first_name, last_name, role)
+  values (
+    new.id,
+    new.id,
+    new.email,
+    new.raw_user_meta_data->>'first_name',
+    new.raw_user_meta_data->>'last_name',
+    coalesce(new.raw_user_meta_data->>'role', 'customer')
+  );
+  return new;
+end;
+$function$;
+
+-- ── TRU-201: payment-path indexes ──────────────────────────────────────────────
+-- Reaper sweeps `payment_status = 'processing'`; the webhook/charge paths look bookings up by
+-- their Stripe PaymentIntent id (null until a charge is attempted, so a partial index).
+create index if not exists idx_bookings_payment_status
+  on public.bookings (payment_status);
+
+create index if not exists idx_bookings_stripe_pi
+  on public.bookings (stripe_payment_intent_id)
+  where stripe_payment_intent_id is not null;


### PR DESCRIPTION
Works through **Engx Epic G (TRU-165)** — the security pass from the July code review.

## DB (applied live via `apply_migration`; migration committed for VC)

- **TRU-198** — `public.handle_new_user()` was `SECURITY DEFINER` with an **unpinned `search_path`** and runs on every signup (the last unpinned definer fn after tru153). Pinned to `''`. Verified: the Supabase security advisor **no longer flags it** under `function_search_path_mutable`, and the `on_auth_user_created` trigger is still bound.
- **TRU-201** — added the missing payment-path indexes the reaper / webhook / charge paths filter on: `idx_bookings_payment_status` and (partial) `idx_bookings_stripe_pi`. Both confirmed present. *The separate ~50 cold-table advisor lints from TRU-142 are intentionally out of scope — noted as remaining on TRU-201.*

## Edge functions — ⚠️ code only, take effect on next deploy

These are committed but **not deployed** (deploys are still manual — TRU-177). They have no effect on the running functions until `supabase functions deploy` is run, so nothing changes in production from this PR alone.

- New **`supabase/functions/_shared/`** (seeds Epic E / TRU-190): `secret.ts` (constant-time compare) + `cors.ts` (origin allow-list).
- **TRU-199** — replaced timing-unsafe `!==` on the `x-webhook-secret` header with `timingSafeEqual` in `send-notification` and `charge-booking` (matches the constant-time compare stripe-webhook already uses).
- **TRU-200** — replaced `Access-Control-Allow-Origin: *` in `stripe-api` and `geo-api` with a per-request allow-list (`trufflpets.com` / `www` / Capacitor `localhost` shells; unknown origins are not reflected). The `json()` helper is now built per-request so it carries the right CORS headers. **Review the allow-list before deploying** — a wrong origin would break the web/mobile app's calls to these functions.

## Config

- **TRU-202** — added `.github/dependabot.yml` (npm root + `emails/`, plus github-actions). **Secret scanning + push protection are GitHub repo-settings toggles** (Settings → Code security) and can't be set from a committed file — that half of TRU-202 remains a manual step for you.

## Status by ticket
- ✅ TRU-198 — done + verified live
- 🟩 TRU-201 — payment indexes done; cold-table lint cleanup deferred
- 🟨 TRU-199 / TRU-200 — code complete, **pending edge-function deploy**
- 🟨 TRU-202 — dependabot config done; secret-scanning toggle is on you

The "Supabase Preview" check will fail as usual (non-blocking, see prior PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nx5aDGa5xtABLoA2ox7BCB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nx5aDGa5xtABLoA2ox7BCB)_