### PR TITLE
TRU-221: Lead pipeline ops view — admin board grouped by stage + 14-day sourcing clock

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -245,19 +245,36 @@ async function creditRedeem(id) {
   } catch (e) { admMsg(e.message, 'error'); }
 }
 
-// ── Requests section (TRU-121: "can't find a carer") ──
+// ── Requests section (TRU-121 capture leads · TRU-221 pipeline view) ──
 const SVC_LABELS = { dog_walking:'Dog walking', dog_sitting:'Dog sitting', dog_boarding:'Dog boarding', dog_daycare:'Dog daycare', drop_in:'Drop-in visit', pet_sitting:'Pet sitting' };
 function svcLabel(t) { return t ? (SVC_LABELS[t] || t) : 'Any service'; }
+// Pipeline order drives the board grouping; terminal statuses only appear in the select.
+const LEAD_STATUSES = [
+  ['captured', 'Captured'], ['called', 'Called'], ['founder_walking', 'Founder walking'],
+  ['sourcing_walker', 'Sourcing walker'], ['meet_greet_booked', 'Meet & greet booked'],
+];
+const LEAD_TERMINAL = [['transitioned', 'Transitioned ✓'], ['lost', 'Lost'], ['closed', 'Closed']];
+const FREQ_LABELS = { one_off:'once', weekly:'weekly', few_per_week:'a few times a week', daily:'every weekday' };
 function reqWhen(rq) {
   const bits = [];
+  if (rq.frequency) bits.push(FREQ_LABELS[rq.frequency] || rq.frequency);
+  else if (rq.recurring) bits.push('recurring');
   if (rq.wanted_date) bits.push(rq.wanted_date);
-  else if (rq.recurring) bits.push('Recurring');
-  else bits.push('Flexible date');
   if (rq.window_start) bits.push(rq.window_start + (rq.window_end ? '–' + rq.window_end : ''));
-  return bits.join(' · ');
+  if (rq.preferred_times && rq.preferred_times.length) bits.push(rq.preferred_times.join('/'));
+  return bits.join(' · ') || 'Flexible';
+}
+// The 14-day sourcing clock (GTM two-week rule) — visible per lead, loud from day 10.
+function clockBadge(rq) {
+  const d = rq.days_in_status ?? 0;
+  if (rq.status === 'founder_walking') {
+    const cls = d >= 10 ? 'b-failed' : 'b-paid';
+    return `<span class="badge ${cls}">day ${d + 1} of 14</span>`;
+  }
+  return `<span class="badge b-refunded">${d === 0 ? 'today' : d + 'd in status'}</span>`;
 }
 function requestCard(rq) {
-  const dog = [rq.dog_size, rq.puppy ? 'puppy' : ''].filter(Boolean).join(' · ');
+  const dogBits = [rq.dog_name, rq.dog_breed, rq.dog_size, rq.puppy ? 'puppy' : ''].filter(Boolean).join(' · ');
   const acct = rq.can_assign ? '<span class="badge b-paid">assignable</span>'
     : rq.customer_id ? '<span class="badge b-refunded">no pet</span>'
     : '<span class="badge b-refunded">guest</span>';
@@ -269,35 +286,47 @@ function requestCard(rq) {
       <button class="btn" onclick="reqFindCarers('${rq.id}')">Find carers</button>
     </div>
     <div id="reqcarers-${rq.id}"></div>` : '';
+  const statusOpts = LEAD_STATUSES.concat(LEAD_TERMINAL)
+    .map(([v, l]) => `<option value="${v}"${rq.status === v ? ' selected' : ''}>${l}</option>`).join('');
   return `<div class="card" id="reqcard-${rq.id}">
-    <div class="row-top"><div><b>${esc(svcLabel(rq.service_type))}</b> in ${esc(rq.suburb || '—')} ${acct}</div><div class="meta">${when(rq.created_at)}</div></div>
-    <div class="meta">${esc(rq.contact)}${rq.email ? ' · ' + esc(rq.email) : ''}${rq.pet ? ' · pet: ' + esc(rq.pet) : ''}</div>
-    <div class="meta">${esc(reqWhen(rq))}${dog ? ' · ' + esc(dog) : ''}</div>
+    <div class="row-top"><div><b>${esc(svcLabel(rq.service_type))}</b> in ${esc(rq.suburb || '—')} ${acct} ${clockBadge(rq)}</div><div class="meta">${when(rq.created_at)}</div></div>
+    <div class="meta"><b>${esc(rq.contact)}</b>${rq.contact_phone ? ` · <a href="tel:${esc(rq.contact_phone)}">${esc(rq.contact_phone)}</a>` : ' · ⚠ no phone'}${rq.email ? ' · ' + esc(rq.email) : ''}</div>
+    <div class="meta">${dogBits ? esc(dogBits) : 'Dog: —'}${rq.pet ? ' · pet on file: ' + esc(rq.pet) : ''}</div>
+    ${rq.dog_temperament_note ? `<div class="meta">Temperament: “${esc(rq.dog_temperament_note)}”</div>` : ''}
+    <div class="meta">${esc(reqWhen(rq))}</div>
     ${rq.note ? `<div class="meta">“${esc(rq.note)}”</div>` : ''}
-    ${rq.status === 'onboarding' ? '<div class="meta"><b>Onboarding a new carer</b></div>' : ''}
     ${assignUi}
     <div class="actions">
+      <select class="reason" id="reqstatus-${rq.id}" style="flex:0 1 auto;">${statusOpts}</select>
       <input class="reason" id="reqnote-${rq.id}" placeholder="Admin note (optional)" value="${esc(rq.admin_note || '')}">
-      <button class="btn" style="background:#fff;color:var(--terracottaDark);" onclick="reqUpdate('${rq.id}','onboarding')">Onboarding</button>
-      <button class="btn" style="background:#fff;color:var(--terracottaDark);" onclick="reqUpdate('${rq.id}','closed')">Close</button>
+      <button class="btn" onclick="reqUpdate('${rq.id}')">Save</button>
     </div>
   </div>`;
 }
 function signalRow(s) {
-  return `<div class="meta">${esc(s.suburb)} · ${esc(svcLabel(s.service_type).toLowerCase())} <b>×${s.count}</b></div>`;
+  return `<tr><td class="meta">${esc(s.week_start)}</td><td class="meta">${esc(s.suburb)}${s.postcode ? ' ' + esc(s.postcode) : ''}</td><td class="meta">${esc(svcLabel(s.service_type).toLowerCase())}</td><td class="meta" style="text-align:right;"><b>×${s.misses}</b></td></tr>`;
 }
 async function renderRequests(c) {
   c.innerHTML = '<div id="adm-msg" class="msg"></div><p class="empty">Loading…</p>';
   try {
     const { requests, signal } = await sbFn('stripe-api', { action:'requests_list' });
-    const reqHtml = (requests && requests.length) ? requests.map(requestCard).join('') : '<p class="empty">No open requests.</p>';
-    const sigHtml = (signal && signal.length) ? signal.map(signalRow).join('') : '<p class="empty">No unmet searches in the last 30 days.</p>';
+    // Group the board by pipeline stage so the founder-walking clock is impossible to miss.
+    const byStatus = {};
+    (requests || []).forEach(r => { (byStatus[r.status] ||= []).push(r); });
+    const reqHtml = (requests && requests.length)
+      ? LEAD_STATUSES.filter(([v]) => byStatus[v] && byStatus[v].length)
+          .map(([v, l]) => `<h1 style="font-size:1.05rem;margin:18px 0 6px;">${l} <span class="meta">(${byStatus[v].length})</span></h1>` + byStatus[v].map(requestCard).join(''))
+          .join('')
+      : '<p class="empty">No live leads.</p>';
+    const sigHtml = (signal && signal.length)
+      ? `<table style="width:100%;border-collapse:collapse;">${signal.map(signalRow).join('')}</table>`
+      : '<p class="empty">No unmet searches in the last 8 weeks.</p>';
     c.innerHTML = `
-      <p class="sub" style="margin-bottom:14px;">Customers who couldn't find a carer. "Find carers" surfaces nearby matches you can assign — this creates a pending booking request the carer accepts and messages the customer. Guest requests (no linked pet) can't be auto-assigned — reply by email, or mark onboarding/closed.</p>
+      <p class="sub" style="margin-bottom:14px;">Captured leads, grouped by pipeline stage. Same-day call is the bar; the 14-day sourcing clock runs while the founder walks. "Find carers" surfaces nearby matches you can assign — this creates a pending booking request and messages the customer.</p>
       <div id="adm-msg" class="msg"></div>
       ${reqHtml}
-      <h1 style="font-size:1.2rem;margin:22px 0 8px;">Unmet searches (30d)</h1>
-      <p class="sub" style="margin-bottom:10px;">Zero-result searches — demand even when nobody submitted a request.</p>
+      <h1 style="font-size:1.2rem;margin:22px 0 8px;">Unmet searches by week</h1>
+      <p class="sub" style="margin-bottom:10px;">Zero-result searches — the recruitment targeting map, even when nobody submitted.</p>
       ${sigHtml}`;
   } catch (e) {
     if (e.message === 'Not authenticated') return signOut();
@@ -339,13 +368,15 @@ async function reqAssign(reqId, providerId, serviceId) {
     renderRequests(document.getElementById('adm-content'));
   } catch (e) { admMsg(e.message, 'error'); }
 }
-async function reqUpdate(reqId, status) {
+async function reqUpdate(reqId) {
+  const status = (document.getElementById('reqstatus-' + reqId) || {}).value || '';
   const note = (document.getElementById('reqnote-' + reqId) || {}).value || '';
-  if (status === 'closed' && !confirm('Close this request?')) return;
+  const terminal = ['transitioned', 'lost', 'closed'].includes(status);
+  if (terminal && !confirm(`Mark this lead ${status}? It drops off the board.`)) return;
   admMsg('');
   try {
     await sbFn('stripe-api', { action:'request_update', request_id:reqId, status, admin_note:note });
-    admMsg(status === 'closed' ? 'Request closed ✓' : 'Marked onboarding ✓', 'ok');
+    admMsg('Lead updated ✓', 'ok');
     renderRequests(document.getElementById('adm-content'));
   } catch (e) { admMsg(e.message, 'error'); }
 }

--- a/supabase/functions/stripe-api/index.ts
+++ b/supabase/functions/stripe-api/index.ts
@@ -456,11 +456,13 @@ Deno.serve(async (req) => {
     if (action === 'requests_list') {
       if (!(await isAdmin(user.id))) return json({ error: 'Not authorised' }, 403);
       const NONE = ['00000000-0000-0000-0000-000000000000'];
+      // TRU-221: every non-terminal pipeline status stays on the board so nothing falls
+      // through; terminal leads (transitioned/lost/closed) drop off.
       const { data: reqs } = await sb.from('carer_requests')
         .select('*')
-        .in('status', ['open', 'onboarding'])
+        .in('status', ['captured', 'called', 'founder_walking', 'sourcing_walker', 'meet_greet_booked'])
         .order('created_at', { ascending: false })
-        .limit(50);
+        .limit(100);
       const rows = reqs || [];
       const custIds = [...new Set(rows.map((r) => r.customer_id).filter(Boolean))] as string[];
       const petIds = [...new Set(rows.map((r) => r.pet_id).filter(Boolean))] as string[];
@@ -474,19 +476,17 @@ Deno.serve(async (req) => {
       const { data: us } = await sb.from('users').select('id,first_name,last_name,email').in('id', uIds.length ? uIds : NONE);
       const userBy = Object.fromEntries((us || []).map((u) => [u.id, u]));
 
-      // Passive signal — unmet searches over the last 30 days, aggregated by suburb + service.
-      const since = new Date(Date.now() - 30 * 864e5).toISOString();
-      const { data: misses } = await sb.from('search_misses').select('suburb,service_type').gte('created_at', since).limit(2000);
-      const aggMap: Record<string, number> = {};
-      (misses || []).forEach((m) => {
-        const k = `${m.suburb}||${m.service_type || ''}`;
-        aggMap[k] = (aggMap[k] || 0) + 1;
-      });
-      const signal = Object.entries(aggMap)
-        .map(([k, count]) => { const [suburb, service_type] = k.split('||'); return { suburb, service_type, count }; })
-        .sort((a, b) => b.count - a.count)
-        .slice(0, 20);
+      // Passive signal — weekly unmet-search counts by suburb (TRU-222's rollup view),
+      // last 8 weeks, biggest gaps first.
+      const since = new Date(Date.now() - 56 * 864e5).toISOString().slice(0, 10);
+      const { data: signal } = await sb.from('search_miss_weekly')
+        .select('week_start,suburb,postcode,service_type,misses')
+        .gte('week_start', since)
+        .order('week_start', { ascending: false })
+        .order('misses', { ascending: false })
+        .limit(40);
 
+      const now = Date.now();
       return json({
         requests: rows.map((r) => {
           const u = userBy[custUser[r.customer_id]];
@@ -496,9 +496,10 @@ Deno.serve(async (req) => {
             email: r.contact_email || (u ? u.email : '') || '',
             pet: r.pet_id ? (petName[r.pet_id] || 'Dog') : '',
             can_assign: !!(r.customer_id && r.pet_id),
+            days_in_status: Math.floor((now - new Date(r.status_changed_at || r.created_at).getTime()) / 864e5),
           };
         }),
-        signal,
+        signal: signal || [],
       });
     }
 
@@ -544,7 +545,7 @@ Deno.serve(async (req) => {
       if (!providerId || !serviceId || !scheduledAt) return json({ error: 'Missing carer, service or time' }, 400);
       const { data: rq } = await sb.from('carer_requests').select('*').eq('id', reqId).maybeSingle();
       if (!rq) return json({ error: 'Request not found' }, 404);
-      if (rq.status !== 'open' && rq.status !== 'onboarding') return json({ error: 'Request already resolved' }, 409);
+      if (['transitioned', 'lost', 'closed'].includes(rq.status)) return json({ error: 'Request already resolved' }, 409);
       if (!rq.customer_id || !rq.pet_id) return json({ error: 'This request has no linked customer/pet to assign' }, 400);
 
       const { data: svc } = await sb.from('provider_services').select('id,duration_mins').eq('id', serviceId).maybeSingle();
@@ -568,12 +569,13 @@ Deno.serve(async (req) => {
       const bookingId = ins.data.id;
       await sb.from('booking_pets').insert({ booking_id: bookingId, pet_id: rq.pet_id });
 
+      // TRU-221: an assigned lead is not terminal — it stays on the board as
+      // meet_greet_booked until the admin moves it to transitioned/lost, so the
+      // follow-through (first booking actually happening) is tracked.
       await sb.from('carer_requests').update({
-        status: 'matched',
+        status: 'meet_greet_booked',
         assigned_provider_id: providerId,
         assigned_booking_id: bookingId,
-        resolved_at: new Date().toISOString(),
-        resolved_by: user.id,
       }).eq('id', reqId);
 
       // Tell the customer in-app (the carer's booking-request email is fired by the DB trigger).
@@ -596,8 +598,9 @@ Deno.serve(async (req) => {
       const reqId = String(payload.request_id || '');
       const status = String(payload.status || '');
       const adminNote = String(payload.admin_note || '').slice(0, 500);
-      if (!['open', 'onboarding', 'closed'].includes(status)) return json({ error: 'Invalid status' }, 400);
-      const resolved = status === 'closed';
+      if (!['captured', 'called', 'founder_walking', 'sourcing_walker', 'meet_greet_booked',
+            'transitioned', 'lost', 'closed'].includes(status)) return json({ error: 'Invalid status' }, 400);
+      const resolved = ['transitioned', 'lost', 'closed'].includes(status);
       const upd = await sb.from('carer_requests').update({
         status,
         admin_note: adminNote || null,


### PR DESCRIPTION
Second PR of the TRU-216 epic. **Stacked on #105** (base is its branch, so GitHub retargets this to main automatically when #105 merges — merge #105 first).

## What changed

**`stripe-api` edge fn** (deployed as v12)
- `requests_list`: filters to the live pipeline statuses (`captured` → `meet_greet_booked`), computes `days_in_status` server-side from `status_changed_at`, and the passive signal now reads `search_miss_weekly` (weekly counts by suburb, last 8 weeks) instead of the old flat 30-day aggregation.
- `request_update`: accepts the full new status set; `resolved_at`/`resolved_by` stamped only on terminal statuses (`transitioned`/`lost`/`closed`), cleared otherwise.
- `request_assign`: had to change in this PR — it wrote the removed `'matched'` status, which now violates the check constraint. Assigned leads park at `meet_greet_booked` and **stay on the board** until the admin confirms follow-through (per TRU-221's "nothing falls through"). The `total_cents: 0` bug in this action is untouched here — it's fixed properly in the TRU-224 PR.

**`admin/index.html`** requests section
- Board grouped by pipeline stage in order; each card: status select + save, phone as a `tel:` link (⚠ flagged when missing), dog name/breed/temperament, frequency + preferred times.
- **The 14-day sourcing clock**: while a lead is `founder_walking` the badge reads "day N of 14" and turns red from day 10. Other stages show days-in-status.
- Weekly unmet-search table (week · suburb + postcode · service · count).

## Verified
- `deno check` + inline-JS `node --check` pass.
- Deployed v12 answers via pg_net from inside the DB (401 unauthenticated, as designed).
- The underlying queries (status filter, `search_miss_weekly`, `status_changed_at` bump) were verified against the live DB in #105's checks.
- Couldn't drive the signed-in admin UI (no admin session available to the agent) — worth a quick eyeball of `/admin/` → Requests after both PRs merge + deploy.

Linear: TRU-221 (parent TRU-216).

🤖 Generated with [Claude Code](https://claude.com/claude-code)