### PR TITLE
TRU-217/218/219/222: No-carer-in-area capture flow — capture state, lead model, demand signal

### DIFF
--- a/search/index.html
+++ b/search/index.html
@@ -210,7 +210,7 @@
   .empty-state p, .error-state p { color: var(--text-muted); font-size: 0.9rem; max-width: 420px; margin: 0 auto 1.25rem; line-height: 1.55; }
   .btn-secondary { padding: 10px 20px; background: transparent; border: 1px solid var(--border); border-radius: 999px; color: var(--text-secondary); font-family: 'DM Sans', sans-serif; font-size: 0.85rem; cursor: pointer; transition: border-color 0.2s, color 0.2s; }
   .btn-secondary:hover { border-color: var(--text-muted); color: var(--text-primary); }
-  /* ── TRU-121: "can't find a carer" request box ── */
+  /* ── TRU-121/216: "can't find a carer" capture state ── */
   .request-box { text-align: center; margin-top: 1rem; padding: 2rem 1.75rem; background: var(--terracotta-soft); border: 1px solid var(--blush); border-radius: 14px; }
   .request-box h3 { font-family: 'Cormorant Garamond', serif; font-size: 1.35rem; font-weight: 500; color: var(--brown); margin: 0 0 0.5rem; }
   .request-box p { color: var(--text-secondary); font-size: 0.9rem; max-width: 440px; margin: 0 auto 1.1rem; line-height: 1.55; }
@@ -219,11 +219,23 @@
   .btn-primary:hover { background: var(--terracotta-light); }
   .btn-primary:disabled { opacity: 0.6; cursor: default; }
   .req-lbl { display: block; font-size: 0.82rem; font-weight: 500; color: var(--text-secondary); margin: 12px 0 5px; }
+  .req-opt { color: var(--text-muted); font-weight: 400; font-size: 0.78rem; }
   .req-fld { width: 100%; padding: 10px 12px; border: 1px solid var(--border); border-radius: 10px; font-family: 'DM Sans', sans-serif; font-size: 0.9rem; color: var(--text-primary); background: var(--warm-white); }
   .req-fld:focus { outline: none; border-color: var(--border-focus); }
   .req-msg { font-size: 0.84rem; min-height: 1em; margin: 10px 0; color: var(--text-muted); }
   .req-msg.error { color: var(--terracotta); }
   #reqForm .btn-primary { margin-top: 8px; }
+  .capture-state h3 { font-size: 1.5rem; }
+  .cap-steps { display: grid; gap: 10px; margin: 1.1rem auto 1.25rem; max-width: 460px; text-align: left; }
+  .cap-step { display: flex; gap: 10px; align-items: flex-start; font-size: 0.88rem; color: var(--text-secondary); line-height: 1.5; }
+  .cap-step .cap-n { flex-shrink: 0; width: 22px; height: 22px; border-radius: 50%; background: var(--terracotta); color: #fff; font-size: 0.72rem; font-weight: 600; display: flex; align-items: center; justify-content: center; margin-top: 1px; }
+  .cap-band { text-align: center; font-size: 0.85rem; color: var(--text-secondary); background: var(--warm-white); border: 1px dashed var(--border); border-radius: 10px; padding: 8px 12px; max-width: 460px; margin: 0 auto 0.5rem; }
+  .req-row { display: grid; grid-template-columns: 1fr 1fr; gap: 0 12px; }
+  @media (max-width: 480px) { .req-row { grid-template-columns: 1fr; } }
+  .chip-row { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 2px; }
+  .chip-time { padding: 7px 14px; border-radius: 999px; border: 1px solid var(--border); background: var(--warm-white); color: var(--text-secondary); font-family: 'DM Sans', sans-serif; font-size: 0.82rem; cursor: pointer; transition: background 0.15s, border-color 0.15s, color 0.15s; }
+  .chip-time.on { background: var(--sage-soft); border-color: var(--sage-light); color: var(--sage-dark); font-weight: 500; }
+  .cap-alt { text-align: center; margin-top: 0.9rem; }
 
   /* ── Mobile ── */
   @media (max-width: 768px) {
@@ -1145,81 +1157,149 @@ function logSearchMiss() {
   loggedMisses.add(key);
   sbRpc('log_search_miss', { p_suburb: state.suburb, p_service: state.service || null }).catch(() => {});
 }
-function requestCtaHtml() {
+/* ── TRU-216/217/218: no-carer-in-area capture state (extends TRU-121) ── */
+// Launch config — the one place to change these numbers. The price band ships hidden until
+// the GTM pricing decision lands: set to e.g. { min: 30, max: 40 } to show the band line.
+const CAPTURE_PRICE_BAND = null;
+
+const CAPTURE_FREQUENCIES = [
+  ['one_off', 'Just once'],
+  ['weekly', 'Once a week'],
+  ['few_per_week', 'A few times a week'],
+  ['daily', 'Every weekday'],
+];
+const CAPTURE_TIMES = [['morning', 'Morning'], ['midday', 'Midday'], ['afternoon', 'Afternoon'], ['evening', 'Evening']];
+const capTimes = new Set(); // preferred-times chip selection (survives re-renders)
+
+function captureStateHtml(areaZero) {
   if (requestSubmitted) {
     return `<div class="request-box request-done fade-in">
       <h3>We're on it 🐾</h3>
-      <p>Thanks — we've got your request and we'll be in touch as soon as we've lined up a carer for you.</p>
+      <p><strong>Tom, Truffl's founder, will call you</strong> — usually the same day — to talk through exactly what you and your dog need.</p>
+      <p>If your perfect walker isn't nearby yet, Tom walks your dog personally while we source and vet your permanent walker — you're never left waiting.</p>
+      <p>We've also emailed you a rundown of what happens next.</p>
     </div>`;
   }
+  const heading = (areaZero && state.suburb) ? `We're new to ${esc(state.suburb)}` : 'Let us find your walker';
+  const bandLine = CAPTURE_PRICE_BAND
+    ? `<div class="cap-band">Most ${state.suburb ? esc(state.suburb) + ' ' : ''}walks are $${CAPTURE_PRICE_BAND.min}–$${CAPTURE_PRICE_BAND.max}. Your walker sets their own rate — we'll help you land inside it.</div>`
+    : '';
+  return `
+    <div class="request-box capture-state fade-in">
+      <h3>${heading}</h3>
+      <p>Request a walk and we'll match you with a vetted walker.</p>
+      <div class="cap-steps">
+        <div class="cap-step"><span class="cap-n">1</span><span><strong>Tom, our founder, calls you</strong> — usually the same day — to hear what you and your dog need.</span></div>
+        <div class="cap-step"><span class="cap-n">2</span><span><strong>Your walks start within days.</strong> Until your permanent walker is ready, Tom walks your dog personally.</span></div>
+        <div class="cap-step"><span class="cap-n">3</span><span><strong>Meet your vetted walker.</strong> We introduce them in person and hand over everything we've learned about your dog.</span></div>
+      </div>
+      ${bandLine}
+      ${captureFormHtml()}
+    </div>
+    <div class="cap-alt"><button class="btn-secondary" id="btnEmptyClear">Clear filters instead</button></div>`;
+}
+
+function captureFormHtml() {
   const loggedIn = !!authUid;
   const petPicker = (loggedIn && myPets.length)
     ? `<label class="req-lbl">Which pet?</label>
        <select class="req-fld" id="reqPet">${myPets.map(p => `<option value="${esc(p.id)}">${esc(p.name)}${p.breed ? ' · ' + esc(p.breed) : ''}</option>`).join('')}</select>`
     : '';
-  const contactFields = loggedIn ? '' : `
-       <label class="req-lbl">Your name</label>
-       <input class="req-fld" id="reqName" type="text" placeholder="First name" autocomplete="given-name">
-       <label class="req-lbl">Email</label>
-       <input class="req-fld" id="reqEmail" type="email" placeholder="you@example.com" autocomplete="email" required>`;
-  return `
-    <div class="request-box fade-in">
-      <h3>Can't find the right carer?</h3>
-      <p>Tell us what you need and we'll find one for you — from our carers, or someone new we go and vet.</p>
-      <button class="btn-primary" id="btnReqOpen" type="button">Let us find you a carer →</button>
-      <form id="reqForm" style="display:none;margin-top:14px;text-align:left;max-width:440px;margin-left:auto;margin-right:auto;">
-        ${petPicker}${contactFields}
-        <label class="req-lbl">Anything else? <span style="color:var(--text-muted);font-weight:400;">(optional)</span></label>
-        <textarea class="req-fld" id="reqNote" rows="2" placeholder="Dates, your dog, what matters to you…"></textarea>
-        <div id="reqMsg" class="req-msg"></div>
-        <button class="btn-primary" id="btnReqSubmit" type="submit">Send request</button>
-      </form>
+  const nameEmail = loggedIn ? '' : `
+    <div class="req-row">
+      <div><label class="req-lbl">Your name</label>
+        <input class="req-fld" id="reqName" type="text" placeholder="First name" autocomplete="given-name"></div>
+      <div><label class="req-lbl">Email</label>
+        <input class="req-fld" id="reqEmail" type="email" placeholder="you@example.com" autocomplete="email"></div>
     </div>`;
+  // Signed-in owners with pets already told us about the dog; guests get the lead-form basics
+  // (full dog profile happens later in the flow, not here).
+  const dogFields = (loggedIn && myPets.length) ? '' : `
+    <div class="req-row">
+      <div><label class="req-lbl">Dog's name</label>
+        <input class="req-fld" id="reqDogName" type="text" placeholder="e.g. Flick"></div>
+      <div><label class="req-lbl">Breed <span class="req-opt">(optional)</span></label>
+        <input class="req-fld" id="reqDogBreed" type="text" placeholder="e.g. Kelpie cross"></div>
+    </div>`;
+  const svcOptions = SERVICES.map(s => `<option value="${s.value}"${state.service === s.value ? ' selected' : ''}>${s.label}</option>`).join('');
+  const freqDefault = state.recurring ? 'weekly' : 'one_off';
+  return `
+    <form id="reqForm" style="margin-top:6px;text-align:left;max-width:460px;margin-left:auto;margin-right:auto;">
+      ${petPicker}${nameEmail}
+      <label class="req-lbl">Phone <span class="req-opt">— so Tom can call you, usually same day</span></label>
+      <input class="req-fld" id="reqPhone" type="tel" placeholder="04xx xxx xxx" autocomplete="tel">
+      ${dogFields}
+      <label class="req-lbl">Temperament, quirks, anything we should know <span class="req-opt">(optional)</span></label>
+      <textarea class="req-fld" id="reqTemperament" rows="2" placeholder="Reactive on lead? Shy with strangers? Pulls like a train?"></textarea>
+      <div class="req-row">
+        <div><label class="req-lbl">Service</label>
+          <select class="req-fld" id="reqService">${svcOptions}</select></div>
+        <div><label class="req-lbl">How often?</label>
+          <select class="req-fld" id="reqFrequency">${CAPTURE_FREQUENCIES.map(([v, l]) => `<option value="${v}"${v === freqDefault ? ' selected' : ''}>${l}</option>`).join('')}</select></div>
+      </div>
+      <label class="req-lbl">Preferred times <span class="req-opt">(pick any)</span></label>
+      <div class="chip-row" id="reqTimes">${CAPTURE_TIMES.map(([v, l]) => `<button type="button" class="chip-time${capTimes.has(v) ? ' on' : ''}" data-time="${v}">${l}</button>`).join('')}</div>
+      <label class="req-lbl">Anything else? <span class="req-opt">(optional)</span></label>
+      <textarea class="req-fld" id="reqNote" rows="2" placeholder="Dates, your building's quirks, what matters to you…"></textarea>
+      <div id="reqMsg" class="req-msg"></div>
+      <button class="btn-primary" id="btnReqSubmit" type="submit" style="width:100%;">Request my walker</button>
+    </form>`;
 }
-function wireRequestCta() {
-  const openBtn = document.getElementById('btnReqOpen');
-  if (openBtn) openBtn.addEventListener('click', () => {
-    document.getElementById('reqForm').style.display = 'block';
-    openBtn.style.display = 'none';
-  });
+
+function wireCaptureState() {
   const form = document.getElementById('reqForm');
   if (form) form.addEventListener('submit', submitCarerRequest);
+  document.querySelectorAll('#reqTimes .chip-time').forEach(ch => ch.addEventListener('click', () => {
+    const t = ch.dataset.time;
+    if (capTimes.has(t)) { capTimes.delete(t); ch.classList.remove('on'); }
+    else { capTimes.add(t); ch.classList.add('on'); }
+  }));
+  const clearBtn = document.getElementById('btnEmptyClear');
+  if (clearBtn) clearBtn.addEventListener('click', clearFilters);
 }
+
 async function submitCarerRequest(e) {
   e.preventDefault();
   const msg = document.getElementById('reqMsg');
   const btn = document.getElementById('btnReqSubmit');
-  const emailEl = document.getElementById('reqEmail');
-  const nameEl = document.getElementById('reqName');
-  const petEl = document.getElementById('reqPet');
-  const noteEl = document.getElementById('reqNote');
-  if (!authUid && emailEl && !emailEl.value.trim()) {
-    msg.textContent = 'Please leave an email so we can reach you.'; msg.className = 'req-msg error'; return;
-  }
+  const val = id => { const el = document.getElementById(id); return el ? el.value.trim() : ''; };
+  const fail = t => { msg.textContent = t; msg.className = 'req-msg error'; };
+  const phone = val('reqPhone').replace(/[^\d+]/g, '');
+  if (!authUid && !val('reqName')) return fail('Please tell us your name.');
+  if (phone.replace(/\D/g, '').length < 8) return fail('Please leave a phone number so Tom can call you.');
+  if (!authUid && !val('reqEmail')) return fail('Please leave an email so we can confirm your request.');
+  if (document.getElementById('reqDogName') && !val('reqDogName')) return fail("Please tell us your dog's name.");
   btn.disabled = true; btn.textContent = 'Sending…'; msg.textContent = ''; msg.className = 'req-msg';
+  const petEl = document.getElementById('reqPet');
   const body = {
     p_suburb: state.suburb || null,
-    p_service_type: state.service || null,
+    p_service_type: val('reqService') || state.service || null,
     p_wanted_date: (!state.recurring && state.date) ? state.date : null,
-    p_recurring: !!state.recurring,
+    p_recurring: val('reqFrequency') !== 'one_off',
     p_window_start: state.windowStart || null,
     p_window_end: state.windowEnd || null,
     p_dog_size: state.size || null,
     p_puppy: !!state.puppy,
     p_pet_id: (authUid && petEl) ? petEl.value : null,
-    p_contact_name: nameEl ? nameEl.value.trim() : null,
-    p_contact_email: emailEl ? emailEl.value.trim() : null,
-    p_note: noteEl ? noteEl.value.trim() : null,
+    p_contact_name: val('reqName') || null,
+    p_contact_email: val('reqEmail') || null,
+    p_note: val('reqNote') || null,
     p_search_params: state,
+    p_contact_phone: phone,
+    p_dog_name: val('reqDogName') || null,
+    p_dog_breed: val('reqDogBreed') || null,
+    p_dog_temperament: val('reqTemperament') || null,
+    p_frequency: val('reqFrequency') || null,
+    p_preferred_times: Array.from(capTimes),
   };
   try {
     const r = await sbRpc('submit_carer_request', body);
     if (!r.ok) { const d = await r.json().catch(() => ({})); throw new Error(d.message || 'Could not send (' + r.status + ')'); }
     requestSubmitted = true;
-    renderResults(renderedProviders); // re-render the empty state → thank-you
+    renderResults(renderedProviders); // re-render the capture state → confirmation
   } catch (err) {
-    msg.textContent = err.message || 'Something went wrong — please try again.'; msg.className = 'req-msg error';
-    btn.disabled = false; btn.textContent = 'Send request';
+    fail(err.message || 'Something went wrong — please try again.');
+    btn.disabled = false; btn.textContent = 'Request my walker';
   }
 }
 
@@ -1237,17 +1317,29 @@ function renderResults(list) {
 
   if (list.length === 0) {
     logSearchMiss(); // TRU-121: passive demand signal for a zero-result search
+    // TRU-217: a true area-zero (the server found nobody near the suburb) gets the full
+    // capture state; a filtered-to-zero (carers exist, the filters excluded them) keeps the
+    // tweak-your-search empty state with the capture form one click away.
+    const areaZero = providers.length === 0 && !!state.suburb;
+    if (areaZero || requestSubmitted) {
+      area.innerHTML = captureStateHtml(true);
+      wireCaptureState();
+      return;
+    }
     area.innerHTML = `
       <div class="empty-state fade-in">
         <div class="empty-icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="6.5"></circle><path d="M16 16l4 4"></path></svg></div>
         <h3>No carers found${state.suburb ? ' near ' + esc(state.suburb) : ''}</h3>
         <p>Try expanding your search area, choosing a different service, or removing some filters.</p>
         <button class="btn-secondary" id="btnEmptyClear">Clear filters</button>
+        <button class="btn-primary" id="btnShowCapture" style="margin-left:8px;">Let us find you a carer →</button>
       </div>
-      ${requestCtaHtml()}
     `;
     document.getElementById('btnEmptyClear').addEventListener('click', clearFilters);
-    wireRequestCta();
+    document.getElementById('btnShowCapture').addEventListener('click', () => {
+      area.innerHTML = captureStateHtml(false);
+      wireCaptureState();
+    });
     return;
   }
 

--- a/supabase/functions/send-notification/index.ts
+++ b/supabase/functions/send-notification/index.ts
@@ -233,9 +233,9 @@ async function buildMessages(type: string, payload: Record<string, unknown>) {
       });
     }
   } else if (type === 'carer_request') {
-    // TRU-121: a customer (or guest) couldn't find a carer and asked us to find one.
-    // Page every admin with the request details; reply-to is the requester so an admin can
-    // respond straight from their inbox.
+    // TRU-121/216: a customer (or guest) couldn't find a carer — the capture-flow lead.
+    // One DB event, two messages: page every admin with everything needed for the candid
+    // founder call (TRU-219), and confirm to the lead what happens next (TRU-220).
     const { data: rq } = await sb.from('carer_requests').select('*').eq('id', payload.request_id as string).single();
     if (!rq) return out;
     const { data: admins } = await sb.from('users').select('email,first_name').eq('is_admin', true);
@@ -244,18 +244,22 @@ async function buildMessages(type: string, payload: Record<string, unknown>) {
     // Contact details come from the linked account when signed in, else the guest fields.
     let contactName: string | null = rq.contact_name;
     let contactEmail: string | null = rq.contact_email;
+    let firstName: string | null = rq.contact_name;
     let petName: string | null = null;
+    let petBreed: string | null = null;
     if (rq.customer_id) {
       const { data: cp } = await sb.from('customer_profiles').select('user_id').eq('id', rq.customer_id).single();
       if (cp?.user_id) {
         const { data: u } = await sb.from('users').select('email,first_name,last_name').eq('id', cp.user_id).single();
         contactName = contactName || `${u?.first_name || ''} ${u?.last_name || ''}`.trim() || null;
         contactEmail = contactEmail || u?.email || null;
+        firstName = firstName || u?.first_name || null;
       }
     }
     if (rq.pet_id) {
-      const { data: pet } = await sb.from('pets').select('name').eq('id', rq.pet_id).single();
+      const { data: pet } = await sb.from('pets').select('name,breed').eq('id', rq.pet_id).single();
       petName = pet?.name || null;
+      petBreed = pet?.breed || null;
     }
 
     const serviceLabel = rq.service_type ? (SERVICE_LABELS[rq.service_type] || rq.service_type) : 'Any service';
@@ -265,12 +269,25 @@ async function buildMessages(type: string, payload: Record<string, unknown>) {
     const windowStr = rq.window_start ? `${rq.window_start}${rq.window_end ? '–' + rq.window_end : ''}` : '—';
     const canAssign = !!(rq.customer_id && rq.pet_id);
 
+    const FREQUENCY_LABELS: Record<string, string> = {
+      one_off: 'Just once', weekly: 'Once a week', few_per_week: 'A few times a week', daily: 'Every weekday',
+    };
+    const dogName = rq.dog_name || petName;
+    const dogStr = [dogName, rq.dog_breed || petBreed, rq.dog_size, rq.puppy ? 'puppy' : '']
+      .filter(Boolean).join(' · ') || '—';
+    const timesStr = (rq.preferred_times as string[] | null)?.length
+      ? (rq.preferred_times as string[]).map((t) => t.charAt(0).toUpperCase() + t.slice(1)).join(', ')
+      : '—';
+
     const rows: [string, string][] = [
+      ['Phone', rq.contact_phone || '⚠ missing'],
       ['Suburb', rq.suburb || '—'],
       ['Service', serviceLabel],
+      ['How often', rq.frequency ? (FREQUENCY_LABELS[rq.frequency] || rq.frequency) : (rq.recurring ? 'Recurring' : 'One-off')],
       ['When', whenStr],
       ['Time window', windowStr],
-      ['Dog', [rq.dog_size, rq.puppy ? 'puppy' : ''].filter(Boolean).join(' · ') || '—'],
+      ['Preferred times', timesStr],
+      ['Dog', dogStr],
       ['From', contactName || (rq.customer_id ? 'Registered customer' : 'Guest')],
       ['Email', contactEmail || '—'],
       ['Account', rq.customer_id ? `Signed-in${rq.pet_id ? ` · pet: ${petName || 'selected'}` : ' · no pet selected'}` : 'Guest (not signed up)'],
@@ -282,17 +299,37 @@ async function buildMessages(type: string, payload: Record<string, unknown>) {
       out.push({
         to: admin.email,
         replyTo: contactEmail || undefined,
-        subject: `🔎 Carer request — ${serviceLabel} in ${rq.suburb || 'unknown suburb'}`,
+        subject: `🔎 New lead — ${serviceLabel} in ${rq.suburb || 'unknown suburb'}${rq.contact_phone ? ` · 📞 ${rq.contact_phone}` : ''}`,
         html: layout({
-          preview: `${requester} couldn't find a carer in ${rq.suburb || 'their area'}`,
-          heading: 'Someone needs a carer',
-          body: p(`${esc(requester)} searched and couldn't find the right carer. Here's what they're after:`) +
+          preview: `${requester} needs a walker in ${rq.suburb || 'their area'} — call them today`,
+          heading: 'New captured lead — call them today',
+          body: p(`${esc(requester)} searched and couldn't find the right carer. Same-day call is the bar. Here's everything for the call:`) +
             detailsTable(rows) +
+            (rq.dog_temperament_note ? p(`<b>Temperament / quirks:</b> ${esc(rq.dog_temperament_note)}`) : '') +
             (rq.note ? p(`<b>Their note:</b> ${esc(rq.note)}`) : '') +
             p(canAssign
-              ? 'You can assign an existing carer straight from the console, or go find and onboard someone new.'
+              ? 'You can assign an existing carer straight from the console, or start the stop-gap flow.'
               : 'Reply to this email to reach them, or work it from the console.'),
           cta: { label: 'Open the admin console', href: `${SITE}/admin/` },
+        }),
+      });
+    }
+
+    // TRU-220: lead-facing confirmation — candid framing, no price numbers, soft promises only.
+    if (contactEmail) {
+      out.push({
+        to: contactEmail,
+        subject: "We're on it — your Truffl walker request",
+        html: layout({
+          preview: 'Tom, our founder, will call you — usually the same day',
+          heading: "We're on it 🐾",
+          body: p(`Hi ${esc(firstName || 'there')}, thanks — we've got your request for ${esc(serviceLabel.toLowerCase())}${rq.suburb ? ` in ${esc(rq.suburb)}` : ''}.`) +
+            p(`<b>Tom, Truffl's founder, will call you</b> — usually the same day — to talk through exactly what ${esc(dogName || 'your dog')} needs.`) +
+            p("If your perfect walker isn't nearby yet, Tom walks your dog personally while we source and vet your permanent walker — so your walks can start within days, and you're never left waiting.") +
+            p("When your walker is ready, we introduce you at a meet &amp; greet and hand over everything we've learned about your dog.") +
+            (rq.customer_id ? '' : p('If you create your account now, booking is one tap when we call.')),
+          cta: rq.customer_id ? undefined : { label: 'Create your account', href: `${SITE}/register/` },
+          footnote: "Your walker sets their own rate — we'll talk pricing openly on the call, no surprises.",
         }),
       });
     }

--- a/supabase/migrations/20260716000000_tru216_capture_flow.sql
+++ b/supabase/migrations/20260716000000_tru216_capture_flow.sql
@@ -1,0 +1,198 @@
+-- TRU-216 (TRU-217/218/222): No-carer-in-area capture flow — lead model + demand signal.
+--
+-- Extends the TRU-121 "can't find a carer" skeleton into the GTM capture flow:
+--   • carer_requests grows founder-call fields (phone is the preferred contact), dog details
+--     for call prep, frequency/preferred-times, and the lead pipeline statuses from TRU-221
+--     (captured → called → founder_walking → sourcing_walker → meet_greet_booked →
+--     transitioned, + lost/closed). status_changed_at powers days-in-status / the 14-day
+--     sourcing clock in the admin console.
+--   • submit_carer_request is REPLACED (dropped + recreated, never overloaded — PostgREST
+--     named-arg dispatch returns 300 when two candidates match). New rule: phone is required
+--     for every lead (the founder call is the product); email stays required for guests.
+--   • search_misses gains postcode (derived server-side from public.suburbs — the page only
+--     knows the free-text suburb) and a weekly rollup view for the recruitment-targeting
+--     scorecard (TRU-222). No dashboard; admin reads it via the edge function.
+--
+-- Applied to the live DB via apply_migration (Supabase branching is broken on this repo);
+-- committed here for version control (see TRU-145). 14-digit unique prefix.
+
+-- ── carer_requests: founder-call + dog-detail fields ─────────────────────────
+alter table public.carer_requests
+  add column if not exists contact_phone        text,
+  add column if not exists dog_name             text,
+  add column if not exists dog_breed            text,
+  add column if not exists dog_temperament_note text,
+  add column if not exists frequency            text,
+  add column if not exists preferred_times      text[] not null default '{}',
+  add column if not exists status_changed_at    timestamptz not null default now();
+
+-- ── lead pipeline statuses (TRU-221 set) ─────────────────────────────────────
+-- Remap the TRU-121 statuses before swapping the check constraint. Site is unlaunched and
+-- rows are few; a destructive remap is fine (open→captured, matched→meet_greet_booked,
+-- onboarding→sourcing_walker).
+alter table public.carer_requests drop constraint if exists carer_requests_status_check;
+update public.carer_requests set status = case status
+  when 'open'       then 'captured'
+  when 'matched'    then 'meet_greet_booked'
+  when 'onboarding' then 'sourcing_walker'
+  else status end;
+alter table public.carer_requests alter column status set default 'captured';
+alter table public.carer_requests add constraint carer_requests_status_check
+  check (status in ('captured','called','founder_walking','sourcing_walker',
+                    'meet_greet_booked','transitioned','lost','closed'));
+
+-- Keep status_changed_at honest so days-in-status is trustworthy.
+create or replace function private.tg_carer_request_status() returns trigger
+language plpgsql security definer set search_path = '' as $$
+begin
+  if NEW.status is distinct from OLD.status then
+    NEW.status_changed_at := now();
+  end if;
+  return NEW;
+end; $$;
+
+drop trigger if exists trg_carer_request_status on public.carer_requests;
+create trigger trg_carer_request_status before update on public.carer_requests
+  for each row execute function private.tg_carer_request_status();
+
+-- ── submit_carer_request: replaced with the capture-form shape ────────────────
+drop function if exists public.submit_carer_request(text,text,date,boolean,text,text,text,boolean,uuid,text,text,text,jsonb);
+
+create function public.submit_carer_request(
+  p_suburb          text    default null,
+  p_service_type    text    default null,
+  p_wanted_date     date    default null,
+  p_recurring       boolean default false,
+  p_window_start    text    default null,
+  p_window_end      text    default null,
+  p_dog_size        text    default null,
+  p_puppy           boolean default false,
+  p_pet_id          uuid    default null,
+  p_contact_name    text    default null,
+  p_contact_email   text    default null,
+  p_note            text    default null,
+  p_search_params   jsonb   default null,
+  p_contact_phone   text    default null,
+  p_dog_name        text    default null,
+  p_dog_breed       text    default null,
+  p_dog_temperament text    default null,
+  p_frequency       text    default null,
+  p_preferred_times text[]  default null
+) returns uuid
+language plpgsql security definer set search_path = public as $$
+declare
+  v_customer_id uuid;
+  v_pet_id      uuid := null;
+  v_phone       text;
+  v_frequency   text;
+  v_times       text[];
+  v_id          uuid;
+begin
+  select cp.id into v_customer_id
+  from public.customer_profiles cp
+  where cp.user_id = auth.uid();
+
+  -- The founder call is the product: every lead needs a phone number.
+  v_phone := nullif(trim(coalesce(p_contact_phone, '')), '');
+  if v_phone is null then
+    raise exception 'contact_phone is required';
+  end if;
+
+  -- Guests must also leave an email (confirmation email + account invite).
+  if v_customer_id is null and coalesce(trim(p_contact_email), '') = '' then
+    raise exception 'contact_email is required for guest requests';
+  end if;
+
+  -- Only accept a pet_id that actually belongs to the caller (defends the assign path).
+  if p_pet_id is not null and v_customer_id is not null then
+    select pt.id into v_pet_id
+    from public.pets pt
+    where pt.id = p_pet_id and pt.customer_id = v_customer_id;
+  end if;
+
+  -- Whitelist enumerated inputs rather than trusting the client.
+  v_frequency := nullif(trim(coalesce(p_frequency, '')), '');
+  if v_frequency is not null
+     and v_frequency not in ('one_off','weekly','few_per_week','daily') then
+    raise exception 'invalid frequency %', v_frequency;
+  end if;
+  v_times := (
+    select coalesce(array_agg(t), '{}')
+    from unnest(coalesce(p_preferred_times, '{}')) as t
+    where t in ('morning','midday','afternoon','evening')
+  );
+
+  insert into public.carer_requests (
+    customer_id, pet_id, contact_name, contact_email, contact_phone, suburb, service_type,
+    wanted_date, recurring, window_start, window_end, dog_size, puppy,
+    dog_name, dog_breed, dog_temperament_note, frequency, preferred_times,
+    note, search_params
+  ) values (
+    v_customer_id, v_pet_id,
+    nullif(trim(coalesce(p_contact_name, '')), ''),
+    nullif(trim(coalesce(p_contact_email, '')), ''),
+    v_phone,
+    nullif(trim(coalesce(p_suburb, '')), ''),
+    nullif(trim(coalesce(p_service_type, '')), ''),
+    p_wanted_date, coalesce(p_recurring, false),
+    nullif(trim(coalesce(p_window_start, '')), ''),
+    nullif(trim(coalesce(p_window_end, '')), ''),
+    nullif(trim(coalesce(p_dog_size, '')), ''),
+    coalesce(p_puppy, false),
+    nullif(trim(coalesce(p_dog_name, '')), ''),
+    nullif(trim(coalesce(p_dog_breed, '')), ''),
+    nullif(trim(coalesce(p_dog_temperament, '')), ''),
+    v_frequency, v_times,
+    nullif(trim(coalesce(p_note, '')), ''),
+    p_search_params
+  ) returning id into v_id;
+
+  return v_id;
+end; $$;
+
+revoke all on function public.submit_carer_request(text,text,date,boolean,text,text,text,boolean,uuid,text,text,text,jsonb,text,text,text,text,text,text[]) from public;
+grant execute on function public.submit_carer_request(text,text,date,boolean,text,text,text,boolean,uuid,text,text,text,jsonb,text,text,text,text,text,text[]) to anon, authenticated;
+
+-- ── search_misses: postcode + weekly rollup (TRU-222) ─────────────────────────
+alter table public.search_misses add column if not exists postcode text;
+
+-- Replaced (same drop-don't-overload rule). Postcode is derived here, not sent by the page:
+-- the search box only carries a suburb name. A name can span postcodes; taking the lowest is
+-- fine for a demand signal.
+drop function if exists public.log_search_miss(text, text);
+
+create function public.log_search_miss(
+  p_suburb  text,
+  p_service text default null
+) returns void
+language plpgsql security definer set search_path = public as $$
+begin
+  if coalesce(trim(p_suburb), '') = '' then return; end if;
+  insert into public.search_misses (suburb, postcode, service_type, customer_id)
+  values (
+    trim(p_suburb),
+    (select s.postcode from public.suburbs s
+      where lower(s.name) = lower(trim(p_suburb))
+      order by s.postcode limit 1),
+    nullif(trim(coalesce(p_service, '')), ''),
+    (select cp.id from public.customer_profiles cp where cp.user_id = auth.uid())
+  );
+end; $$;
+
+revoke all on function public.log_search_miss(text, text) from public;
+grant execute on function public.log_search_miss(text, text) to anon, authenticated;
+
+-- Weekly counts by suburb — the recruitment-targeting scorecard. Read via service_role only
+-- (the admin edge function); security_invoker so it carries no definer privileges of its own.
+create or replace view public.search_miss_weekly
+with (security_invoker = true) as
+  select date_trunc('week', created_at)::date as week_start,
+         suburb,
+         max(postcode)                        as postcode,
+         service_type,
+         count(*)                             as misses
+  from public.search_misses
+  group by 1, 2, 4;
+
+revoke all on public.search_miss_weekly from anon, authenticated;
+grant select on public.search_miss_weekly to service_role;


### PR DESCRIPTION
First PR of the TRU-216 epic (no-carer-in-area capture flow). Extends the TRU-121 skeleton rather than building parallel machinery.

## What changed

**Migration `20260716000000_tru216_capture_flow.sql`** (already applied to the live DB via MCP; committed for VC)
- `carer_requests` gains founder-call fields: `contact_phone` (**required for every lead** — the founder call is the product), `dog_name`, `dog_breed`, `dog_temperament_note`, `frequency`, `preferred_times[]`, `status_changed_at` (trigger-maintained; powers days-in-status / the 14-day clock in PR 2).
- Status set remapped to the TRU-221 pipeline: `captured → called → founder_walking → sourcing_walker → meet_greet_booked → transitioned` (+ `lost`/`closed`).
- `submit_carer_request` + `log_search_miss` **replaced, not overloaded** (PostgREST returns 300 on ambiguous overloads). Frequency/preferred-times values whitelisted server-side.
- TRU-222: `search_misses.postcode` derived server-side from `public.suburbs`; new `search_miss_weekly` view (service_role only) = counts by suburb by week.

**`search/index.html`** (TRU-217/218)
- True area-zero search (server found nobody near the suburb) now renders the full capture state: "We're new to {suburb}", the matching promise, a 3-step what-happens-next strip, and the lead form **open** (name/email for guests, phone, dog details, temperament, service + frequency, preferred-time chips).
- Filtered-to-zero (carers exist, filters excluded them) keeps the tweak-your-search empty state with the capture form one click away.
- **Price band ships hidden** (`CAPTURE_PRICE_BAND = null`) until the GTM pricing decision — one-line change to show it.
- Post-submit confirmation sets expectations: founder call same day, founder-backstop, no price promises (TRU-220 part 1).

**`send-notification` edge fn** (TRU-219 + TRU-220 email; deployed as v10)
- Founder alert now leads with the phone number (in the subject too), dog details, frequency, preferred times.
- Same DB event also emails the lead a candid confirmation (founder call → backstop → meet & greet; register CTA for guests; "your walker sets their own rate" footnote).

## Verified (live)
- Migration asserts: columns, single RPC overloads, new check constraint, weekly view.
- RPC validation: missing phone / missing guest email / bad frequency all raise; bogus preferred-time values filtered.
- Full E2E from the real page (local static server → live Supabase): guest form submit → row correct (`captured`, phone normalised, chips stored) → `send-notification` 200 ×2 in edge logs (admin alert + lead confirmation via Resend).
- `status_changed_at` bumps on status change; `log_search_miss('Newington')` → postcode 2127.
- CI-style checks pass locally: inline-JS `node --check`, `deno check`.
- Test leads + misses deleted after verification.

Linear: TRU-217, TRU-218, TRU-219, TRU-222 (parent TRU-216). TRU-220's email half is included here; the remaining TRU-220 scope ships with the epic's later PRs if anything is left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)