### PR TITLE
TRU-176: replay migrations against a fresh DB in CI

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -1,0 +1,82 @@
+# TRU-176: replay the full migration history against a fresh database on every change
+# under supabase/. This is what makes the files in supabase/migrations/ the real,
+# provable source of truth rather than a hand-maintained record of what was applied
+# to prod (the drift called out in TRU-145/TRU-176).
+#
+# The job fails if any migration errors when applied from scratch, and also if the
+# replayed end state is missing objects we know prod relies on (smoke asserts below) —
+# so a migration that "succeeds" but silently produces the wrong schema still fails.
+name: Migrations
+
+on:
+  pull_request:
+    paths: ['supabase/**']
+  push:
+    branches: [main]
+    paths: ['supabase/**']
+
+jobs:
+  replay:
+    name: Replay migrations on a fresh DB
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Start fresh local database
+        run: supabase db start
+
+      - name: Replay all migrations from scratch
+        run: supabase db reset
+
+      - name: Smoke-assert the replayed end state
+        run: |
+          psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres" \
+            --set ON_ERROR_STOP=1 --quiet <<'SQL'
+          do $$
+          declare
+            missing text := '';
+          begin
+            -- Booking-creation RPCs (TRU-170/171)
+            if to_regprocedure('public.create_booking(uuid,uuid[],timestamptz,timestamptz,timestamptz,int,text)') is null then
+              missing := missing || ' public.create_booking'; end if;
+            if not exists (select 1 from pg_proc p join pg_namespace n on n.oid = p.pronamespace
+                           where n.nspname = 'public' and p.proname = 'create_booking_series') then
+              missing := missing || ' public.create_booking_series'; end if;
+
+            -- Price guards (TRU-171)
+            if not exists (select 1 from pg_trigger where tgname = 'trg_guard_booking_price') then
+              missing := missing || ' trg_guard_booking_price'; end if;
+            if not exists (select 1 from pg_trigger where tgname = 'trg_guard_series_price') then
+              missing := missing || ' trg_guard_series_price'; end if;
+
+            -- Payment-path objects (TRU-146/172/173/201)
+            if not exists (select 1 from pg_indexes where indexname = 'idx_bookings_payment_status') then
+              missing := missing || ' idx_bookings_payment_status'; end if;
+            if not exists (select 1 from pg_proc p join pg_namespace n on n.oid = p.pronamespace
+                           where n.nspname = 'private' and p.proname = 'reap_stranded_charges') then
+              missing := missing || ' private.reap_stranded_charges'; end if;
+            if not exists (select 1 from pg_proc p join pg_namespace n on n.oid = p.pronamespace
+                           where n.nspname = 'private' and p.proname = 'tg_charge_on_completion') then
+              missing := missing || ' private.tg_charge_on_completion'; end if;
+
+            -- Signup trigger fn must exist AND have a pinned search_path (TRU-198)
+            if not exists (select 1 from pg_proc p join pg_namespace n on n.oid = p.pronamespace
+                           where n.nspname = 'public' and p.proname = 'handle_new_user'
+                             and p.proconfig::text like '%search_path%') then
+              missing := missing || ' handle_new_user(search_path pinned)'; end if;
+
+            -- Core tables sanity
+            if to_regclass('public.bookings') is null then missing := missing || ' public.bookings'; end if;
+            if to_regclass('public.booking_series') is null then missing := missing || ' public.booking_series'; end if;
+            if to_regclass('private.stripe_config') is null then missing := missing || ' private.stripe_config'; end if;
+
+            if missing <> '' then
+              raise exception 'replayed schema is missing:%', missing;
+            end if;
+            raise notice 'smoke asserts passed';
+          end $$;
+          SQL

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -22,15 +22,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: supabase/setup-cli@v1
-        with:
-          version: latest
-
+      # Install the CLI via npm rather than supabase/setup-cli: the action resolves
+      # "latest" through the GitHub API and intermittently dies on runner-IP rate
+      # limits; npm fetches the pinned-major binary from the release CDN instead.
       - name: Start fresh local database
-        run: supabase db start
+        run: npx --yes supabase@2 db start
 
       - name: Replay all migrations from scratch
-        run: supabase db reset
+        run: npx --yes supabase@2 db reset
 
       - name: Smoke-assert the replayed end state
         run: |

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,10 @@
+# TRU-176: minimal Supabase CLI config so `supabase db reset` can replay the migration
+# history against a fresh local DB (used by .github/workflows/migrations.yml).
+# Deliberately minimal — the full local development story (auth config, seed data,
+# edge-function serving, docs) is TRU-209.
+project_id = "truffl"
+
+[db]
+port = 54322
+shadow_port = 54320
+major_version = 17

--- a/supabase/migrations/20260615000000_tru14_meet_and_greets.sql
+++ b/supabase/migrations/20260615000000_tru14_meet_and_greets.sql
@@ -10,8 +10,7 @@
 -- provider_profiles.id mismatch called out in TRU-61.
 --
 -- Applied to the live DB via apply_migration (Supabase branching is broken on this
--- repo); committed here for version control. The "Supabase Preview" check on this
--- PR is expected to fail and is non-blocking.
+-- repo); committed here for version control.
 
 -- 1. New series state: the intended booking is locked in as pending until the M&G
 --    is completed and the customer proceeds.

--- a/supabase/migrations/20260628000000_tru143_stripe_connect_onboarding.sql
+++ b/supabase/migrations/20260628000000_tru143_stripe_connect_onboarding.sql
@@ -4,8 +4,7 @@
 -- charge Edge Function via pg_net.
 --
 -- Applied to the live DB via apply_migration (Supabase branching is broken on this repo);
--- committed here for version control. The "Supabase Preview" check on the PR is expected to
--- fail and is non-blocking.
+-- committed here for version control.
 
 alter table public.provider_profiles
   add column if not exists stripe_account_id text,

--- a/supabase/migrations/20260628000001_tru144_customer_stripe_customer_id.sql
+++ b/supabase/migrations/20260628000001_tru144_customer_stripe_customer_id.sql
@@ -3,7 +3,6 @@
 -- Customer id so the saved card can be charged on service completion (Phase 3).
 --
 -- Applied to the live DB via apply_migration (Supabase branching is broken on this repo);
--- committed here for version control. The "Supabase Preview" check on the PR is expected to
--- fail and is non-blocking (see TRU-145).
+-- committed here for version control.
 alter table public.customer_profiles
   add column if not exists stripe_customer_id text;

--- a/supabase/migrations/20260628000002_tru146_charge_on_completion.sql
+++ b/supabase/migrations/20260628000002_tru146_charge_on_completion.sql
@@ -5,8 +5,7 @@
 -- can never roll back the booking write. Mirrors the email pipeline (private.notify_email).
 --
 -- Applied to the live DB via apply_migration (Supabase branching is broken on this repo);
--- committed here for version control. The "Supabase Preview" check on the PR is expected to
--- fail and is non-blocking (see TRU-145).
+-- committed here for version control.
 
 -- Per-booking payment tracking. A single PaymentIntent may settle multiple bookings, so a
 -- later fortnightly per-(customer,carer) batch job can reuse the same charge engine.

--- a/supabase/migrations/20260629000000_tru149_payment_failed_email.sql
+++ b/supabase/migrations/20260629000000_tru149_payment_failed_email.sql
@@ -3,8 +3,7 @@
 -- an email hiccup can never roll back the booking write.
 --
 -- Applied to the live DB via apply_migration (Supabase branching is broken on this repo);
--- committed here for version control. The "Supabase Preview" check on the PR is expected to
--- fail and is non-blocking (see TRU-145).
+-- committed here for version control.
 create or replace function private.tg_payment_failed() returns trigger language plpgsql security definer set search_path = '' as $$
 begin
   if NEW.payment_status = 'failed' and OLD.payment_status is distinct from 'failed' then

--- a/supabase/migrations/20260629000001_tru150_refunds_and_admin.sql
+++ b/supabase/migrations/20260629000001_tru150_refunds_and_admin.sql
@@ -3,8 +3,7 @@
 -- Refund tracking + the 'refunded' payment state.
 --
 -- Applied to the live DB via apply_migration (Supabase branching is broken on this repo);
--- committed here for version control. The "Supabase Preview" check on the PR is expected to
--- fail and is non-blocking (see TRU-145).
+-- committed here for version control.
 alter table public.users add column if not exists is_admin boolean not null default false;
 
 alter table public.bookings

--- a/supabase/migrations/20260702000000_tru153_revoke_definer_fn_execute.sql
+++ b/supabase/migrations/20260702000000_tru153_revoke_definer_fn_execute.sql
@@ -9,8 +9,7 @@
 -- mark_meet_greet_complete stays granted to authenticated (the client calls it intentionally).
 -- Leaves PostGIS st_estimatedextent alone (extension-owned).
 --
--- Applied to the live DB via apply_migration; committed for version control. Supabase Preview
--- check is expected to fail and is non-blocking (see TRU-145).
+-- Applied to the live DB via apply_migration; committed for version control.
 
 revoke execute on function public.generate_series_bookings(uuid, integer) from public, anon, authenticated;
 revoke execute on function public.roll_all_series_bookings() from public, anon, authenticated;

--- a/supabase/migrations/20260710000000_tru172_webhook_idempotency.sql
+++ b/supabase/migrations/20260710000000_tru172_webhook_idempotency.sql
@@ -11,8 +11,7 @@
 -- grant to service_role after revoking the public/anon/authenticated defaults.
 --
 -- Applied to the live DB via apply_migration (Supabase branching is broken on this repo);
--- committed here for version control. The "Supabase Preview" PR check is expected to fail
--- and is non-blocking (see TRU-145).
+-- committed here for version control.
 
 -- 1. Dedupe store: one row per processed Stripe event id. Written only by the RPC below.
 create table if not exists private.stripe_processed_events (

--- a/supabase/migrations/20260710000001_tru173_charge_reaper.sql
+++ b/supabase/migrations/20260710000001_tru173_charge_reaper.sql
@@ -13,8 +13,7 @@
 --   * marking a booking 'failed' would fire private.tg_payment_failed (TRU-149) and email the
 --     customer about a failure that may never have really happened.
 --
--- Applied to the live DB via apply_migration; committed here for version control. The
--- "Supabase Preview" PR check is expected to fail and is non-blocking (see TRU-145).
+-- Applied to the live DB via apply_migration; committed here for version control.
 
 -- 1. When the booking was claimed into 'processing' — lets the sweep measure staleness.
 alter table public.bookings

--- a/supabase/migrations/20260710000002_tru170_171_server_side_pricing.sql
+++ b/supabase/migrations/20260710000002_tru170_171_server_side_pricing.sql
@@ -16,8 +16,7 @@
 -- booking trustworthy too.
 --
 -- Applied to the live DB via apply_migration (Supabase branching is broken on this repo);
--- committed here for version control. The "Supabase Preview" check on the PR is expected to
--- fail and is non-blocking (see TRU-145 and the tru146/tru172 migration headers).
+-- committed here for version control.
 
 -- ── 1. Single source of truth for price ───────────────────────────────────────
 -- base + (extra pets * per-extra-pet fee), read straight from provider_services.

--- a/supabase/migrations/20260714000000_tru165_db_security_hardening.sql
+++ b/supabase/migrations/20260714000000_tru165_db_security_hardening.sql
@@ -11,8 +11,7 @@
 --          here — tracked as remaining scope on TRU-201.)
 --
 -- Applied to the live DB via apply_migration (Supabase branching is broken on this repo);
--- committed here for version control. The "Supabase Preview" PR check is expected to fail and is
--- non-blocking (see TRU-145 and prior migration headers).
+-- committed here for version control.
 
 -- ── TRU-198: pin search_path on the signup trigger function ────────────────────
 create or replace function public.handle_new_user()


### PR DESCRIPTION
**Engx Epic B (TRU-160), ticket TRU-176.** Makes `supabase/migrations/` a provable source of truth instead of a hand-maintained record.

## What changed

- **`supabase/config.toml`** (new) — minimal CLI config (`project_id`, `[db] major_version = 17` to match prod). Just enough for `supabase db reset`; the full local-dev story (auth config, seed, docs) stays TRU-209.
- **`.github/workflows/migrations.yml`** (new) — on any PR/push touching `supabase/**`:
  1. `supabase db start` → fresh local database
  2. `supabase db reset` → replays the **entire migration history from scratch**; any migration that fails from-scratch fails the job
  3. **Smoke asserts** via psql: the replayed end state must contain the objects prod relies on — `create_booking`/`create_booking_series` RPCs, the `trg_guard_*_price` triggers, payment-path indexes, `private.reap_stranded_charges`, `private.tg_charge_on_completion`, `handle_new_user` with a **pinned search_path**, and core tables. A replay that "succeeds" into the wrong schema still fails.

## This PR is its own test

The workflow triggers on this very PR (config.toml is under `supabase/`). If the replay job fails here, I'll push fixes to the offending migrations until it's green — that iteration is the point of the ticket. **Hold off merging until the `Migrations / Replay` check is green.** Once green, a follow-up commit on this PR removes the "Supabase Preview expected to fail" caveats from the migration headers (done-when #2).

## Drift status (done-when #3, scoped)

Compared prod's migration ledger to git: **51 applied entries vs 30 files** — prod records real apply-timestamps and finer-grained steps (e.g. TRU-170/171 is 4 ledger entries, consolidated into 1 git file), plus 11 pre-baseline entries covered by `00000000000000_baseline.sql`. Content equivalence was maintained as each was applied via `apply_migration`; this job now proves the files replay to the intended end state. **Ledger repair** (aligning `supabase_migrations.schema_migrations` versions with git filenames) is deliberately deferred to TRU-177, where it's a prerequisite for automated `db push`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nx5aDGa5xtABLoA2ox7BCB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nx5aDGa5xtABLoA2ox7BCB)_