### PR TITLE
TRU-224: Lead → owner conversion, founder stop-gap booking + request_assign £0 fix

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -288,6 +288,29 @@ function requestCard(rq) {
     <div id="reqcarers-${rq.id}"></div>` : '';
   const statusOpts = LEAD_STATUSES.concat(LEAD_TERMINAL)
     .map(([v, l]) => `<option value="${v}"${rq.status === v ? ' selected' : ''}>${l}</option>`).join('');
+  // TRU-224: conversion controls. Guest leads get a one-click account link once the owner
+  // registers; linked leads get the founder stop-gap booking form (rate + schedule → M&G
+  // series via admin_create_lead_series). Real-carer assignment stays via "Find carers".
+  const linkUi = !rq.customer_id
+    ? (rq.account_exists
+        ? `<div class="actions"><button class="btn" onclick="reqLinkCustomer('${rq.id}')">Link account (${esc(rq.email)})</button></div>`
+        : `<div class="meta">No account yet — they register via the confirmation email, then a link button appears here.</div>`)
+    : '';
+  const founderUi = rq.customer_id && !rq.assigned_series_id ? `
+    <div class="meta" style="margin-top:8px;"><b>Founder stop-gap</b> — books you as the walker at an interim rate; free M&G first, card captured at proceed.</div>
+    <div class="actions" style="flex-wrap:wrap;">
+      <input class="reason" id="fRate-${rq.id}" type="number" min="1" step="1" placeholder="$/walk" style="flex:0 1 90px;min-width:0;">
+      <select class="reason" id="fDur-${rq.id}" style="flex:0 1 auto;"><option value="30">30 min</option><option value="60">60 min</option></select>
+      <input class="reason" id="fMg-${rq.id}" type="datetime-local" title="Meet & greet time" style="flex:0 1 auto;min-width:0;">
+      <input class="reason" id="fStart-${rq.id}" type="date" title="First walk date" style="flex:0 1 auto;min-width:0;">
+      <input class="reason" id="fTime-${rq.id}" type="time" value="09:00" title="Walk time" style="flex:0 1 auto;min-width:0;">
+    </div>
+    <div class="actions" style="flex-wrap:wrap;">
+      ${['Mon','Tue','Wed','Thu','Fri','Sat','Sun'].map((d, i) => `<button type="button" class="btn" data-d="${i + 1}" onclick="fDayToggle('${rq.id}', this)" style="background:#fff;color:var(--terracottaDark);">${d}</button>`).join('')}
+      <button class="btn" onclick="founderBook('${rq.id}','${esc(rq.service_type || 'dog_walking')}','${rq.pet_id || ''}')">Book me as stop-gap</button>
+    </div>` : '';
+  const seriesNote = rq.assigned_series_id
+    ? `<div class="meta"><b>Series live</b> — M&G booked; owner proceeds in their profile (card capture) to activate.</div>` : '';
   return `<div class="card" id="reqcard-${rq.id}">
     <div class="row-top"><div><b>${esc(svcLabel(rq.service_type))}</b> in ${esc(rq.suburb || '—')} ${acct} ${clockBadge(rq)}</div><div class="meta">${when(rq.created_at)}</div></div>
     <div class="meta"><b>${esc(rq.contact)}</b>${rq.contact_phone ? ` · <a href="tel:${esc(rq.contact_phone)}">${esc(rq.contact_phone)}</a>` : ' · ⚠ no phone'}${rq.email ? ' · ' + esc(rq.email) : ''}</div>
@@ -295,13 +318,53 @@ function requestCard(rq) {
     ${rq.dog_temperament_note ? `<div class="meta">Temperament: “${esc(rq.dog_temperament_note)}”</div>` : ''}
     <div class="meta">${esc(reqWhen(rq))}</div>
     ${rq.note ? `<div class="meta">“${esc(rq.note)}”</div>` : ''}
+    ${linkUi}
+    ${seriesNote}
     ${assignUi}
+    ${founderUi}
     <div class="actions">
       <select class="reason" id="reqstatus-${rq.id}" style="flex:0 1 auto;">${statusOpts}</select>
       <input class="reason" id="reqnote-${rq.id}" placeholder="Admin note (optional)" value="${esc(rq.admin_note || '')}">
       <button class="btn" onclick="reqUpdate('${rq.id}')">Save</button>
     </div>
   </div>`;
+}
+// TRU-224: founder stop-gap booking helpers.
+const founderDays = {}; // per-lead selected isodow set (Mon=1 … Sun=7)
+function fDayToggle(id, btn) {
+  const set = (founderDays[id] ||= new Set());
+  const d = +btn.dataset.d;
+  if (set.has(d)) { set.delete(d); btn.style.background = '#fff'; btn.style.color = 'var(--terracottaDark)'; }
+  else { set.add(d); btn.style.background = 'var(--terracotta)'; btn.style.color = '#fff'; }
+}
+async function reqLinkCustomer(id) {
+  admMsg('');
+  try {
+    const r = await sbFn('stripe-api', { action:'request_link_customer', request_id:id });
+    admMsg('Account linked ✓' + ((r.pets && r.pets.length) ? '' : ' — owner has no pets yet; they must add one before booking.'), 'ok');
+    renderRequests(document.getElementById('adm-content'));
+  } catch (e) { admMsg(e.message, 'error'); }
+}
+async function founderBook(rqId, serviceType, petId) {
+  const val = s => (document.getElementById(s + '-' + rqId) || {}).value || '';
+  const rate = Math.round(parseFloat(val('fRate')) * 100);
+  const mg = val('fMg'), start = val('fStart'), time = val('fTime');
+  const days = Array.from(founderDays[rqId] || []);
+  if (!(rate > 0)) { admMsg('Set the stop-gap rate first.', 'error'); return; }
+  if (!mg || !start || !time) { admMsg('Set the meet & greet time, start date and walk time.', 'error'); return; }
+  if (!days.length) { admMsg('Pick at least one walk day.', 'error'); return; }
+  if (!confirm(`Book yourself as the stop-gap walker at $${(rate / 100).toFixed(0)}/walk? This creates the free meet & greet and the recurring series.`)) return;
+  admMsg('');
+  try {
+    const r = await sbFn('stripe-api', { action:'founder_service_ensure', service_type:serviceType, duration_mins:+val('fDur') || 30, price_cents:rate });
+    await sbFn('stripe-api', {
+      action:'request_create_series', request_id:rqId, service_id:r.service_id,
+      mg_scheduled_at:new Date(mg).toISOString(), start_date:start, time_of_day:time,
+      days_of_week:days, frequency_type:'specific_days', pet_id: petId || null,
+    });
+    admMsg('Stop-gap series created ✓ — meet & greet booked and owner notified.', 'ok');
+    renderRequests(document.getElementById('adm-content'));
+  } catch (e) { admMsg(e.message, 'error'); }
 }
 function signalRow(s) {
   return `<tr><td class="meta">${esc(s.week_start)}</td><td class="meta">${esc(s.suburb)}${s.postcode ? ' ' + esc(s.postcode) : ''}</td><td class="meta">${esc(svcLabel(s.service_type).toLowerCase())}</td><td class="meta" style="text-align:right;"><b>×${s.misses}</b></td></tr>`;

--- a/supabase/functions/charge-booking/index.ts
+++ b/supabase/functions/charge-booking/index.ts
@@ -105,11 +105,21 @@ Deno.serve(async (req) => {
     };
     let fee = 0;
     if (!covered) {
-      const { data: pp } = await sb.from('provider_profiles').select('stripe_account_id').eq('id', b.provider_id).single();
-      if (!pp?.stripe_account_id) { await markFailed(bookingId); return json({ error: 'carer has no payout account' }, 400); }
-      piBody['transfer_data[destination]'] = pp.stripe_account_id;
-      fee = Math.round((b.total_cents * PLATFORM_FEE_BPS) / 10000);
-      if (fee > 0) piBody['application_fee_amount'] = fee; // omitted at 0% — Stripe requires it positive
+      const { data: pp } = await sb.from('provider_profiles').select('stripe_account_id,user_id').eq('id', b.provider_id).single();
+      if (pp?.stripe_account_id) {
+        piBody['transfer_data[destination]'] = pp.stripe_account_id;
+        fee = Math.round((b.total_cents * PLATFORM_FEE_BPS) / 10000);
+        if (fee > 0) piBody['application_fee_amount'] = fee; // omitted at 0% — Stripe requires it positive
+      } else {
+        // TRU-224: founder stop-gap walks — the provider profile belongs to an admin user
+        // with no connected account. The platform retains the full amount, the TRU-139
+        // covered-walk money mechanics applied to founder walks. Any other carer without
+        // a payout account is still a hard failure.
+        const { data: pu } = pp?.user_id
+          ? await sb.from('users').select('is_admin').eq('id', pp.user_id).single()
+          : { data: null };
+        if (!pu?.is_admin) { await markFailed(bookingId); return json({ error: 'carer has no payout account' }, 400); }
+      }
     }
 
     let pi;

--- a/supabase/functions/stripe-api/index.ts
+++ b/supabase/functions/stripe-api/index.ts
@@ -18,10 +18,13 @@
 //   cover_reassign  - (admin) take over a covered cancelled booking (TRU-139)
 //   cover_fell_through - (admin) mark cover as failed; issue a manual credit + owner message
 //   credit_redeem   - (admin) mark a manual credit as applied
-//   requests_list   - (admin) open "can't find a carer" requests + unmet-search signal (TRU-121)
+//   requests_list   - (admin) live capture-flow leads by pipeline stage + weekly unmet-search signal (TRU-121/221)
 //   request_find_carers - (admin) candidate carers near a request (reuses search_carers)
-//   request_assign  - (admin) assign an existing carer -> creates a pending booking request
-//   request_update  - (admin) set a request's status + admin note (guest / onboarding path)
+//   request_assign  - (admin) assign an existing carer -> creates a priced pending booking request
+//   request_link_customer - (admin) link a registered account to a guest lead by email (TRU-224)
+//   founder_service_ensure - (admin) founder stop-gap provider profile + priced service row (TRU-224)
+//   request_create_series - (admin) lead -> pending_meet_greet series via admin_create_lead_series (TRU-224)
+//   request_update  - (admin) set a lead's pipeline status + admin note (TRU-221)
 //
 // Required function secrets (Supabase → Edge Functions → Secrets):
 //   STRIPE_SECRET_KEY   - sk_test_… (platform secret key)
@@ -218,11 +221,17 @@ Deno.serve(async (req) => {
       };
       let fee = 0;
       if (!covered) {
-        const { data: pp } = await sb.from('provider_profiles').select('stripe_account_id').eq('id', b.provider_id).single();
-        if (!pp?.stripe_account_id) return json({ error: 'Carer has no payout account' }, 400);
-        piBody['transfer_data[destination]'] = pp.stripe_account_id;
-        fee = Math.round((b.total_cents * PLATFORM_FEE_BPS) / 10000);
-        if (fee > 0) piBody['application_fee_amount'] = fee;
+        const { data: pp } = await sb.from('provider_profiles').select('stripe_account_id,user_id').eq('id', b.provider_id).single();
+        if (pp?.stripe_account_id) {
+          piBody['transfer_data[destination]'] = pp.stripe_account_id;
+          fee = Math.round((b.total_cents * PLATFORM_FEE_BPS) / 10000);
+          if (fee > 0) piBody['application_fee_amount'] = fee;
+        } else if (!pp?.user_id || !(await isAdmin(pp.user_id))) {
+          return json({ error: 'Carer has no payout account' }, 400);
+        }
+        // else: TRU-224 founder stop-gap walk — the provider profile belongs to an admin
+        // with no connected account; the platform retains the full amount (the TRU-139
+        // covered-walk money mechanics, applied to founder walks).
       }
       // No confirm — the client confirms with the Payment Element so a new card / 3DS works.
       const pi = await stripe('payment_intents', 'POST', piBody);
@@ -476,6 +485,15 @@ Deno.serve(async (req) => {
       const { data: us } = await sb.from('users').select('id,first_name,last_name,email').in('id', uIds.length ? uIds : NONE);
       const userBy = Object.fromEntries((us || []).map((u) => [u.id, u]));
 
+      // TRU-224: for guest leads, flag when an account already exists for the contact email
+      // so the console can offer one-click linking after the lead registers.
+      const guestEmails = [...new Set(rows.filter((r) => !r.customer_id && r.contact_email)
+        .map((r) => String(r.contact_email).toLowerCase()))];
+      const { data: matchUsers } = guestEmails.length
+        ? await sb.from('users').select('email').in('email', guestEmails)
+        : { data: [] as { email: string }[] };
+      const emailHasAccount = new Set((matchUsers || []).map((u) => String(u.email).toLowerCase()));
+
       // Passive signal — weekly unmet-search counts by suburb (TRU-222's rollup view),
       // last 8 weeks, biggest gaps first.
       const since = new Date(Date.now() - 56 * 864e5).toISOString().slice(0, 10);
@@ -497,6 +515,8 @@ Deno.serve(async (req) => {
             pet: r.pet_id ? (petName[r.pet_id] || 'Dog') : '',
             can_assign: !!(r.customer_id && r.pet_id),
             days_in_status: Math.floor((now - new Date(r.status_changed_at || r.created_at).getTime()) / 864e5),
+            account_exists: !!r.customer_id
+              || (r.contact_email ? emailHasAccount.has(String(r.contact_email).toLowerCase()) : false),
           };
         }),
         signal: signal || [],
@@ -548,13 +568,16 @@ Deno.serve(async (req) => {
       if (['transitioned', 'lost', 'closed'].includes(rq.status)) return json({ error: 'Request already resolved' }, 409);
       if (!rq.customer_id || !rq.pet_id) return json({ error: 'This request has no linked customer/pet to assign' }, 400);
 
-      const { data: svc } = await sb.from('provider_services').select('id,duration_mins').eq('id', serviceId).maybeSingle();
+      const { data: svc } = await sb.from('provider_services')
+        .select('id,duration_mins,price_cents,is_available').eq('id', serviceId).maybeSingle();
       if (!svc) return json({ error: 'Service not found' }, 404);
+      if (!svc.is_available || svc.price_cents == null) return json({ error: 'Service is unavailable or has no price' }, 400);
 
-      // Mirror the customer's single-booking insert (book/index.html): status 'pending',
-      // total_cents 0 (single bookings price on completion; series carry locked_price_cents).
-      // The carer still accepts and the customer still confirms — nothing is forced. The
-      // existing trg_email_booking_request trigger notifies the carer on insert.
+      // TRU-224 (£0 bug fix): price the booking from the service at assign time — the old
+      // total_cents: 0 insert was never repriced, so charge-on-completion (TRU-146) skipped
+      // it and assigned bookings were free. Single pet here (rq.pet_id), so no extra-pet fee
+      // — mirrors private.compute_service_price for a pet count of 1. The carer still
+      // accepts; trg_email_booking_request notifies them on insert.
       const ins = await sb.from('bookings').insert({
         customer_id: rq.customer_id,
         provider_id: providerId,
@@ -563,7 +586,7 @@ Deno.serve(async (req) => {
         status: 'pending',
         scheduled_at: scheduledAt,
         duration_mins: svc.duration_mins ?? null,
-        total_cents: 0,
+        total_cents: svc.price_cents,
       }).select('id').single();
       if (ins.error || !ins.data) return json({ error: 'Could not create booking: ' + (ins.error?.message || '') }, 500);
       const bookingId = ins.data.id;
@@ -591,6 +614,130 @@ Deno.serve(async (req) => {
         });
       }
       return json({ ok: true, booking_id: bookingId });
+    }
+
+    if (action === 'request_link_customer') {
+      // TRU-224: after the lead registers (confirmation email CTA / founder call), link
+      // their new account to the lead by email so the booking steps can run.
+      if (!(await isAdmin(user.id))) return json({ error: 'Not authorised' }, 403);
+      const reqId = String(payload.request_id || '');
+      const { data: rq } = await sb.from('carer_requests').select('id,status,customer_id,contact_email').eq('id', reqId).maybeSingle();
+      if (!rq) return json({ error: 'Request not found' }, 404);
+      const email = String(payload.customer_email || rq.contact_email || '').trim().toLowerCase();
+      if (!email) return json({ error: 'No email to match on' }, 400);
+      let customerId = rq.customer_id as string | null;
+      if (!customerId) {
+        const { data: u } = await sb.from('users').select('id').ilike('email', email).maybeSingle();
+        if (!u) return json({ error: `No account found for ${email}` }, 404);
+        const { data: cp } = await sb.from('customer_profiles').select('id').eq('user_id', u.id).maybeSingle();
+        if (!cp) return json({ error: 'That account has no customer profile' }, 404);
+        customerId = cp.id;
+      }
+      await sb.from('carer_requests').update({
+        customer_id: customerId,
+        converted_customer_id: customerId,
+      }).eq('id', reqId);
+      const { data: pets } = await sb.from('pets').select('id,name,breed').eq('customer_id', customerId);
+      return json({ ok: true, customer_id: customerId, pets: pets || [] });
+    }
+
+    if (action === 'founder_service_ensure') {
+      // TRU-224: get-or-create the calling admin's internal provider profile (the TRU-139
+      // cover_reassign pattern — inactive + unverified, never searchable) and upsert a
+      // provider_services row at the stop-gap rate for the lead's service type. Pricing
+      // then flows through the normal machinery (compute_service_price reads this row).
+      if (!(await isAdmin(user.id))) return json({ error: 'Not authorised' }, 403);
+      const serviceType = String(payload.service_type || 'dog_walking');
+      const durationMins = Math.max(15, Math.round(Number(payload.duration_mins ?? 30)) || 30);
+      const priceCents = Math.round(Number(payload.price_cents || 0));
+      if (!(priceCents > 0)) return json({ error: 'Set a stop-gap rate first' }, 400);
+
+      let { data: mypp } = await sb.from('provider_profiles').select('id').eq('user_id', user.id).maybeSingle();
+      if (!mypp) {
+        const ins = await sb.from('provider_profiles')
+          .insert({ user_id: user.id, is_active: false, is_verified: false, bio: 'Truffl founder stop-gap' })
+          .select('id').single();
+        if (ins.error || !ins.data) return json({ error: 'Could not create founder profile' }, 500);
+        mypp = ins.data;
+      }
+
+      // provider_services.provider_id references users.id (not provider_profiles.id).
+      const { data: existing } = await sb.from('provider_services')
+        .select('id').eq('provider_id', user.id).eq('service_type', serviceType)
+        .eq('duration_mins', durationMins).maybeSingle();
+      if (existing) {
+        await sb.from('provider_services').update({ price_cents: priceCents, is_available: true }).eq('id', existing.id);
+        return json({ ok: true, service_id: existing.id, provider_profile_id: mypp.id });
+      }
+      const svcIns = await sb.from('provider_services').insert({
+        provider_id: user.id,
+        service_type: serviceType,
+        duration_mins: durationMins,
+        price_cents: priceCents,
+        is_available: true,
+      }).select('id').single();
+      if (svcIns.error || !svcIns.data) return json({ error: 'Could not create service: ' + (svcIns.error?.message || '') }, 500);
+      return json({ ok: true, service_id: svcIns.data.id, provider_profile_id: mypp.id });
+    }
+
+    if (action === 'request_create_series') {
+      // TRU-224: create the lead's pending_meet_greet series (founder stop-gap or a real
+      // carer) via the service_role-only definer RPC — pricing and the M&G gate booking
+      // happen server-side in SQL, mirroring create_booking_series. From here the flow is
+      // all existing machinery: owner marks the M&G complete, proceeds (card saved via
+      // SetupIntent), the series activates and walks charge on completion.
+      if (!(await isAdmin(user.id))) return json({ error: 'Not authorised' }, 403);
+      const reqId = String(payload.request_id || '');
+      const serviceId = String(payload.service_id || '');
+      const mgAt = String(payload.mg_scheduled_at || '');
+      const startDate = String(payload.start_date || '');
+      const timeOfDay = String(payload.time_of_day || '');
+      const daysOfWeek = Array.isArray(payload.days_of_week) ? (payload.days_of_week as number[]) : [];
+      // series_frequency enum: daily | weekdays | specific_days (specific_days uses days_of_week, isodow 1–7)
+      const frequencyType = String(payload.frequency_type || 'specific_days');
+      const bookingKind = String(payload.booking_kind || 'recurring');
+      if (!['daily', 'weekdays', 'specific_days'].includes(frequencyType)) return json({ error: 'Invalid frequency' }, 400);
+      if (!reqId || !serviceId || !mgAt || !startDate || !timeOfDay) {
+        return json({ error: 'Missing service, meet & greet time, start date or walk time' }, 400);
+      }
+      if (frequencyType === 'specific_days' && !daysOfWeek.length) {
+        return json({ error: 'Pick at least one walk day' }, 400);
+      }
+      const { data: rq } = await sb.from('carer_requests').select('id,customer_id,pet_id').eq('id', reqId).maybeSingle();
+      if (!rq) return json({ error: 'Request not found' }, 404);
+      const customerId = rq.customer_id as string | null;
+      if (!customerId) return json({ error: 'Link the lead to an account first' }, 400);
+      const petId = String(payload.pet_id || rq.pet_id || '');
+      if (!petId) return json({ error: 'Pick a pet first (the owner must add one)' }, 400);
+
+      const { data: seriesId, error: rpcErr } = await sb.rpc('admin_create_lead_series', {
+        p_request_id: reqId,
+        p_customer_id: customerId,
+        p_service_id: serviceId,
+        p_pet_ids: [petId],
+        p_booking_kind: bookingKind,
+        p_frequency_type: frequencyType,
+        p_days_of_week: daysOfWeek,
+        p_time_of_day: timeOfDay,
+        p_window_end_time: payload.window_end_time ? String(payload.window_end_time) : null,
+        p_start_date: startDate,
+        p_end_date: payload.end_date ? String(payload.end_date) : null,
+        p_mg_scheduled_at: mgAt,
+      });
+      if (rpcErr) return json({ error: rpcErr.message }, 400);
+
+      // Tell the owner in-app; the M&G banner in messages + the proceed step in profile
+      // take it from here.
+      const { data: cp } = await sb.from('customer_profiles').select('user_id').eq('id', customerId).single();
+      if (cp?.user_id) {
+        await sb.from('system_messages').insert({
+          recipient_user_id: cp.user_id,
+          body: `Your first walks are set up — we've booked a free meet & greet so you can meet your walker before anything starts. Check your bookings for the time.`,
+          link_url: '/profile/',
+          link_label: 'View my bookings',
+        });
+      }
+      return json({ ok: true, series_id: seriesId });
     }
 
     if (action === 'request_update') {

--- a/supabase/migrations/20260717000000_tru224_lead_conversion.sql
+++ b/supabase/migrations/20260717000000_tru224_lead_conversion.sql
@@ -1,0 +1,115 @@
+-- TRU-224: convert a captured lead into an owner + first booking with the founder as carer.
+--
+-- The capture flow (TRU-216) ends with a lead record; this migration wires it into the real
+-- booking pipeline:
+--   • carer_requests.converted_customer_id / assigned_series_id link the lead to the owner
+--     account and the founder booking series, so the TRU-221 pipeline can follow through.
+--   • public.admin_create_lead_series is the server-side path the admin console uses to
+--     create the founder (or any carer's) pending_meet_greet series for a lead. It mirrors
+--     public.create_booking_series exactly (provider derived from the service, price via
+--     private.compute_service_price, M&G booking created atomically) but takes an explicit
+--     customer instead of auth.uid(), because the admin — not the owner — drives this step.
+--     EXECUTE is granted to service_role ONLY: it is called from the stripe-api edge function
+--     behind its users.is_admin gate, never from clients.
+--
+-- Payment stays exactly where TRU-144/146 put it: card captured at the M&G proceed step,
+-- charge on completion. Nothing here touches money.
+--
+-- Applied to the live DB via apply_migration (Supabase branching is broken on this repo);
+-- committed here for version control (see TRU-145). 14-digit unique prefix.
+
+alter table public.carer_requests
+  add column if not exists converted_customer_id uuid references public.customer_profiles(id) on delete set null,
+  add column if not exists assigned_series_id    uuid references public.booking_series(id) on delete set null;
+
+create or replace function public.admin_create_lead_series(
+  p_request_id      uuid,
+  p_customer_id     uuid,
+  p_service_id      uuid,
+  p_pet_ids         uuid[],
+  p_booking_kind    text,
+  p_frequency_type  public.series_frequency,
+  p_days_of_week    int[],
+  p_time_of_day     time,
+  p_window_end_time time        default null,
+  p_start_date      date        default null,
+  p_end_date        date        default null,
+  p_mg_scheduled_at timestamptz default null
+) returns uuid language plpgsql security definer set search_path = public as $$
+declare
+  v_provider_id uuid;
+  v_owned       int;
+  v_locked      int;
+  v_series_id   uuid;
+  v_mg_id       uuid;
+  v_status      text;
+begin
+  select status into v_status from public.carer_requests where id = p_request_id;
+  if v_status is null then
+    raise exception 'Lead % not found', p_request_id;
+  end if;
+  if v_status in ('transitioned', 'lost', 'closed') then
+    raise exception 'Lead % is already resolved (%)', p_request_id, v_status;
+  end if;
+
+  if p_pet_ids is null or array_length(p_pet_ids, 1) is null then
+    raise exception 'At least one pet is required';
+  end if;
+  select count(*) into v_owned
+    from public.pets where id = any(p_pet_ids) and customer_id = p_customer_id;
+  if v_owned <> cardinality(p_pet_ids) then
+    raise exception 'One or more pets do not belong to customer %', p_customer_id;
+  end if;
+
+  -- provider_services.provider_id is an auth.users.id; map it to provider_profiles.id.
+  select pp.id into v_provider_id
+    from public.provider_services ps
+    join public.provider_profiles pp on pp.user_id = ps.provider_id
+   where ps.id = p_service_id;
+  if v_provider_id is null then
+    raise exception 'Service % not found or has no provider profile', p_service_id;
+  end if;
+  v_locked := private.compute_service_price(p_service_id, cardinality(p_pet_ids));
+
+  insert into public.booking_series (
+    customer_id, provider_id, service_id, booking_kind,
+    frequency_type, days_of_week, time_of_day, window_end_time,
+    start_date, end_date, status, locked_price_cents
+  ) values (
+    p_customer_id, v_provider_id, p_service_id, coalesce(p_booking_kind, 'recurring'),
+    p_frequency_type, coalesce(p_days_of_week, '{}'::int[]), p_time_of_day, p_window_end_time,
+    p_start_date, p_end_date, 'pending_meet_greet'::public.series_status, v_locked
+  ) returning id into v_series_id;
+
+  insert into public.series_pets (series_id, pet_id)
+  select v_series_id, unnest(p_pet_ids);
+
+  -- The gate booking: free flagged M&G, same shape as create_booking_series's M&G branch.
+  insert into public.bookings (
+    customer_id, provider_id, pet_id, service_id, status,
+    scheduled_at, duration_mins, total_cents, is_meet_and_greet, series_id
+  ) values (
+    p_customer_id, v_provider_id, p_pet_ids[1], p_service_id, 'confirmed',
+    coalesce(p_mg_scheduled_at, (p_start_date::timestamp + time '12:00') at time zone 'Australia/Sydney'),
+    30, 0, true, v_series_id
+  ) returning id into v_mg_id;
+
+  insert into public.booking_pets (booking_id, pet_id)
+  select v_mg_id, unnest(p_pet_ids);
+
+  -- Wire the lead into the pipeline: it parks at meet_greet_booked (TRU-221 board) and
+  -- carries the links the follow-through needs.
+  update public.carer_requests set
+    status                = 'meet_greet_booked',
+    converted_customer_id = p_customer_id,
+    customer_id           = coalesce(customer_id, p_customer_id),
+    pet_id                = coalesce(pet_id, p_pet_ids[1]),
+    assigned_series_id    = v_series_id,
+    assigned_provider_id  = v_provider_id
+  where id = p_request_id;
+
+  return v_series_id;
+end; $$;
+
+revoke all on function public.admin_create_lead_series(uuid, uuid, uuid, uuid[], text, public.series_frequency, int[], time, time, date, date, timestamptz) from public, anon, authenticated;
+grant execute on function public.admin_create_lead_series(uuid, uuid, uuid, uuid[], text, public.series_frequency, int[], time, time, date, date, timestamptz) to service_role;


### PR DESCRIPTION
Third PR of the TRU-216 epic. **Stacked on #106** (which stacks on #105) — merge order: #105 → #106 → this.

## What changed

**Migration `20260717000000_tru224_lead_conversion.sql`** (applied live)
- `carer_requests.converted_customer_id` + `assigned_series_id` — the lead ↔ owner ↔ series links the pipeline follows through on.
- `public.admin_create_lead_series(...)` — **service_role-only** SECURITY DEFINER RPC mirroring `create_booking_series` (provider derived from the service, price via `private.compute_service_price`, `pending_meet_greet` series + free M&G gate booking created atomically), but with an explicit customer because the admin drives this step after the founder call. Also validates pet ownership and rejects terminal leads, then parks the lead at `meet_greet_booked` with all links set.

**`stripe-api`** (deployed v13)
- `request_link_customer` — after the lead registers (confirmation-email CTA), one call links their account to the lead by email; `requests_list` now flags `account_exists` for guest leads so the console shows the button at the right moment.
- `founder_service_ensure` — get-or-create the founder's internal provider profile (the TRU-139 `cover_reassign` pattern: `is_active:false`, `is_verified:false`, never searchable) + upsert a `provider_services` row at the **stop-gap rate typed in at booking time** (no hardcoded rate; the GTM number is still open).
- `request_create_series` — calls the RPC, then a system message to the owner. From there it's **all existing machinery**: M&G banner in messages → `mark_meet_greet_complete` → proceed step in profile (SetupIntent card capture, TRU-144) → series activates → walks charge on completion (TRU-146).
- **`request_assign` £0 bug fixed** (flagged on TRU-170): bookings are now priced from the chosen `provider_services` row at assign time, so charge-on-completion stops skipping them.

**`charge-booking`** (deployed v6) **+ `retry_charge`**
- The TRU-139 retain-in-full branch now also covers bookings whose provider profile belongs to an **admin user with no connected account** (founder stop-gap walks): owner pays full price, no destination transfer, no application fee. Any other carer without a payout account still hard-fails.

**`admin/index.html`**
- Guest lead card: "Link account (email)" once the account exists, or a hint that the owner needs to register first.
- Linked lead card: founder stop-gap form — $/walk, 30/60 min, M&G datetime, start date, walk time, day-of-week chips → "Book me as stop-gap".

## Verified (live)
- `admin_create_lead_series` end-to-end against the live DB with real test data: series `pending_meet_greet` at the service's price (4000¢), `specific_days {1,3,5}`, M&G booking (confirmed/flagged/$0/30min), lead linked + parked at `meet_greet_booked`. Negative tests: wrong-owner pet rejected, terminal lead rejected. All test rows cleaned up.
- Deployed v13 content round-tripped via `get_edge_function` and matches the committed file.
- `deno check` (stripe-api + charge-booking) and inline-JS `node --check` (admin) pass.

## Before the first real lead
The founder charge path (admin provider, retain-in-full) changes money code — do one **test-mode end-to-end**: capture → register → link → founder series → M&G complete → proceed with a Stripe test card → complete a walk → confirm the PaymentIntent succeeds with **no** destination transfer. I couldn't run the signed-in steps from this session.

Linear: TRU-224 (parent TRU-216); also resolves the `request_assign` loose end commented on TRU-170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)