### PR TITLE
TRU-226: "Can't see an option that suits you?" capture CTA at the bottom of search results

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -278,6 +278,11 @@ function requestCard(rq) {
   const acct = rq.can_assign ? '<span class="badge b-paid">assignable</span>'
     : rq.customer_id ? '<span class="badge b-refunded">no pet</span>'
     : '<span class="badge b-refunded">guest</span>';
+  // TRU-226: fit-gap leads (saw carers, none suited) get a loud badge — this is a supply
+  // QUALITY signal, not a coverage gap.
+  const trigBadge = rq.capture_trigger === 'browsed_unhappy'
+    ? `<span class="badge b-failed">saw ${rq.results_seen ?? '?'} carers</span>`
+    : rq.capture_trigger === 'filtered_out' ? '<span class="badge b-refunded">filtered out</span>' : '';
   const dtVal = rq.wanted_date ? (rq.wanted_date + 'T' + (rq.window_start || '09:00')) : '';
   const assignUi = rq.can_assign ? `
     <div class="actions">
@@ -321,7 +326,7 @@ function requestCard(rq) {
   const seriesNote = rq.assigned_series_id && !rq.handover_mg_booking_id
     ? `<div class="meta"><b>Series live</b> — M&G booked; owner proceeds in their profile (card capture) to activate.</div>` : '';
   return `<div class="card" id="reqcard-${rq.id}">
-    <div class="row-top"><div><b>${esc(svcLabel(rq.service_type))}</b> in ${esc(rq.suburb || '—')} ${acct} ${clockBadge(rq)}</div><div class="meta">${when(rq.created_at)}</div></div>
+    <div class="row-top"><div><b>${esc(svcLabel(rq.service_type))}</b> in ${esc(rq.suburb || '—')} ${acct} ${trigBadge} ${clockBadge(rq)}</div><div class="meta">${when(rq.created_at)}</div></div>
     <div class="meta"><b>${esc(rq.contact)}</b>${rq.contact_phone ? ` · <a href="tel:${esc(rq.contact_phone)}">${esc(rq.contact_phone)}</a>` : ' · ⚠ no phone'}${rq.email ? ' · ' + esc(rq.email) : ''}</div>
     <div class="meta">${dogBits ? esc(dogBits) : 'Dog: —'}${rq.pet ? ' · pet on file: ' + esc(rq.pet) : ''}</div>
     ${rq.dog_temperament_note ? `<div class="meta">Temperament: “${esc(rq.dog_temperament_note)}”</div>` : ''}

--- a/search/index.html
+++ b/search/index.html
@@ -1170,8 +1170,12 @@ const CAPTURE_FREQUENCIES = [
 ];
 const CAPTURE_TIMES = [['morning', 'Morning'], ['midday', 'Midday'], ['afternoon', 'Afternoon'], ['evening', 'Evening']];
 const capTimes = new Set(); // preferred-times chip selection (survives re-renders)
+// TRU-226: which surface produced the lead. no_carers = true area-zero, filtered_out =
+// carers exist but the filters excluded them, browsed_unhappy = saw the list, none suited.
+let captureTrigger = 'no_carers';
 
-function captureStateHtml(areaZero) {
+function captureStateHtml(trigger) {
+  captureTrigger = trigger;
   if (requestSubmitted) {
     return `<div class="request-box request-done fade-in">
       <h3>We're on it 🐾</h3>
@@ -1180,7 +1184,9 @@ function captureStateHtml(areaZero) {
       <p>We've also emailed you a rundown of what happens next.</p>
     </div>`;
   }
-  const heading = (areaZero && state.suburb) ? `We're new to ${esc(state.suburb)}` : 'Let us find your walker';
+  const heading = (trigger === 'no_carers' && state.suburb) ? `We're new to ${esc(state.suburb)}`
+    : trigger === 'browsed_unhappy' ? "Let's find the right fit"
+    : 'Let us find your walker';
   const bandLine = CAPTURE_PRICE_BAND
     ? `<div class="cap-band">Most ${state.suburb ? esc(state.suburb) + ' ' : ''}walks are $${CAPTURE_PRICE_BAND.min}–$${CAPTURE_PRICE_BAND.max}. Your walker sets their own rate — we'll help you land inside it.</div>`
     : '';
@@ -1196,7 +1202,19 @@ function captureStateHtml(areaZero) {
       ${bandLine}
       ${captureFormHtml()}
     </div>
-    <div class="cap-alt"><button class="btn-secondary" id="btnEmptyClear">Clear filters instead</button></div>`;
+    ${trigger === 'browsed_unhappy' ? '' : '<div class="cap-alt"><button class="btn-secondary" id="btnEmptyClear">Clear filters instead</button></div>'}`;
+}
+
+// TRU-226: collapsed CTA under a non-empty results list — the "scrolled to the bottom and
+// still not convinced" lead. Same process as the zero-result capture, different flag.
+function browseCaptureHtml() {
+  if (requestSubmitted) return captureStateHtml('browsed_unhappy'); // thank-you card
+  return `
+    <div class="request-box fade-in" style="margin-top:1.5rem;">
+      <h3>Can't see an option that suits you?</h3>
+      <p>Tell us what you're after and we'll match you with a vetted walker — someone we know, or someone new we go and vet.</p>
+      <button class="btn-primary" id="btnBrowseCapture" type="button">Let us find your walker →</button>
+    </div>`;
 }
 
 function captureFormHtml() {
@@ -1291,6 +1309,8 @@ async function submitCarerRequest(e) {
     p_dog_temperament: val('reqTemperament') || null,
     p_frequency: val('reqFrequency') || null,
     p_preferred_times: Array.from(capTimes),
+    p_trigger: captureTrigger,
+    p_results_seen: providers.length, // server-side count, pre client filters (TRU-226)
   };
   try {
     const r = await sbRpc('submit_carer_request', body);
@@ -1322,7 +1342,7 @@ function renderResults(list) {
     // tweak-your-search empty state with the capture form one click away.
     const areaZero = providers.length === 0 && !!state.suburb;
     if (areaZero || requestSubmitted) {
-      area.innerHTML = captureStateHtml(true);
+      area.innerHTML = captureStateHtml('no_carers');
       wireCaptureState();
       return;
     }
@@ -1337,7 +1357,7 @@ function renderResults(list) {
     `;
     document.getElementById('btnEmptyClear').addEventListener('click', clearFilters);
     document.getElementById('btnShowCapture').addEventListener('click', () => {
-      area.innerHTML = captureStateHtml(false);
+      area.innerHTML = captureStateHtml('filtered_out');
       wireCaptureState();
     });
     return;
@@ -1346,13 +1366,22 @@ function renderResults(list) {
   const cap = 20;
   const visible = list.slice(0, cap);
   const more = list.length > cap;
-  area.innerHTML = `<div class="provider-list">${visible.map(renderCard).join('')}</div>${more ? `<div style="text-align:center;margin-top:1.5rem;"><button class="btn-secondary" id="btnLoadMore">Load more</button></div>` : ''}`;
+  // TRU-226: #browseCapture sits OUTSIDE .provider-list so Load more's insertAdjacentHTML
+  // never disturbs it, and the CTA stays at the true bottom of the page.
+  area.innerHTML = `<div class="provider-list">${visible.map(renderCard).join('')}</div>${more ? `<div style="text-align:center;margin-top:1.5rem;"><button class="btn-secondary" id="btnLoadMore">Load more</button></div>` : ''}<div id="browseCapture">${browseCaptureHtml()}</div>`;
   if (more) {
     document.getElementById('btnLoadMore').addEventListener('click', () => {
       area.querySelector('.provider-list').insertAdjacentHTML('beforeend', list.slice(cap).map(renderCard).join(''));
       document.getElementById('btnLoadMore').remove();
     });
   }
+  const bc = document.getElementById('btnBrowseCapture');
+  if (bc) bc.addEventListener('click', () => {
+    const box = document.getElementById('browseCapture');
+    box.innerHTML = captureStateHtml('browsed_unhappy');
+    wireCaptureState();
+    box.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  });
 
   const ctxClear = document.getElementById('btnClearAll');
   if (ctxClear) ctxClear.addEventListener('click', clearFilters);

--- a/supabase/functions/send-notification/index.ts
+++ b/supabase/functions/send-notification/index.ts
@@ -279,8 +279,16 @@ async function buildMessages(type: string, payload: Record<string, unknown>) {
       ? (rq.preferred_times as string[]).map((t) => t.charAt(0).toUpperCase() + t.slice(1)).join(', ')
       : '—';
 
+    // TRU-226: why this lead exists — supply gap vs fit gap. Call-prep gold either way.
+    const whyStr = rq.capture_trigger === 'browsed_unhappy'
+      ? `Saw ${rq.results_seen ?? '?'} carer${rq.results_seen === 1 ? '' : 's'} — none suited`
+      : rq.capture_trigger === 'filtered_out'
+        ? 'Carers exist, but their filters excluded them all'
+        : 'No carers in their area';
+
     const rows: [string, string][] = [
       ['Phone', rq.contact_phone || '⚠ missing'],
+      ['Why', whyStr],
       ['Suburb', rq.suburb || '—'],
       ['Service', serviceLabel],
       ['How often', rq.frequency ? (FREQUENCY_LABELS[rq.frequency] || rq.frequency) : (rq.recurring ? 'Recurring' : 'One-off')],

--- a/supabase/migrations/20260718000000_tru226_browse_capture.sql
+++ b/supabase/migrations/20260718000000_tru226_browse_capture.sql
@@ -1,0 +1,129 @@
+-- TRU-226: capture leads from the BOTTOM of a non-empty results list, flagged by source.
+--
+-- The TRU-216 capture flow only triggered on zero-result searches. An owner who scrolls a
+-- full list and thinks "still not it" is an equally valuable lead — but the flag matters:
+-- that lead exists DESPITE available carers (a fit/quality gap), not because of a supply
+-- gap. So:
+--   • carer_requests.capture_trigger records the source (named capture_trigger, not
+--     "trigger" — TRIGGER is a SQL keyword and unquoted use invites tooling papercuts):
+--       no_carers       — true area-zero (default; also all pre-existing rows)
+--       filtered_out    — carers exist but the owner's filters excluded them all
+--       browsed_unhappy — saw the list, clicked "Can't see an option that suits you?"
+--   • carer_requests.results_seen — how many carers the search returned (server-side
+--     count, pre client filters). Per-suburb supply-QUALITY signal for recruitment.
+--   • submit_carer_request replaced (dropped + recreated, never overloaded — PostgREST
+--     named-arg dispatch 300s on ambiguous overloads) with p_trigger + p_results_seen,
+--     both defaulted so the cached live page keeps working between migration and deploy.
+--
+-- Applied to the live DB via apply_migration (Supabase branching is broken on this repo);
+-- committed here for version control (see TRU-145). 14-digit unique prefix.
+
+alter table public.carer_requests
+  add column if not exists capture_trigger text not null default 'no_carers'
+    check (capture_trigger in ('no_carers','filtered_out','browsed_unhappy')),
+  add column if not exists results_seen int;
+
+drop function if exists public.submit_carer_request(text,text,date,boolean,text,text,text,boolean,uuid,text,text,text,jsonb,text,text,text,text,text,text[]);
+
+create function public.submit_carer_request(
+  p_suburb          text    default null,
+  p_service_type    text    default null,
+  p_wanted_date     date    default null,
+  p_recurring       boolean default false,
+  p_window_start    text    default null,
+  p_window_end      text    default null,
+  p_dog_size        text    default null,
+  p_puppy           boolean default false,
+  p_pet_id          uuid    default null,
+  p_contact_name    text    default null,
+  p_contact_email   text    default null,
+  p_note            text    default null,
+  p_search_params   jsonb   default null,
+  p_contact_phone   text    default null,
+  p_dog_name        text    default null,
+  p_dog_breed       text    default null,
+  p_dog_temperament text    default null,
+  p_frequency       text    default null,
+  p_preferred_times text[]  default null,
+  p_trigger         text    default 'no_carers',
+  p_results_seen    int     default null
+) returns uuid
+language plpgsql security definer set search_path = public as $$
+declare
+  v_customer_id uuid;
+  v_pet_id      uuid := null;
+  v_phone       text;
+  v_frequency   text;
+  v_trigger     text;
+  v_times       text[];
+  v_id          uuid;
+begin
+  select cp.id into v_customer_id
+  from public.customer_profiles cp
+  where cp.user_id = auth.uid();
+
+  -- The founder call is the product: every lead needs a phone number.
+  v_phone := nullif(trim(coalesce(p_contact_phone, '')), '');
+  if v_phone is null then
+    raise exception 'contact_phone is required';
+  end if;
+
+  -- Guests must also leave an email (confirmation email + account invite).
+  if v_customer_id is null and coalesce(trim(p_contact_email), '') = '' then
+    raise exception 'contact_email is required for guest requests';
+  end if;
+
+  -- Only accept a pet_id that actually belongs to the caller (defends the assign path).
+  if p_pet_id is not null and v_customer_id is not null then
+    select pt.id into v_pet_id
+    from public.pets pt
+    where pt.id = p_pet_id and pt.customer_id = v_customer_id;
+  end if;
+
+  -- Whitelist enumerated inputs rather than trusting the client.
+  v_frequency := nullif(trim(coalesce(p_frequency, '')), '');
+  if v_frequency is not null
+     and v_frequency not in ('one_off','weekly','few_per_week','daily') then
+    raise exception 'invalid frequency %', v_frequency;
+  end if;
+  v_trigger := coalesce(nullif(trim(coalesce(p_trigger, '')), ''), 'no_carers');
+  if v_trigger not in ('no_carers','filtered_out','browsed_unhappy') then
+    raise exception 'invalid trigger %', v_trigger;
+  end if;
+  v_times := (
+    select coalesce(array_agg(t), '{}')
+    from unnest(coalesce(p_preferred_times, '{}')) as t
+    where t in ('morning','midday','afternoon','evening')
+  );
+
+  insert into public.carer_requests (
+    customer_id, pet_id, contact_name, contact_email, contact_phone, suburb, service_type,
+    wanted_date, recurring, window_start, window_end, dog_size, puppy,
+    dog_name, dog_breed, dog_temperament_note, frequency, preferred_times,
+    capture_trigger, results_seen, note, search_params
+  ) values (
+    v_customer_id, v_pet_id,
+    nullif(trim(coalesce(p_contact_name, '')), ''),
+    nullif(trim(coalesce(p_contact_email, '')), ''),
+    v_phone,
+    nullif(trim(coalesce(p_suburb, '')), ''),
+    nullif(trim(coalesce(p_service_type, '')), ''),
+    p_wanted_date, coalesce(p_recurring, false),
+    nullif(trim(coalesce(p_window_start, '')), ''),
+    nullif(trim(coalesce(p_window_end, '')), ''),
+    nullif(trim(coalesce(p_dog_size, '')), ''),
+    coalesce(p_puppy, false),
+    nullif(trim(coalesce(p_dog_name, '')), ''),
+    nullif(trim(coalesce(p_dog_breed, '')), ''),
+    nullif(trim(coalesce(p_dog_temperament, '')), ''),
+    v_frequency, v_times,
+    v_trigger, p_results_seen,
+    nullif(trim(coalesce(p_note, '')), ''),
+    p_search_params
+  ) returning id into v_id;
+
+  return v_id;
+end; $$;
+
+revoke all on function public.submit_carer_request(text,text,date,boolean,text,text,text,boolean,uuid,text,text,text,jsonb,text,text,text,text,text,text[],text,int) from public;
+grant execute on function public.submit_carer_request(text,text,date,boolean,text,text,text,boolean,uuid,text,text,text,jsonb,text,text,text,text,text,text[],text,int) to anon, authenticated;


### PR DESCRIPTION
Extends the TRU-216 capture flow to non-empty results. **Stacked**: merge order #105 → #106 → #107 → #108 → this.

## What changed

**Migration `20260718000000_tru226_browse_capture.sql`** (applied live)
- `carer_requests.capture_trigger` — why the lead exists: `no_carers` (area-zero; default + all pre-existing rows), `filtered_out` (carers exist, filters excluded them), `browsed_unhappy` (saw the list, none suited). Named `capture_trigger` rather than the ticket's implied `trigger` — TRIGGER is a SQL keyword.
- `carer_requests.results_seen` — how many carers the search returned (server-side, pre client filters). This is the per-suburb supply-**quality** signal.
- `submit_carer_request` replaced (drop + recreate, same no-overload rule) with `p_trigger` (whitelisted server-side) + `p_results_seen`, both defaulted so the cached live page keeps working between migration and site deploy.

**`search/index.html`**
- Collapsed box under every non-empty results list: **"Can't see an option that suits you?"** → button expands the existing capture form in place (heading "Let's find the right fit") and scrolls to it. Sits outside `.provider-list` so Load more can't disturb it.
- Every capture surface now stamps its trigger; submit sends `p_trigger` + `p_results_seen`. No `log_search_miss` on the browse path — it isn't a zero-result miss; the submission itself is the signal.
- After submit the results list stays visible with the thank-you card in the bottom slot.

**`send-notification`** (deployed v11): founder alert gains a **Why** row — "Saw 4 carers — none suited" is the call-prep opener for these leads (ask what was missing).

**`admin/index.html`**: `browsed_unhappy` leads get a red **"saw N carers"** badge (fit problem, not coverage gap); `filtered_out` a grey badge.

## Verified (live)
- Whitelist rejects invalid triggers; single RPC overload confirmed.
- Guest RPC smoke + a real UI submit (local static server → live Supabase, Newington's 4-carer list) both stored `browsed_unhappy` / `results_seen: 4` / chip selection; edge fn v11 returned 200 (admin alert with Why row + lead confirmation sent).
- Zero-result regression: Katoomba still renders "We're new to Katoomba" with trigger `no_carers` and no browse box.
- Inline-JS `node --check` (both pages) + `deno check` pass. Test rows cleaned up (one pre-existing "Joe Bloggs" lead from Tom's own testing left untouched).

Linear: TRU-226 (parent TRU-216).

🤖 Generated with [Claude Code](https://claude.com/claude-code)