### PR TITLE
TRU-225: Handover — series + future walks move to the nominated carer at their listed rate

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -309,7 +309,16 @@ function requestCard(rq) {
       ${['Mon','Tue','Wed','Thu','Fri','Sat','Sun'].map((d, i) => `<button type="button" class="btn" data-d="${i + 1}" onclick="fDayToggle('${rq.id}', this)" style="background:#fff;color:var(--terracottaDark);">${d}</button>`).join('')}
       <button class="btn" onclick="founderBook('${rq.id}','${esc(rq.service_type || 'dog_walking')}','${rq.pet_id || ''}')">Book me as stop-gap</button>
     </div>` : '';
-  const seriesNote = rq.assigned_series_id
+  // TRU-225: handover state on the card. Once nominated, "Complete handover" runs the
+  // transition (marks the 3-way M&G complete, repoints the series + future walks at the
+  // nominee's rate, lead → transitioned).
+  const handoverUi = rq.handover_mg_booking_id
+    ? `<div class="meta"><b>Handover nominated</b> — 3-way M&G ${esc(rq.handover_mg_status || 'confirmed')}${rq.handover_mg_at ? ' · ' + when(rq.handover_mg_at) : ''}</div>
+       <div class="actions"><button class="btn" onclick="handoverComplete('${rq.id}')">Complete handover</button></div>`
+    : (rq.assigned_series_id
+        ? `<div class="meta">Sourcing the permanent walker? "Find carers" → nominate for handover (needs their payouts set up).</div>`
+        : '');
+  const seriesNote = rq.assigned_series_id && !rq.handover_mg_booking_id
     ? `<div class="meta"><b>Series live</b> — M&G booked; owner proceeds in their profile (card capture) to activate.</div>` : '';
   return `<div class="card" id="reqcard-${rq.id}">
     <div class="row-top"><div><b>${esc(svcLabel(rq.service_type))}</b> in ${esc(rq.suburb || '—')} ${acct} ${clockBadge(rq)}</div><div class="meta">${when(rq.created_at)}</div></div>
@@ -320,6 +329,7 @@ function requestCard(rq) {
     ${rq.note ? `<div class="meta">“${esc(rq.note)}”</div>` : ''}
     ${linkUi}
     ${seriesNote}
+    ${handoverUi}
     ${assignUi}
     ${founderUi}
     <div class="actions">
@@ -329,6 +339,8 @@ function requestCard(rq) {
     </div>
   </div>`;
 }
+// TRU-224/225: per-lead context the candidate cards need (filled by renderRequests).
+const leadInfo = {};
 // TRU-224: founder stop-gap booking helpers.
 const founderDays = {}; // per-lead selected isodow set (Mon=1 … Sun=7)
 function fDayToggle(id, btn) {
@@ -375,7 +387,10 @@ async function renderRequests(c) {
     const { requests, signal } = await sbFn('stripe-api', { action:'requests_list' });
     // Group the board by pipeline stage so the founder-walking clock is impossible to miss.
     const byStatus = {};
-    (requests || []).forEach(r => { (byStatus[r.status] ||= []).push(r); });
+    (requests || []).forEach(r => {
+      leadInfo[r.id] = { hasSeries: !!r.assigned_series_id };
+      (byStatus[r.status] ||= []).push(r);
+    });
     const reqHtml = (requests && requests.length)
       ? LEAD_STATUSES.filter(([v]) => byStatus[v] && byStatus[v].length)
           .map(([v, l]) => `<h1 style="font-size:1.05rem;margin:18px 0 6px;">${l} <span class="meta">(${byStatus[v].length})</span></h1>` + byStatus[v].map(requestCard).join(''))
@@ -399,14 +414,41 @@ async function renderRequests(c) {
 function carerCandidate(reqId, cr) {
   const dist = (cr.distance_km != null) ? cr.distance_km + ' km' : '';
   const rating = cr.avg_rating ? '★' + (+cr.avg_rating).toFixed(1) : 'new';
+  // TRU-225: when the lead already has a live (founder) series, candidates are handover
+  // nominees rather than direct assignments.
+  const handoverMode = !!(leadInfo[reqId] && leadInfo[reqId].hasSeries);
   const svcBtns = (cr.services || []).map(s => {
     const label = svcLabel(s.service_type) + (s.price_cents != null ? ' ' + money(s.price_cents) : '') + (s.duration_mins ? ' / ' + s.duration_mins + 'm' : '');
-    return `<button class="btn" onclick="reqAssign('${reqId}','${cr.provider_id}','${s.id}')">Assign · ${esc(label)}</button>`;
+    return handoverMode
+      ? `<button class="btn" onclick="handoverNominate('${reqId}','${cr.provider_id}','${s.id}')">Nominate · ${esc(label)}</button>`
+      : `<button class="btn" onclick="reqAssign('${reqId}','${cr.provider_id}','${s.id}')">Assign · ${esc(label)}</button>`;
   }).join(' ');
   return `<div class="card" style="margin:8px 0 0;background:var(--cream);">
     <div class="row-top"><div><b>${esc(cr.name)}</b>${cr.is_verified ? ' <span class="badge b-paid">verified</span>' : ''}</div><div class="meta">${esc(cr.suburb || '')}${dist ? ' · ' + dist : ''} · ${rating}</div></div>
     <div class="actions">${svcBtns || '<span class="meta">No matching service</span>'}</div>
   </div>`;
+}
+async function handoverNominate(reqId, providerId, serviceId) {
+  const dtEl = document.getElementById('reqdt-' + reqId);
+  const dt = dtEl && dtEl.value ? dtEl.value : '';
+  if (!dt) { admMsg('Set the 3-way meet & greet date/time first (the Start field).', 'error'); return; }
+  if (!confirm('Nominate this carer for handover? It books the 3-way meet & greet (you + owner + carer) and messages the owner with their rate.')) return;
+  admMsg('');
+  try {
+    const iso = new Date(dt).toISOString();
+    await sbFn('stripe-api', { action:'handover_nominate', request_id:reqId, provider_id:providerId, service_id:serviceId, mg_scheduled_at:iso });
+    admMsg('Handover nominated ✓ — 3-way meet & greet booked and owner introduced.', 'ok');
+    renderRequests(document.getElementById('adm-content'));
+  } catch (e) { admMsg(e.message, 'error'); }
+}
+async function handoverComplete(reqId) {
+  if (!confirm('Complete the handover? Future walks move to the new carer at THEIR listed rate; completed founder walks keep their history. This also marks the 3-way meet & greet done.')) return;
+  admMsg('');
+  try {
+    const r = await sbFn('stripe-api', { action:'handover_complete', request_id:reqId });
+    admMsg(`Handover complete ✓ — ${r.reassigned ?? 0} future walk(s) moved to the new carer. Lead transitioned.`, 'ok');
+    renderRequests(document.getElementById('adm-content'));
+  } catch (e) { admMsg(e.message, 'error'); }
 }
 async function reqFindCarers(id) {
   const box = document.getElementById('reqcarers-' + id);

--- a/supabase/functions/stripe-api/index.ts
+++ b/supabase/functions/stripe-api/index.ts
@@ -24,6 +24,8 @@
 //   request_link_customer - (admin) link a registered account to a guest lead by email (TRU-224)
 //   founder_service_ensure - (admin) founder stop-gap provider profile + priced service row (TRU-224)
 //   request_create_series - (admin) lead -> pending_meet_greet series via admin_create_lead_series (TRU-224)
+//   handover_nominate - (admin) book the 3-way M&G with the incoming permanent carer (TRU-225)
+//   handover_complete - (admin) transition the series to the nominee at their listed rate (TRU-225)
 //   request_update  - (admin) set a lead's pipeline status + admin note (TRU-221)
 //
 // Required function secrets (Supabase → Edge Functions → Secrets):
@@ -494,6 +496,14 @@ Deno.serve(async (req) => {
         : { data: [] as { email: string }[] };
       const emailHasAccount = new Set((matchUsers || []).map((u) => String(u.email).toLowerCase()));
 
+      // TRU-225: surface the 3-way handover M&G status so the console can show
+      // "Complete handover" at the right moment.
+      const hoIds = [...new Set(rows.map((r) => r.handover_mg_booking_id).filter(Boolean))] as string[];
+      const { data: hoBookings } = hoIds.length
+        ? await sb.from('bookings').select('id,status,scheduled_at').in('id', hoIds)
+        : { data: [] as { id: string; status: string; scheduled_at: string }[] };
+      const hoBy = Object.fromEntries((hoBookings || []).map((b) => [b.id, b]));
+
       // Passive signal — weekly unmet-search counts by suburb (TRU-222's rollup view),
       // last 8 weeks, biggest gaps first.
       const since = new Date(Date.now() - 56 * 864e5).toISOString().slice(0, 10);
@@ -517,6 +527,8 @@ Deno.serve(async (req) => {
             days_in_status: Math.floor((now - new Date(r.status_changed_at || r.created_at).getTime()) / 864e5),
             account_exists: !!r.customer_id
               || (r.contact_email ? emailHasAccount.has(String(r.contact_email).toLowerCase()) : false),
+            handover_mg_status: r.handover_mg_booking_id ? (hoBy[r.handover_mg_booking_id]?.status || null) : null,
+            handover_mg_at: r.handover_mg_booking_id ? (hoBy[r.handover_mg_booking_id]?.scheduled_at || null) : null,
           };
         }),
         signal: signal || [],
@@ -738,6 +750,78 @@ Deno.serve(async (req) => {
         });
       }
       return json({ ok: true, series_id: seriesId });
+    }
+
+    if (action === 'handover_nominate') {
+      // TRU-225: book the 3-way M&G (owner + incoming carer + founder) on the lead's
+      // series. Validation (nominee active/verified/payouts-ready, matching priced
+      // service) and the booking insert live in the service_role-only RPC.
+      if (!(await isAdmin(user.id))) return json({ error: 'Not authorised' }, 403);
+      const reqId = String(payload.request_id || '');
+      const providerId = String(payload.provider_id || ''); // provider_profiles.id
+      const serviceId = String(payload.service_id || '');   // nominee's provider_services.id
+      const mgAt = String(payload.mg_scheduled_at || '');
+      if (!reqId || !providerId || !serviceId || !mgAt) return json({ error: 'Missing carer, service or meet & greet time' }, 400);
+
+      const { data: mgId, error: rpcErr } = await sb.rpc('admin_nominate_handover', {
+        p_request_id: reqId,
+        p_provider_profile_id: providerId,
+        p_service_id: serviceId,
+        p_mg_scheduled_at: mgAt,
+      });
+      if (rpcErr) return json({ error: rpcErr.message }, 400);
+
+      // Candid owner message: introduce the walker and quote THEIR listed rate up front
+      // (GTM: the number lands inside an expectation set on day one, confirmed at the M&G).
+      const { data: rq } = await sb.from('carer_requests').select('customer_id').eq('id', reqId).single();
+      const { data: pp } = await sb.from('provider_profiles').select('user_id').eq('id', providerId).single();
+      const { data: nu } = pp?.user_id ? await sb.from('users').select('first_name').eq('id', pp.user_id).single() : { data: null };
+      const { data: svc } = await sb.from('provider_services').select('price_cents').eq('id', serviceId).single();
+      const { data: cp } = rq?.customer_id ? await sb.from('customer_profiles').select('user_id').eq('id', rq.customer_id).single() : { data: null };
+      if (cp?.user_id) {
+        const rateStr = svc?.price_cents ? ` Their rate is $${(svc.price_cents / 100).toFixed(0)} per walk — we'll confirm everything together at the meet & greet.` : '';
+        await sb.from('system_messages').insert({
+          recipient_user_id: cp.user_id,
+          body: `Great news — we've found your permanent walker${nu?.first_name ? `, ${nu.first_name}` : ''}. We've booked a meet & greet so you can meet them together with Tom.${rateStr}`,
+          link_url: '/profile/',
+          link_label: 'View my bookings',
+        });
+      }
+      return json({ ok: true, mg_booking_id: mgId });
+    }
+
+    if (action === 'handover_complete') {
+      // TRU-225: after the 3-way meet — series + future walks move to the nominee at
+      // their listed rate, founder history preserved, lead → transitioned. Atomic in
+      // the service_role-only RPC.
+      if (!(await isAdmin(user.id))) return json({ error: 'Not authorised' }, 403);
+      const reqId = String(payload.request_id || '');
+      if (!reqId) return json({ error: 'Missing request id' }, 400);
+
+      const { data: rq } = await sb.from('carer_requests')
+        .select('customer_id,handover_provider_id,handover_service_id').eq('id', reqId).maybeSingle();
+      if (!rq) return json({ error: 'Request not found' }, 404);
+
+      const { data: moved, error: rpcErr } = await sb.rpc('admin_complete_handover', {
+        p_request_id: reqId,
+        p_resolved_by: user.id,
+      });
+      if (rpcErr) return json({ error: rpcErr.message }, 400);
+
+      const { data: pp } = rq.handover_provider_id ? await sb.from('provider_profiles').select('user_id').eq('id', rq.handover_provider_id).single() : { data: null };
+      const { data: nu } = pp?.user_id ? await sb.from('users').select('first_name').eq('id', pp.user_id).single() : { data: null };
+      const { data: svc } = rq.handover_service_id ? await sb.from('provider_services').select('price_cents').eq('id', rq.handover_service_id).single() : { data: null };
+      const { data: cp } = rq.customer_id ? await sb.from('customer_profiles').select('user_id').eq('id', rq.customer_id).single() : { data: null };
+      if (cp?.user_id) {
+        const rateStr = svc?.price_cents ? ` at $${(svc.price_cents / 100).toFixed(0)} per walk` : '';
+        await sb.from('system_messages').insert({
+          recipient_user_id: cp.user_id,
+          body: `It's official — ${nu?.first_name || 'your new walker'} takes over your walks from here${rateStr}. Everything we've learned about your dog goes with them, and Tom is always a message away.`,
+          link_url: '/profile/',
+          link_label: 'View my bookings',
+        });
+      }
+      return json({ ok: true, reassigned: moved });
     }
 
     if (action === 'request_update') {

--- a/supabase/migrations/20260717000001_tru225_handover.sql
+++ b/supabase/migrations/20260717000001_tru225_handover.sql
@@ -1,0 +1,220 @@
+-- TRU-225: handover — nominate a permanent carer to take over a lead's booking series.
+--
+-- The product side of the GTM two-week rule: the founder walks as a stop-gap (TRU-224),
+-- then hands the series to a sourced permanent walker at THEIR listed rate. Builds on the
+-- TRU-139 reassignment pattern (original_provider_id preserves who was booked vs who
+-- walked) but runs founder → new carer, operates on the whole series' future bookings,
+-- and changes the price at transition.
+--
+--   • carer_requests.handover_* track the in-flight nomination.
+--   • admin_nominate_handover: validates the nominee (active, verified, Stripe payouts
+--     ready — a post-handover charge would otherwise die in charge-booking) and books the
+--     3-way M&G on the same series with the nominee as provider. Lead → meet_greet_booked.
+--   • admin_complete_handover: after the 3-way meet, atomically marks the handover M&G
+--     completed, repoints the series (provider/service/locked_price_cents → nominee's
+--     listed rate) so future materialisation is automatic, reassigns future pending/
+--     confirmed walks at the new rate with history preserved, and moves the lead to
+--     transitioned. NOTE the deliberate deviation from the owner-driven M&G flow: the
+--     messages-page "mark complete" banner only renders for pending_meet_greet series,
+--     and a handover series is already active — the founder is physically at the 3-way
+--     meet, so completion is the founder's console action.
+--   • trg_meet_greet_gate now requires the completed M&G to match the series' CURRENT
+--     provider. Defensive: after handover a series carries a completed M&G from the old
+--     provider, and any future re-arm to pending_meet_greet must not be satisfied by it.
+--     Backward compatible — every M&G booking is created with the series' provider.
+--
+-- Both RPCs are EXECUTE-granted to service_role only (called from stripe-api behind its
+-- users.is_admin gate). SECURITY DEFINER runs as postgres, so the TRU-171 price-guard
+-- triggers pass.
+--
+-- Applied to the live DB via apply_migration (Supabase branching is broken on this repo);
+-- committed here for version control (see TRU-145). 14-digit unique prefix.
+
+alter table public.carer_requests
+  add column if not exists handover_provider_id   uuid references public.provider_profiles(id) on delete set null,
+  add column if not exists handover_service_id    uuid references public.provider_services(id) on delete set null,
+  add column if not exists handover_mg_booking_id uuid references public.bookings(id) on delete set null;
+
+-- ── provider-matched meet & greet gate ────────────────────────────────────────
+create or replace function public.trg_meet_greet_gate()
+returns trigger language plpgsql security definer set search_path to 'public' as $function$
+begin
+  if OLD.status = 'pending_meet_greet' and NEW.status = 'active' then
+    if not exists (
+      select 1 from public.bookings b
+      where b.series_id = NEW.id
+        and b.is_meet_and_greet = true
+        and b.status = 'completed'
+        and b.provider_id = NEW.provider_id  -- TRU-225: the M&G must be with the current carer
+    ) then
+      raise exception 'Cannot activate series % before its meet & greet is completed', NEW.id
+        using errcode = 'check_violation';
+    end if;
+  end if;
+  return NEW;
+end;
+$function$;
+
+revoke all on function public.trg_meet_greet_gate() from public, anon, authenticated;
+
+-- ── nominate: book the 3-way M&G with the incoming carer ─────────────────────
+create or replace function public.admin_nominate_handover(
+  p_request_id          uuid,
+  p_provider_profile_id uuid,
+  p_service_id          uuid,
+  p_mg_scheduled_at     timestamptz
+) returns uuid language plpgsql security definer set search_path = public as $$
+declare
+  rq  public.carer_requests%rowtype;
+  s   public.booking_series%rowtype;
+  pp  public.provider_profiles%rowtype;
+  svc public.provider_services%rowtype;
+  cur_type text;
+  v_mg_id  uuid;
+begin
+  select * into rq from public.carer_requests where id = p_request_id;
+  if not found then raise exception 'Lead % not found', p_request_id; end if;
+  if rq.status in ('transitioned', 'lost', 'closed') then
+    raise exception 'Lead % is already resolved (%)', p_request_id, rq.status;
+  end if;
+  if rq.assigned_series_id is null then
+    raise exception 'Lead % has no booking series to hand over', p_request_id;
+  end if;
+
+  select * into s from public.booking_series where id = rq.assigned_series_id;
+  if not found then raise exception 'Series % not found', rq.assigned_series_id; end if;
+  if s.status <> 'active' then
+    raise exception 'Series % is not active (%) — handover applies to a running series', s.id, s.status;
+  end if;
+
+  select * into pp from public.provider_profiles where id = p_provider_profile_id;
+  if not found then raise exception 'Carer profile % not found', p_provider_profile_id; end if;
+  if not pp.is_active or not pp.is_verified then
+    raise exception 'Nominee must be an active, verified carer';
+  end if;
+  -- Hard requirement: without a payouts-ready connected account, the first post-handover
+  -- completion charge fails in charge-booking.
+  if pp.stripe_account_id is null or not coalesce(pp.payouts_enabled, false) then
+    raise exception 'Nominee has no payouts-ready Stripe account yet';
+  end if;
+
+  select * into svc from public.provider_services where id = p_service_id;
+  if not found then raise exception 'Service % not found', p_service_id; end if;
+  if svc.provider_id <> pp.user_id then
+    raise exception 'Service % does not belong to the nominee', p_service_id;
+  end if;
+  if not svc.is_available or svc.price_cents is null then
+    raise exception 'Nominee service is unavailable or has no price';
+  end if;
+  select ps.service_type into cur_type from public.provider_services ps where ps.id = s.service_id;
+  if cur_type is not null and svc.service_type <> cur_type then
+    raise exception 'Nominee service type (%) does not match the series (%)', svc.service_type, cur_type;
+  end if;
+
+  -- The 3-way M&G: same series, incoming carer as provider. Seeds the owner↔carer
+  -- conversation and, once completed, satisfies the provider-matched gate for the pair.
+  insert into public.bookings (
+    customer_id, provider_id, pet_id, service_id, status,
+    scheduled_at, duration_mins, total_cents, is_meet_and_greet, series_id
+  ) values (
+    s.customer_id, pp.id,
+    (select sp.pet_id from public.series_pets sp where sp.series_id = s.id limit 1),
+    p_service_id, 'confirmed', p_mg_scheduled_at, 30, 0, true, s.id
+  ) returning id into v_mg_id;
+
+  insert into public.booking_pets (booking_id, pet_id)
+  select v_mg_id, sp.pet_id from public.series_pets sp where sp.series_id = s.id;
+
+  update public.carer_requests set
+    handover_provider_id   = pp.id,
+    handover_service_id    = p_service_id,
+    handover_mg_booking_id = v_mg_id,
+    status                 = 'meet_greet_booked'
+  where id = p_request_id;
+
+  return v_mg_id;
+end; $$;
+
+revoke all on function public.admin_nominate_handover(uuid, uuid, uuid, timestamptz) from public, anon, authenticated;
+grant execute on function public.admin_nominate_handover(uuid, uuid, uuid, timestamptz) to service_role;
+
+-- ── complete: transition the series to the nominee at their listed rate ───────
+create or replace function public.admin_complete_handover(
+  p_request_id  uuid,
+  p_resolved_by uuid
+) returns integer language plpgsql security definer set search_path = public as $$
+declare
+  rq        public.carer_requests%rowtype;
+  s         public.booking_series%rowtype;
+  svc       public.provider_services%rowtype;
+  mg_status text;
+  v_pets    int;
+  v_price   int;
+  v_moved   int;
+begin
+  select * into rq from public.carer_requests where id = p_request_id;
+  if not found then raise exception 'Lead % not found', p_request_id; end if;
+  if rq.status in ('transitioned', 'lost', 'closed') then
+    raise exception 'Lead % is already resolved (%)', p_request_id, rq.status;
+  end if;
+  if rq.handover_provider_id is null or rq.handover_service_id is null or rq.handover_mg_booking_id is null then
+    raise exception 'Lead % has no nominated handover', p_request_id;
+  end if;
+
+  select status into mg_status from public.bookings where id = rq.handover_mg_booking_id;
+  if mg_status = 'cancelled' then
+    raise exception 'The 3-way meet & greet was cancelled — nominate again';
+  end if;
+  -- The founder is at the 3-way meet; completing the handover completes the M&G
+  -- (the owner-side banner only renders for pending_meet_greet series).
+  if mg_status <> 'completed' then
+    update public.bookings
+       set status = 'completed', completed_at = now(), updated_at = now()
+     where id = rq.handover_mg_booking_id;
+  end if;
+
+  select * into s from public.booking_series where id = rq.assigned_series_id;
+  if not found then raise exception 'Series % not found', rq.assigned_series_id; end if;
+
+  select * into svc from public.provider_services where id = rq.handover_service_id;
+  if not found or svc.price_cents is null then
+    raise exception 'Nominee service is missing or unpriced';
+  end if;
+  select count(*) into v_pets from public.series_pets where series_id = s.id;
+  v_price := svc.price_cents + greatest(0, v_pets - 1) * coalesce(svc.additional_pet_price_cents, 0);
+
+  -- Repoint the series: future materialisation (generate_series_bookings copies
+  -- provider_id + locked_price_cents) is automatically at the new carer's rate.
+  update public.booking_series set
+    provider_id        = rq.handover_provider_id,
+    service_id         = rq.handover_service_id,
+    locked_price_cents = v_price
+  where id = s.id;
+
+  -- Reassign future, not-yet-walked bookings at the new rate. Completed founder walks
+  -- keep provider/price history untouched (TRU-139 pattern via original_provider_id).
+  update public.bookings b set
+    original_provider_id = coalesce(b.original_provider_id, b.provider_id),
+    provider_id          = rq.handover_provider_id,
+    service_id           = rq.handover_service_id,
+    total_cents          = v_price,
+    duration_mins        = coalesce(svc.duration_mins, b.duration_mins),
+    updated_at           = now()
+  where b.series_id = s.id
+    and not coalesce(b.is_meet_and_greet, false)
+    and b.scheduled_at > now()
+    and b.status in ('pending', 'confirmed');
+  get diagnostics v_moved = row_count;
+
+  update public.carer_requests set
+    status               = 'transitioned',
+    assigned_provider_id = rq.handover_provider_id,
+    resolved_at          = now(),
+    resolved_by          = p_resolved_by
+  where id = p_request_id;
+
+  return v_moved;
+end; $$;
+
+revoke all on function public.admin_complete_handover(uuid, uuid) from public, anon, authenticated;
+grant execute on function public.admin_complete_handover(uuid, uuid) to service_role;


### PR DESCRIPTION
Final PR of the TRU-216 epic. **Stacked**: merge order #105 → #106 → #107 → this.

## What changed

**Migration `20260717000001_tru225_handover.sql`** (applied live)
- `carer_requests.handover_provider_id` / `handover_service_id` / `handover_mg_booking_id`.
- **Gate amendment**: `trg_meet_greet_gate` now requires the completed M&G to match the series' *current* provider — after handover a series carries the old provider's completed M&G, and a future re-arm must not be satisfied by it. Backward compatible (M&G bookings are always created with the series' provider); exercised in the rehearsal below.
- `admin_nominate_handover` (service_role-only): validates the nominee — active, verified, **payouts-ready Stripe account hard-required** (else the first post-handover completion charge dies in `charge-booking`), priced service matching the series' type — then books the 3-way M&G on the same series with the nominee as provider and parks the lead at `meet_greet_booked`.
- `admin_complete_handover` (service_role-only, atomic): marks the 3-way M&G completed, repoints the series (`provider_id`/`service_id`/`locked_price_cents` → nominee's listed rate — future materialisation via `generate_series_bookings` is then automatic), reassigns future `pending`/`confirmed` walks at the new rate with `original_provider_id` preserving the founder (TRU-139 pattern; completed walks untouched), lead → `transitioned`.

**`stripe-api`** (deployed v14): `handover_nominate` / `handover_complete` wrappers + candid owner system-messages that quote the nominee's **listed rate** up front (GTM: the number lands inside an expectation set on day one, confirmed face to face). `requests_list` surfaces the 3-way M&G status/time.

**`admin/index.html`**: when a lead has a live series, "Find carers" candidates become **Nominate · rate** buttons (M&G time from the existing date field); the card then shows the 3-way M&G state and **Complete handover**.

## Deliberate deviation from the ticket
"3-way M&G scheduled through the existing M&G flow" — the booking is a normal flagged M&G on the series, but **completion is the founder's console action**, not the owner's: the owner-side "mark complete" banner only renders for `pending_meet_greet` series, and a handover series is already `active`. Since the founder is physically at the 3-way meet, `handover_complete` marks the M&G done as part of the transition. No second card capture is needed (card already on file from the founder-series proceed) — and the completed nominee M&G means `hasCompletedMeetGreet()` passes for the (owner, new carer) pair, so direct rebooking works.

## Verified (live rehearsal, then cleaned up)
- Founder series activated through the **amended provider-matched gate**; 10 future walks materialised (+1 past completed founder walk planted).
- Non-payouts nominee **rejected** with the payouts-ready error.
- Nominate: 3-way M&G created with nominee as provider; lead `meet_greet_booked` with all `handover_*` set.
- Complete: series → nominee/`4000¢` (their 60-min listed rate); **all 10 future walks** moved (provider, service, price, duration) with `original_provider_id` = founder; past `3000¢` completed walk untouched; both M&Gs completed; lead `transitioned` + resolved stamps.
- `deno check` + inline-JS `node --check` pass.

Post-handover completion charges use the normal destination-charge path (nominee is payouts-ready by construction) — covered by the existing TRU-146 machinery.

Linear: TRU-225 (parent TRU-216 — this completes the epic's build scope; TRU-223 copy is Tom's).

🤖 Generated with [Claude Code](https://claude.com/claude-code)