### PR TITLE
Land the stranded TRU-216 stack on main (#106–#109 content)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -309,7 +309,16 @@ function requestCard(rq) {
       ${['Mon','Tue','Wed','Thu','Fri','Sat','Sun'].map((d, i) => `<button type="button" class="btn" data-d="${i + 1}" onclick="fDayToggle('${rq.id}', this)" style="background:#fff;color:var(--terracottaDark);">${d}</button>`).join('')}
       <button class="btn" onclick="founderBook('${rq.id}','${esc(rq.service_type || 'dog_walking')}','${rq.pet_id || ''}')">Book me as stop-gap</button>
     </div>` : '';
-  const seriesNote = rq.assigned_series_id
+  // TRU-225: handover state on the card. Once nominated, "Complete handover" runs the
+  // transition (marks the 3-way M&G complete, repoints the series + future walks at the
+  // nominee's rate, lead → transitioned).
+  const handoverUi = rq.handover_mg_booking_id
+    ? `<div class="meta"><b>Handover nominated</b> — 3-way M&G ${esc(rq.handover_mg_status || 'confirmed')}${rq.handover_mg_at ? ' · ' + when(rq.handover_mg_at) : ''}</div>
+       <div class="actions"><button class="btn" onclick="handoverComplete('${rq.id}')">Complete handover</button></div>`
+    : (rq.assigned_series_id
+        ? `<div class="meta">Sourcing the permanent walker? "Find carers" → nominate for handover (needs their payouts set up).</div>`
+        : '');
+  const seriesNote = rq.assigned_series_id && !rq.handover_mg_booking_id
     ? `<div class="meta"><b>Series live</b> — M&G booked; owner proceeds in their profile (card capture) to activate.</div>` : '';
   return `<div class="card" id="reqcard-${rq.id}">
     <div class="row-top"><div><b>${esc(svcLabel(rq.service_type))}</b> in ${esc(rq.suburb || '—')} ${acct} ${clockBadge(rq)}</div><div class="meta">${when(rq.created_at)}</div></div>
@@ -320,6 +329,7 @@ function requestCard(rq) {
     ${rq.note ? `<div class="meta">“${esc(rq.note)}”</div>` : ''}
     ${linkUi}
     ${seriesNote}
+    ${handoverUi}
     ${assignUi}
     ${founderUi}
     <div class="actions">
@@ -329,6 +339,8 @@ function requestCard(rq) {
     </div>
   </div>`;
 }
+// TRU-224/225: per-lead context the candidate cards need (filled by renderRequests).
+const leadInfo = {};
 // TRU-224: founder stop-gap booking helpers.
 const founderDays = {}; // per-lead selected isodow set (Mon=1 … Sun=7)
 function fDayToggle(id, btn) {
@@ -375,7 +387,10 @@ async function renderRequests(c) {
     const { requests, signal } = await sbFn('stripe-api', { action:'requests_list' });
     // Group the board by pipeline stage so the founder-walking clock is impossible to miss.
     const byStatus = {};
-    (requests || []).forEach(r => { (byStatus[r.status] ||= []).push(r); });
+    (requests || []).forEach(r => {
+      leadInfo[r.id] = { hasSeries: !!r.assigned_series_id };
+      (byStatus[r.status] ||= []).push(r);
+    });
     const reqHtml = (requests && requests.length)
       ? LEAD_STATUSES.filter(([v]) => byStatus[v] && byStatus[v].length)
           .map(([v, l]) => `<h1 style="font-size:1.05rem;margin:18px 0 6px;">${l} <span class="meta">(${byStatus[v].length})</span></h1>` + byStatus[v].map(requestCard).join(''))
@@ -399,14 +414,41 @@ async function renderRequests(c) {
 function carerCandidate(reqId, cr) {
   const dist = (cr.distance_km != null) ? cr.distance_km + ' km' : '';
   const rating = cr.avg_rating ? '★' + (+cr.avg_rating).toFixed(1) : 'new';
+  // TRU-225: when the lead already has a live (founder) series, candidates are handover
+  // nominees rather than direct assignments.
+  const handoverMode = !!(leadInfo[reqId] && leadInfo[reqId].hasSeries);
   const svcBtns = (cr.services || []).map(s => {
     const label = svcLabel(s.service_type) + (s.price_cents != null ? ' ' + money(s.price_cents) : '') + (s.duration_mins ? ' / ' + s.duration_mins + 'm' : '');
-    return `<button class="btn" onclick="reqAssign('${reqId}','${cr.provider_id}','${s.id}')">Assign · ${esc(label)}</button>`;
+    return handoverMode
+      ? `<button class="btn" onclick="handoverNominate('${reqId}','${cr.provider_id}','${s.id}')">Nominate · ${esc(label)}</button>`
+      : `<button class="btn" onclick="reqAssign('${reqId}','${cr.provider_id}','${s.id}')">Assign · ${esc(label)}</button>`;
   }).join(' ');
   return `<div class="card" style="margin:8px 0 0;background:var(--cream);">
     <div class="row-top"><div><b>${esc(cr.name)}</b>${cr.is_verified ? ' <span class="badge b-paid">verified</span>' : ''}</div><div class="meta">${esc(cr.suburb || '')}${dist ? ' · ' + dist : ''} · ${rating}</div></div>
     <div class="actions">${svcBtns || '<span class="meta">No matching service</span>'}</div>
   </div>`;
+}
+async function handoverNominate(reqId, providerId, serviceId) {
+  const dtEl = document.getElementById('reqdt-' + reqId);
+  const dt = dtEl && dtEl.value ? dtEl.value : '';
+  if (!dt) { admMsg('Set the 3-way meet & greet date/time first (the Start field).', 'error'); return; }
+  if (!confirm('Nominate this carer for handover? It books the 3-way meet & greet (you + owner + carer) and messages the owner with their rate.')) return;
+  admMsg('');
+  try {
+    const iso = new Date(dt).toISOString();
+    await sbFn('stripe-api', { action:'handover_nominate', request_id:reqId, provider_id:providerId, service_id:serviceId, mg_scheduled_at:iso });
+    admMsg('Handover nominated ✓ — 3-way meet & greet booked and owner introduced.', 'ok');
+    renderRequests(document.getElementById('adm-content'));
+  } catch (e) { admMsg(e.message, 'error'); }
+}
+async function handoverComplete(reqId) {
+  if (!confirm('Complete the handover? Future walks move to the new carer at THEIR listed rate; completed founder walks keep their history. This also marks the 3-way meet & greet done.')) return;
+  admMsg('');
+  try {
+    const r = await sbFn('stripe-api', { action:'handover_complete', request_id:reqId });
+    admMsg(`Handover complete ✓ — ${r.reassigned ?? 0} future walk(s) moved to the new carer. Lead transitioned.`, 'ok');
+    renderRequests(document.getElementById('adm-content'));
+  } catch (e) { admMsg(e.message, 'error'); }
 }
 async function reqFindCarers(id) {
   const box = document.getElementById('reqcarers-' + id);

--- a/admin/index.html
+++ b/admin/index.html
@@ -288,6 +288,29 @@ function requestCard(rq) {
     <div id="reqcarers-${rq.id}"></div>` : '';
   const statusOpts = LEAD_STATUSES.concat(LEAD_TERMINAL)
     .map(([v, l]) => `<option value="${v}"${rq.status === v ? ' selected' : ''}>${l}</option>`).join('');
+  // TRU-224: conversion controls. Guest leads get a one-click account link once the owner
+  // registers; linked leads get the founder stop-gap booking form (rate + schedule → M&G
+  // series via admin_create_lead_series). Real-carer assignment stays via "Find carers".
+  const linkUi = !rq.customer_id
+    ? (rq.account_exists
+        ? `<div class="actions"><button class="btn" onclick="reqLinkCustomer('${rq.id}')">Link account (${esc(rq.email)})</button></div>`
+        : `<div class="meta">No account yet — they register via the confirmation email, then a link button appears here.</div>`)
+    : '';
+  const founderUi = rq.customer_id && !rq.assigned_series_id ? `
+    <div class="meta" style="margin-top:8px;"><b>Founder stop-gap</b> — books you as the walker at an interim rate; free M&G first, card captured at proceed.</div>
+    <div class="actions" style="flex-wrap:wrap;">
+      <input class="reason" id="fRate-${rq.id}" type="number" min="1" step="1" placeholder="$/walk" style="flex:0 1 90px;min-width:0;">
+      <select class="reason" id="fDur-${rq.id}" style="flex:0 1 auto;"><option value="30">30 min</option><option value="60">60 min</option></select>
+      <input class="reason" id="fMg-${rq.id}" type="datetime-local" title="Meet & greet time" style="flex:0 1 auto;min-width:0;">
+      <input class="reason" id="fStart-${rq.id}" type="date" title="First walk date" style="flex:0 1 auto;min-width:0;">
+      <input class="reason" id="fTime-${rq.id}" type="time" value="09:00" title="Walk time" style="flex:0 1 auto;min-width:0;">
+    </div>
+    <div class="actions" style="flex-wrap:wrap;">
+      ${['Mon','Tue','Wed','Thu','Fri','Sat','Sun'].map((d, i) => `<button type="button" class="btn" data-d="${i + 1}" onclick="fDayToggle('${rq.id}', this)" style="background:#fff;color:var(--terracottaDark);">${d}</button>`).join('')}
+      <button class="btn" onclick="founderBook('${rq.id}','${esc(rq.service_type || 'dog_walking')}','${rq.pet_id || ''}')">Book me as stop-gap</button>
+    </div>` : '';
+  const seriesNote = rq.assigned_series_id
+    ? `<div class="meta"><b>Series live</b> — M&G booked; owner proceeds in their profile (card capture) to activate.</div>` : '';
   return `<div class="card" id="reqcard-${rq.id}">
     <div class="row-top"><div><b>${esc(svcLabel(rq.service_type))}</b> in ${esc(rq.suburb || '—')} ${acct} ${clockBadge(rq)}</div><div class="meta">${when(rq.created_at)}</div></div>
     <div class="meta"><b>${esc(rq.contact)}</b>${rq.contact_phone ? ` · <a href="tel:${esc(rq.contact_phone)}">${esc(rq.contact_phone)}</a>` : ' · ⚠ no phone'}${rq.email ? ' · ' + esc(rq.email) : ''}</div>
@@ -295,13 +318,53 @@ function requestCard(rq) {
     ${rq.dog_temperament_note ? `<div class="meta">Temperament: “${esc(rq.dog_temperament_note)}”</div>` : ''}
     <div class="meta">${esc(reqWhen(rq))}</div>
     ${rq.note ? `<div class="meta">“${esc(rq.note)}”</div>` : ''}
+    ${linkUi}
+    ${seriesNote}
     ${assignUi}
+    ${founderUi}
     <div class="actions">
       <select class="reason" id="reqstatus-${rq.id}" style="flex:0 1 auto;">${statusOpts}</select>
       <input class="reason" id="reqnote-${rq.id}" placeholder="Admin note (optional)" value="${esc(rq.admin_note || '')}">
       <button class="btn" onclick="reqUpdate('${rq.id}')">Save</button>
     </div>
   </div>`;
+}
+// TRU-224: founder stop-gap booking helpers.
+const founderDays = {}; // per-lead selected isodow set (Mon=1 … Sun=7)
+function fDayToggle(id, btn) {
+  const set = (founderDays[id] ||= new Set());
+  const d = +btn.dataset.d;
+  if (set.has(d)) { set.delete(d); btn.style.background = '#fff'; btn.style.color = 'var(--terracottaDark)'; }
+  else { set.add(d); btn.style.background = 'var(--terracotta)'; btn.style.color = '#fff'; }
+}
+async function reqLinkCustomer(id) {
+  admMsg('');
+  try {
+    const r = await sbFn('stripe-api', { action:'request_link_customer', request_id:id });
+    admMsg('Account linked ✓' + ((r.pets && r.pets.length) ? '' : ' — owner has no pets yet; they must add one before booking.'), 'ok');
+    renderRequests(document.getElementById('adm-content'));
+  } catch (e) { admMsg(e.message, 'error'); }
+}
+async function founderBook(rqId, serviceType, petId) {
+  const val = s => (document.getElementById(s + '-' + rqId) || {}).value || '';
+  const rate = Math.round(parseFloat(val('fRate')) * 100);
+  const mg = val('fMg'), start = val('fStart'), time = val('fTime');
+  const days = Array.from(founderDays[rqId] || []);
+  if (!(rate > 0)) { admMsg('Set the stop-gap rate first.', 'error'); return; }
+  if (!mg || !start || !time) { admMsg('Set the meet & greet time, start date and walk time.', 'error'); return; }
+  if (!days.length) { admMsg('Pick at least one walk day.', 'error'); return; }
+  if (!confirm(`Book yourself as the stop-gap walker at $${(rate / 100).toFixed(0)}/walk? This creates the free meet & greet and the recurring series.`)) return;
+  admMsg('');
+  try {
+    const r = await sbFn('stripe-api', { action:'founder_service_ensure', service_type:serviceType, duration_mins:+val('fDur') || 30, price_cents:rate });
+    await sbFn('stripe-api', {
+      action:'request_create_series', request_id:rqId, service_id:r.service_id,
+      mg_scheduled_at:new Date(mg).toISOString(), start_date:start, time_of_day:time,
+      days_of_week:days, frequency_type:'specific_days', pet_id: petId || null,
+    });
+    admMsg('Stop-gap series created ✓ — meet & greet booked and owner notified.', 'ok');
+    renderRequests(document.getElementById('adm-content'));
+  } catch (e) { admMsg(e.message, 'error'); }
 }
 function signalRow(s) {
   return `<tr><td class="meta">${esc(s.week_start)}</td><td class="meta">${esc(s.suburb)}${s.postcode ? ' ' + esc(s.postcode) : ''}</td><td class="meta">${esc(svcLabel(s.service_type).toLowerCase())}</td><td class="meta" style="text-align:right;"><b>×${s.misses}</b></td></tr>`;

--- a/admin/index.html
+++ b/admin/index.html
@@ -245,19 +245,36 @@ async function creditRedeem(id) {
   } catch (e) { admMsg(e.message, 'error'); }
 }
 
-// ── Requests section (TRU-121: "can't find a carer") ──
+// ── Requests section (TRU-121 capture leads · TRU-221 pipeline view) ──
 const SVC_LABELS = { dog_walking:'Dog walking', dog_sitting:'Dog sitting', dog_boarding:'Dog boarding', dog_daycare:'Dog daycare', drop_in:'Drop-in visit', pet_sitting:'Pet sitting' };
 function svcLabel(t) { return t ? (SVC_LABELS[t] || t) : 'Any service'; }
+// Pipeline order drives the board grouping; terminal statuses only appear in the select.
+const LEAD_STATUSES = [
+  ['captured', 'Captured'], ['called', 'Called'], ['founder_walking', 'Founder walking'],
+  ['sourcing_walker', 'Sourcing walker'], ['meet_greet_booked', 'Meet & greet booked'],
+];
+const LEAD_TERMINAL = [['transitioned', 'Transitioned ✓'], ['lost', 'Lost'], ['closed', 'Closed']];
+const FREQ_LABELS = { one_off:'once', weekly:'weekly', few_per_week:'a few times a week', daily:'every weekday' };
 function reqWhen(rq) {
   const bits = [];
+  if (rq.frequency) bits.push(FREQ_LABELS[rq.frequency] || rq.frequency);
+  else if (rq.recurring) bits.push('recurring');
   if (rq.wanted_date) bits.push(rq.wanted_date);
-  else if (rq.recurring) bits.push('Recurring');
-  else bits.push('Flexible date');
   if (rq.window_start) bits.push(rq.window_start + (rq.window_end ? '–' + rq.window_end : ''));
-  return bits.join(' · ');
+  if (rq.preferred_times && rq.preferred_times.length) bits.push(rq.preferred_times.join('/'));
+  return bits.join(' · ') || 'Flexible';
+}
+// The 14-day sourcing clock (GTM two-week rule) — visible per lead, loud from day 10.
+function clockBadge(rq) {
+  const d = rq.days_in_status ?? 0;
+  if (rq.status === 'founder_walking') {
+    const cls = d >= 10 ? 'b-failed' : 'b-paid';
+    return `<span class="badge ${cls}">day ${d + 1} of 14</span>`;
+  }
+  return `<span class="badge b-refunded">${d === 0 ? 'today' : d + 'd in status'}</span>`;
 }
 function requestCard(rq) {
-  const dog = [rq.dog_size, rq.puppy ? 'puppy' : ''].filter(Boolean).join(' · ');
+  const dogBits = [rq.dog_name, rq.dog_breed, rq.dog_size, rq.puppy ? 'puppy' : ''].filter(Boolean).join(' · ');
   const acct = rq.can_assign ? '<span class="badge b-paid">assignable</span>'
     : rq.customer_id ? '<span class="badge b-refunded">no pet</span>'
     : '<span class="badge b-refunded">guest</span>';
@@ -269,35 +286,47 @@ function requestCard(rq) {
       <button class="btn" onclick="reqFindCarers('${rq.id}')">Find carers</button>
     </div>
     <div id="reqcarers-${rq.id}"></div>` : '';
+  const statusOpts = LEAD_STATUSES.concat(LEAD_TERMINAL)
+    .map(([v, l]) => `<option value="${v}"${rq.status === v ? ' selected' : ''}>${l}</option>`).join('');
   return `<div class="card" id="reqcard-${rq.id}">
-    <div class="row-top"><div><b>${esc(svcLabel(rq.service_type))}</b> in ${esc(rq.suburb || '—')} ${acct}</div><div class="meta">${when(rq.created_at)}</div></div>
-    <div class="meta">${esc(rq.contact)}${rq.email ? ' · ' + esc(rq.email) : ''}${rq.pet ? ' · pet: ' + esc(rq.pet) : ''}</div>
-    <div class="meta">${esc(reqWhen(rq))}${dog ? ' · ' + esc(dog) : ''}</div>
+    <div class="row-top"><div><b>${esc(svcLabel(rq.service_type))}</b> in ${esc(rq.suburb || '—')} ${acct} ${clockBadge(rq)}</div><div class="meta">${when(rq.created_at)}</div></div>
+    <div class="meta"><b>${esc(rq.contact)}</b>${rq.contact_phone ? ` · <a href="tel:${esc(rq.contact_phone)}">${esc(rq.contact_phone)}</a>` : ' · ⚠ no phone'}${rq.email ? ' · ' + esc(rq.email) : ''}</div>
+    <div class="meta">${dogBits ? esc(dogBits) : 'Dog: —'}${rq.pet ? ' · pet on file: ' + esc(rq.pet) : ''}</div>
+    ${rq.dog_temperament_note ? `<div class="meta">Temperament: “${esc(rq.dog_temperament_note)}”</div>` : ''}
+    <div class="meta">${esc(reqWhen(rq))}</div>
     ${rq.note ? `<div class="meta">“${esc(rq.note)}”</div>` : ''}
-    ${rq.status === 'onboarding' ? '<div class="meta"><b>Onboarding a new carer</b></div>' : ''}
     ${assignUi}
     <div class="actions">
+      <select class="reason" id="reqstatus-${rq.id}" style="flex:0 1 auto;">${statusOpts}</select>
       <input class="reason" id="reqnote-${rq.id}" placeholder="Admin note (optional)" value="${esc(rq.admin_note || '')}">
-      <button class="btn" style="background:#fff;color:var(--terracottaDark);" onclick="reqUpdate('${rq.id}','onboarding')">Onboarding</button>
-      <button class="btn" style="background:#fff;color:var(--terracottaDark);" onclick="reqUpdate('${rq.id}','closed')">Close</button>
+      <button class="btn" onclick="reqUpdate('${rq.id}')">Save</button>
     </div>
   </div>`;
 }
 function signalRow(s) {
-  return `<div class="meta">${esc(s.suburb)} · ${esc(svcLabel(s.service_type).toLowerCase())} <b>×${s.count}</b></div>`;
+  return `<tr><td class="meta">${esc(s.week_start)}</td><td class="meta">${esc(s.suburb)}${s.postcode ? ' ' + esc(s.postcode) : ''}</td><td class="meta">${esc(svcLabel(s.service_type).toLowerCase())}</td><td class="meta" style="text-align:right;"><b>×${s.misses}</b></td></tr>`;
 }
 async function renderRequests(c) {
   c.innerHTML = '<div id="adm-msg" class="msg"></div><p class="empty">Loading…</p>';
   try {
     const { requests, signal } = await sbFn('stripe-api', { action:'requests_list' });
-    const reqHtml = (requests && requests.length) ? requests.map(requestCard).join('') : '<p class="empty">No open requests.</p>';
-    const sigHtml = (signal && signal.length) ? signal.map(signalRow).join('') : '<p class="empty">No unmet searches in the last 30 days.</p>';
+    // Group the board by pipeline stage so the founder-walking clock is impossible to miss.
+    const byStatus = {};
+    (requests || []).forEach(r => { (byStatus[r.status] ||= []).push(r); });
+    const reqHtml = (requests && requests.length)
+      ? LEAD_STATUSES.filter(([v]) => byStatus[v] && byStatus[v].length)
+          .map(([v, l]) => `<h1 style="font-size:1.05rem;margin:18px 0 6px;">${l} <span class="meta">(${byStatus[v].length})</span></h1>` + byStatus[v].map(requestCard).join(''))
+          .join('')
+      : '<p class="empty">No live leads.</p>';
+    const sigHtml = (signal && signal.length)
+      ? `<table style="width:100%;border-collapse:collapse;">${signal.map(signalRow).join('')}</table>`
+      : '<p class="empty">No unmet searches in the last 8 weeks.</p>';
     c.innerHTML = `
-      <p class="sub" style="margin-bottom:14px;">Customers who couldn't find a carer. "Find carers" surfaces nearby matches you can assign — this creates a pending booking request the carer accepts and messages the customer. Guest requests (no linked pet) can't be auto-assigned — reply by email, or mark onboarding/closed.</p>
+      <p class="sub" style="margin-bottom:14px;">Captured leads, grouped by pipeline stage. Same-day call is the bar; the 14-day sourcing clock runs while the founder walks. "Find carers" surfaces nearby matches you can assign — this creates a pending booking request and messages the customer.</p>
       <div id="adm-msg" class="msg"></div>
       ${reqHtml}
-      <h1 style="font-size:1.2rem;margin:22px 0 8px;">Unmet searches (30d)</h1>
-      <p class="sub" style="margin-bottom:10px;">Zero-result searches — demand even when nobody submitted a request.</p>
+      <h1 style="font-size:1.2rem;margin:22px 0 8px;">Unmet searches by week</h1>
+      <p class="sub" style="margin-bottom:10px;">Zero-result searches — the recruitment targeting map, even when nobody submitted.</p>
       ${sigHtml}`;
   } catch (e) {
     if (e.message === 'Not authenticated') return signOut();
@@ -339,13 +368,15 @@ async function reqAssign(reqId, providerId, serviceId) {
     renderRequests(document.getElementById('adm-content'));
   } catch (e) { admMsg(e.message, 'error'); }
 }
-async function reqUpdate(reqId, status) {
+async function reqUpdate(reqId) {
+  const status = (document.getElementById('reqstatus-' + reqId) || {}).value || '';
   const note = (document.getElementById('reqnote-' + reqId) || {}).value || '';
-  if (status === 'closed' && !confirm('Close this request?')) return;
+  const terminal = ['transitioned', 'lost', 'closed'].includes(status);
+  if (terminal && !confirm(`Mark this lead ${status}? It drops off the board.`)) return;
   admMsg('');
   try {
     await sbFn('stripe-api', { action:'request_update', request_id:reqId, status, admin_note:note });
-    admMsg(status === 'closed' ? 'Request closed ✓' : 'Marked onboarding ✓', 'ok');
+    admMsg('Lead updated ✓', 'ok');
     renderRequests(document.getElementById('adm-content'));
   } catch (e) { admMsg(e.message, 'error'); }
 }

--- a/admin/index.html
+++ b/admin/index.html
@@ -278,6 +278,11 @@ function requestCard(rq) {
   const acct = rq.can_assign ? '<span class="badge b-paid">assignable</span>'
     : rq.customer_id ? '<span class="badge b-refunded">no pet</span>'
     : '<span class="badge b-refunded">guest</span>';
+  // TRU-226: fit-gap leads (saw carers, none suited) get a loud badge — this is a supply
+  // QUALITY signal, not a coverage gap.
+  const trigBadge = rq.capture_trigger === 'browsed_unhappy'
+    ? `<span class="badge b-failed">saw ${rq.results_seen ?? '?'} carers</span>`
+    : rq.capture_trigger === 'filtered_out' ? '<span class="badge b-refunded">filtered out</span>' : '';
   const dtVal = rq.wanted_date ? (rq.wanted_date + 'T' + (rq.window_start || '09:00')) : '';
   const assignUi = rq.can_assign ? `
     <div class="actions">
@@ -321,7 +326,7 @@ function requestCard(rq) {
   const seriesNote = rq.assigned_series_id && !rq.handover_mg_booking_id
     ? `<div class="meta"><b>Series live</b> — M&G booked; owner proceeds in their profile (card capture) to activate.</div>` : '';
   return `<div class="card" id="reqcard-${rq.id}">
-    <div class="row-top"><div><b>${esc(svcLabel(rq.service_type))}</b> in ${esc(rq.suburb || '—')} ${acct} ${clockBadge(rq)}</div><div class="meta">${when(rq.created_at)}</div></div>
+    <div class="row-top"><div><b>${esc(svcLabel(rq.service_type))}</b> in ${esc(rq.suburb || '—')} ${acct} ${trigBadge} ${clockBadge(rq)}</div><div class="meta">${when(rq.created_at)}</div></div>
     <div class="meta"><b>${esc(rq.contact)}</b>${rq.contact_phone ? ` · <a href="tel:${esc(rq.contact_phone)}">${esc(rq.contact_phone)}</a>` : ' · ⚠ no phone'}${rq.email ? ' · ' + esc(rq.email) : ''}</div>
     <div class="meta">${dogBits ? esc(dogBits) : 'Dog: —'}${rq.pet ? ' · pet on file: ' + esc(rq.pet) : ''}</div>
     ${rq.dog_temperament_note ? `<div class="meta">Temperament: “${esc(rq.dog_temperament_note)}”</div>` : ''}

--- a/search/index.html
+++ b/search/index.html
@@ -1170,8 +1170,12 @@ const CAPTURE_FREQUENCIES = [
 ];
 const CAPTURE_TIMES = [['morning', 'Morning'], ['midday', 'Midday'], ['afternoon', 'Afternoon'], ['evening', 'Evening']];
 const capTimes = new Set(); // preferred-times chip selection (survives re-renders)
+// TRU-226: which surface produced the lead. no_carers = true area-zero, filtered_out =
+// carers exist but the filters excluded them, browsed_unhappy = saw the list, none suited.
+let captureTrigger = 'no_carers';
 
-function captureStateHtml(areaZero) {
+function captureStateHtml(trigger) {
+  captureTrigger = trigger;
   if (requestSubmitted) {
     return `<div class="request-box request-done fade-in">
       <h3>We're on it 🐾</h3>
@@ -1180,7 +1184,9 @@ function captureStateHtml(areaZero) {
       <p>We've also emailed you a rundown of what happens next.</p>
     </div>`;
   }
-  const heading = (areaZero && state.suburb) ? `We're new to ${esc(state.suburb)}` : 'Let us find your walker';
+  const heading = (trigger === 'no_carers' && state.suburb) ? `We're new to ${esc(state.suburb)}`
+    : trigger === 'browsed_unhappy' ? "Let's find the right fit"
+    : 'Let us find your walker';
   const bandLine = CAPTURE_PRICE_BAND
     ? `<div class="cap-band">Most ${state.suburb ? esc(state.suburb) + ' ' : ''}walks are $${CAPTURE_PRICE_BAND.min}–$${CAPTURE_PRICE_BAND.max}. Your walker sets their own rate — we'll help you land inside it.</div>`
     : '';
@@ -1196,7 +1202,19 @@ function captureStateHtml(areaZero) {
       ${bandLine}
       ${captureFormHtml()}
     </div>
-    <div class="cap-alt"><button class="btn-secondary" id="btnEmptyClear">Clear filters instead</button></div>`;
+    ${trigger === 'browsed_unhappy' ? '' : '<div class="cap-alt"><button class="btn-secondary" id="btnEmptyClear">Clear filters instead</button></div>'}`;
+}
+
+// TRU-226: collapsed CTA under a non-empty results list — the "scrolled to the bottom and
+// still not convinced" lead. Same process as the zero-result capture, different flag.
+function browseCaptureHtml() {
+  if (requestSubmitted) return captureStateHtml('browsed_unhappy'); // thank-you card
+  return `
+    <div class="request-box fade-in" style="margin-top:1.5rem;">
+      <h3>Can't see an option that suits you?</h3>
+      <p>Tell us what you're after and we'll match you with a vetted walker — someone we know, or someone new we go and vet.</p>
+      <button class="btn-primary" id="btnBrowseCapture" type="button">Let us find your walker →</button>
+    </div>`;
 }
 
 function captureFormHtml() {
@@ -1291,6 +1309,8 @@ async function submitCarerRequest(e) {
     p_dog_temperament: val('reqTemperament') || null,
     p_frequency: val('reqFrequency') || null,
     p_preferred_times: Array.from(capTimes),
+    p_trigger: captureTrigger,
+    p_results_seen: providers.length, // server-side count, pre client filters (TRU-226)
   };
   try {
     const r = await sbRpc('submit_carer_request', body);
@@ -1322,7 +1342,7 @@ function renderResults(list) {
     // tweak-your-search empty state with the capture form one click away.
     const areaZero = providers.length === 0 && !!state.suburb;
     if (areaZero || requestSubmitted) {
-      area.innerHTML = captureStateHtml(true);
+      area.innerHTML = captureStateHtml('no_carers');
       wireCaptureState();
       return;
     }
@@ -1337,7 +1357,7 @@ function renderResults(list) {
     `;
     document.getElementById('btnEmptyClear').addEventListener('click', clearFilters);
     document.getElementById('btnShowCapture').addEventListener('click', () => {
-      area.innerHTML = captureStateHtml(false);
+      area.innerHTML = captureStateHtml('filtered_out');
       wireCaptureState();
     });
     return;
@@ -1346,13 +1366,22 @@ function renderResults(list) {
   const cap = 20;
   const visible = list.slice(0, cap);
   const more = list.length > cap;
-  area.innerHTML = `<div class="provider-list">${visible.map(renderCard).join('')}</div>${more ? `<div style="text-align:center;margin-top:1.5rem;"><button class="btn-secondary" id="btnLoadMore">Load more</button></div>` : ''}`;
+  // TRU-226: #browseCapture sits OUTSIDE .provider-list so Load more's insertAdjacentHTML
+  // never disturbs it, and the CTA stays at the true bottom of the page.
+  area.innerHTML = `<div class="provider-list">${visible.map(renderCard).join('')}</div>${more ? `<div style="text-align:center;margin-top:1.5rem;"><button class="btn-secondary" id="btnLoadMore">Load more</button></div>` : ''}<div id="browseCapture">${browseCaptureHtml()}</div>`;
   if (more) {
     document.getElementById('btnLoadMore').addEventListener('click', () => {
       area.querySelector('.provider-list').insertAdjacentHTML('beforeend', list.slice(cap).map(renderCard).join(''));
       document.getElementById('btnLoadMore').remove();
     });
   }
+  const bc = document.getElementById('btnBrowseCapture');
+  if (bc) bc.addEventListener('click', () => {
+    const box = document.getElementById('browseCapture');
+    box.innerHTML = captureStateHtml('browsed_unhappy');
+    wireCaptureState();
+    box.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  });
 
   const ctxClear = document.getElementById('btnClearAll');
   if (ctxClear) ctxClear.addEventListener('click', clearFilters);

--- a/supabase/functions/charge-booking/index.ts
+++ b/supabase/functions/charge-booking/index.ts
@@ -105,11 +105,21 @@ Deno.serve(async (req) => {
     };
     let fee = 0;
     if (!covered) {
-      const { data: pp } = await sb.from('provider_profiles').select('stripe_account_id').eq('id', b.provider_id).single();
-      if (!pp?.stripe_account_id) { await markFailed(bookingId); return json({ error: 'carer has no payout account' }, 400); }
-      piBody['transfer_data[destination]'] = pp.stripe_account_id;
-      fee = Math.round((b.total_cents * PLATFORM_FEE_BPS) / 10000);
-      if (fee > 0) piBody['application_fee_amount'] = fee; // omitted at 0% — Stripe requires it positive
+      const { data: pp } = await sb.from('provider_profiles').select('stripe_account_id,user_id').eq('id', b.provider_id).single();
+      if (pp?.stripe_account_id) {
+        piBody['transfer_data[destination]'] = pp.stripe_account_id;
+        fee = Math.round((b.total_cents * PLATFORM_FEE_BPS) / 10000);
+        if (fee > 0) piBody['application_fee_amount'] = fee; // omitted at 0% — Stripe requires it positive
+      } else {
+        // TRU-224: founder stop-gap walks — the provider profile belongs to an admin user
+        // with no connected account. The platform retains the full amount, the TRU-139
+        // covered-walk money mechanics applied to founder walks. Any other carer without
+        // a payout account is still a hard failure.
+        const { data: pu } = pp?.user_id
+          ? await sb.from('users').select('is_admin').eq('id', pp.user_id).single()
+          : { data: null };
+        if (!pu?.is_admin) { await markFailed(bookingId); return json({ error: 'carer has no payout account' }, 400); }
+      }
     }
 
     let pi;

--- a/supabase/functions/send-notification/index.ts
+++ b/supabase/functions/send-notification/index.ts
@@ -279,8 +279,16 @@ async function buildMessages(type: string, payload: Record<string, unknown>) {
       ? (rq.preferred_times as string[]).map((t) => t.charAt(0).toUpperCase() + t.slice(1)).join(', ')
       : '—';
 
+    // TRU-226: why this lead exists — supply gap vs fit gap. Call-prep gold either way.
+    const whyStr = rq.capture_trigger === 'browsed_unhappy'
+      ? `Saw ${rq.results_seen ?? '?'} carer${rq.results_seen === 1 ? '' : 's'} — none suited`
+      : rq.capture_trigger === 'filtered_out'
+        ? 'Carers exist, but their filters excluded them all'
+        : 'No carers in their area';
+
     const rows: [string, string][] = [
       ['Phone', rq.contact_phone || '⚠ missing'],
+      ['Why', whyStr],
       ['Suburb', rq.suburb || '—'],
       ['Service', serviceLabel],
       ['How often', rq.frequency ? (FREQUENCY_LABELS[rq.frequency] || rq.frequency) : (rq.recurring ? 'Recurring' : 'One-off')],

--- a/supabase/functions/stripe-api/index.ts
+++ b/supabase/functions/stripe-api/index.ts
@@ -456,11 +456,13 @@ Deno.serve(async (req) => {
     if (action === 'requests_list') {
       if (!(await isAdmin(user.id))) return json({ error: 'Not authorised' }, 403);
       const NONE = ['00000000-0000-0000-0000-000000000000'];
+      // TRU-221: every non-terminal pipeline status stays on the board so nothing falls
+      // through; terminal leads (transitioned/lost/closed) drop off.
       const { data: reqs } = await sb.from('carer_requests')
         .select('*')
-        .in('status', ['open', 'onboarding'])
+        .in('status', ['captured', 'called', 'founder_walking', 'sourcing_walker', 'meet_greet_booked'])
         .order('created_at', { ascending: false })
-        .limit(50);
+        .limit(100);
       const rows = reqs || [];
       const custIds = [...new Set(rows.map((r) => r.customer_id).filter(Boolean))] as string[];
       const petIds = [...new Set(rows.map((r) => r.pet_id).filter(Boolean))] as string[];
@@ -474,19 +476,17 @@ Deno.serve(async (req) => {
       const { data: us } = await sb.from('users').select('id,first_name,last_name,email').in('id', uIds.length ? uIds : NONE);
       const userBy = Object.fromEntries((us || []).map((u) => [u.id, u]));
 
-      // Passive signal — unmet searches over the last 30 days, aggregated by suburb + service.
-      const since = new Date(Date.now() - 30 * 864e5).toISOString();
-      const { data: misses } = await sb.from('search_misses').select('suburb,service_type').gte('created_at', since).limit(2000);
-      const aggMap: Record<string, number> = {};
-      (misses || []).forEach((m) => {
-        const k = `${m.suburb}||${m.service_type || ''}`;
-        aggMap[k] = (aggMap[k] || 0) + 1;
-      });
-      const signal = Object.entries(aggMap)
-        .map(([k, count]) => { const [suburb, service_type] = k.split('||'); return { suburb, service_type, count }; })
-        .sort((a, b) => b.count - a.count)
-        .slice(0, 20);
+      // Passive signal — weekly unmet-search counts by suburb (TRU-222's rollup view),
+      // last 8 weeks, biggest gaps first.
+      const since = new Date(Date.now() - 56 * 864e5).toISOString().slice(0, 10);
+      const { data: signal } = await sb.from('search_miss_weekly')
+        .select('week_start,suburb,postcode,service_type,misses')
+        .gte('week_start', since)
+        .order('week_start', { ascending: false })
+        .order('misses', { ascending: false })
+        .limit(40);
 
+      const now = Date.now();
       return json({
         requests: rows.map((r) => {
           const u = userBy[custUser[r.customer_id]];
@@ -496,9 +496,10 @@ Deno.serve(async (req) => {
             email: r.contact_email || (u ? u.email : '') || '',
             pet: r.pet_id ? (petName[r.pet_id] || 'Dog') : '',
             can_assign: !!(r.customer_id && r.pet_id),
+            days_in_status: Math.floor((now - new Date(r.status_changed_at || r.created_at).getTime()) / 864e5),
           };
         }),
-        signal,
+        signal: signal || [],
       });
     }
 
@@ -544,7 +545,7 @@ Deno.serve(async (req) => {
       if (!providerId || !serviceId || !scheduledAt) return json({ error: 'Missing carer, service or time' }, 400);
       const { data: rq } = await sb.from('carer_requests').select('*').eq('id', reqId).maybeSingle();
       if (!rq) return json({ error: 'Request not found' }, 404);
-      if (rq.status !== 'open' && rq.status !== 'onboarding') return json({ error: 'Request already resolved' }, 409);
+      if (['transitioned', 'lost', 'closed'].includes(rq.status)) return json({ error: 'Request already resolved' }, 409);
       if (!rq.customer_id || !rq.pet_id) return json({ error: 'This request has no linked customer/pet to assign' }, 400);
 
       const { data: svc } = await sb.from('provider_services').select('id,duration_mins').eq('id', serviceId).maybeSingle();
@@ -568,12 +569,13 @@ Deno.serve(async (req) => {
       const bookingId = ins.data.id;
       await sb.from('booking_pets').insert({ booking_id: bookingId, pet_id: rq.pet_id });
 
+      // TRU-221: an assigned lead is not terminal — it stays on the board as
+      // meet_greet_booked until the admin moves it to transitioned/lost, so the
+      // follow-through (first booking actually happening) is tracked.
       await sb.from('carer_requests').update({
-        status: 'matched',
+        status: 'meet_greet_booked',
         assigned_provider_id: providerId,
         assigned_booking_id: bookingId,
-        resolved_at: new Date().toISOString(),
-        resolved_by: user.id,
       }).eq('id', reqId);
 
       // Tell the customer in-app (the carer's booking-request email is fired by the DB trigger).
@@ -596,8 +598,9 @@ Deno.serve(async (req) => {
       const reqId = String(payload.request_id || '');
       const status = String(payload.status || '');
       const adminNote = String(payload.admin_note || '').slice(0, 500);
-      if (!['open', 'onboarding', 'closed'].includes(status)) return json({ error: 'Invalid status' }, 400);
-      const resolved = status === 'closed';
+      if (!['captured', 'called', 'founder_walking', 'sourcing_walker', 'meet_greet_booked',
+            'transitioned', 'lost', 'closed'].includes(status)) return json({ error: 'Invalid status' }, 400);
+      const resolved = ['transitioned', 'lost', 'closed'].includes(status);
       const upd = await sb.from('carer_requests').update({
         status,
         admin_note: adminNote || null,

--- a/supabase/functions/stripe-api/index.ts
+++ b/supabase/functions/stripe-api/index.ts
@@ -24,6 +24,8 @@
 //   request_link_customer - (admin) link a registered account to a guest lead by email (TRU-224)
 //   founder_service_ensure - (admin) founder stop-gap provider profile + priced service row (TRU-224)
 //   request_create_series - (admin) lead -> pending_meet_greet series via admin_create_lead_series (TRU-224)
+//   handover_nominate - (admin) book the 3-way M&G with the incoming permanent carer (TRU-225)
+//   handover_complete - (admin) transition the series to the nominee at their listed rate (TRU-225)
 //   request_update  - (admin) set a lead's pipeline status + admin note (TRU-221)
 //
 // Required function secrets (Supabase → Edge Functions → Secrets):
@@ -494,6 +496,14 @@ Deno.serve(async (req) => {
         : { data: [] as { email: string }[] };
       const emailHasAccount = new Set((matchUsers || []).map((u) => String(u.email).toLowerCase()));
 
+      // TRU-225: surface the 3-way handover M&G status so the console can show
+      // "Complete handover" at the right moment.
+      const hoIds = [...new Set(rows.map((r) => r.handover_mg_booking_id).filter(Boolean))] as string[];
+      const { data: hoBookings } = hoIds.length
+        ? await sb.from('bookings').select('id,status,scheduled_at').in('id', hoIds)
+        : { data: [] as { id: string; status: string; scheduled_at: string }[] };
+      const hoBy = Object.fromEntries((hoBookings || []).map((b) => [b.id, b]));
+
       // Passive signal — weekly unmet-search counts by suburb (TRU-222's rollup view),
       // last 8 weeks, biggest gaps first.
       const since = new Date(Date.now() - 56 * 864e5).toISOString().slice(0, 10);
@@ -517,6 +527,8 @@ Deno.serve(async (req) => {
             days_in_status: Math.floor((now - new Date(r.status_changed_at || r.created_at).getTime()) / 864e5),
             account_exists: !!r.customer_id
               || (r.contact_email ? emailHasAccount.has(String(r.contact_email).toLowerCase()) : false),
+            handover_mg_status: r.handover_mg_booking_id ? (hoBy[r.handover_mg_booking_id]?.status || null) : null,
+            handover_mg_at: r.handover_mg_booking_id ? (hoBy[r.handover_mg_booking_id]?.scheduled_at || null) : null,
           };
         }),
         signal: signal || [],
@@ -738,6 +750,78 @@ Deno.serve(async (req) => {
         });
       }
       return json({ ok: true, series_id: seriesId });
+    }
+
+    if (action === 'handover_nominate') {
+      // TRU-225: book the 3-way M&G (owner + incoming carer + founder) on the lead's
+      // series. Validation (nominee active/verified/payouts-ready, matching priced
+      // service) and the booking insert live in the service_role-only RPC.
+      if (!(await isAdmin(user.id))) return json({ error: 'Not authorised' }, 403);
+      const reqId = String(payload.request_id || '');
+      const providerId = String(payload.provider_id || ''); // provider_profiles.id
+      const serviceId = String(payload.service_id || '');   // nominee's provider_services.id
+      const mgAt = String(payload.mg_scheduled_at || '');
+      if (!reqId || !providerId || !serviceId || !mgAt) return json({ error: 'Missing carer, service or meet & greet time' }, 400);
+
+      const { data: mgId, error: rpcErr } = await sb.rpc('admin_nominate_handover', {
+        p_request_id: reqId,
+        p_provider_profile_id: providerId,
+        p_service_id: serviceId,
+        p_mg_scheduled_at: mgAt,
+      });
+      if (rpcErr) return json({ error: rpcErr.message }, 400);
+
+      // Candid owner message: introduce the walker and quote THEIR listed rate up front
+      // (GTM: the number lands inside an expectation set on day one, confirmed at the M&G).
+      const { data: rq } = await sb.from('carer_requests').select('customer_id').eq('id', reqId).single();
+      const { data: pp } = await sb.from('provider_profiles').select('user_id').eq('id', providerId).single();
+      const { data: nu } = pp?.user_id ? await sb.from('users').select('first_name').eq('id', pp.user_id).single() : { data: null };
+      const { data: svc } = await sb.from('provider_services').select('price_cents').eq('id', serviceId).single();
+      const { data: cp } = rq?.customer_id ? await sb.from('customer_profiles').select('user_id').eq('id', rq.customer_id).single() : { data: null };
+      if (cp?.user_id) {
+        const rateStr = svc?.price_cents ? ` Their rate is $${(svc.price_cents / 100).toFixed(0)} per walk — we'll confirm everything together at the meet & greet.` : '';
+        await sb.from('system_messages').insert({
+          recipient_user_id: cp.user_id,
+          body: `Great news — we've found your permanent walker${nu?.first_name ? `, ${nu.first_name}` : ''}. We've booked a meet & greet so you can meet them together with Tom.${rateStr}`,
+          link_url: '/profile/',
+          link_label: 'View my bookings',
+        });
+      }
+      return json({ ok: true, mg_booking_id: mgId });
+    }
+
+    if (action === 'handover_complete') {
+      // TRU-225: after the 3-way meet — series + future walks move to the nominee at
+      // their listed rate, founder history preserved, lead → transitioned. Atomic in
+      // the service_role-only RPC.
+      if (!(await isAdmin(user.id))) return json({ error: 'Not authorised' }, 403);
+      const reqId = String(payload.request_id || '');
+      if (!reqId) return json({ error: 'Missing request id' }, 400);
+
+      const { data: rq } = await sb.from('carer_requests')
+        .select('customer_id,handover_provider_id,handover_service_id').eq('id', reqId).maybeSingle();
+      if (!rq) return json({ error: 'Request not found' }, 404);
+
+      const { data: moved, error: rpcErr } = await sb.rpc('admin_complete_handover', {
+        p_request_id: reqId,
+        p_resolved_by: user.id,
+      });
+      if (rpcErr) return json({ error: rpcErr.message }, 400);
+
+      const { data: pp } = rq.handover_provider_id ? await sb.from('provider_profiles').select('user_id').eq('id', rq.handover_provider_id).single() : { data: null };
+      const { data: nu } = pp?.user_id ? await sb.from('users').select('first_name').eq('id', pp.user_id).single() : { data: null };
+      const { data: svc } = rq.handover_service_id ? await sb.from('provider_services').select('price_cents').eq('id', rq.handover_service_id).single() : { data: null };
+      const { data: cp } = rq.customer_id ? await sb.from('customer_profiles').select('user_id').eq('id', rq.customer_id).single() : { data: null };
+      if (cp?.user_id) {
+        const rateStr = svc?.price_cents ? ` at $${(svc.price_cents / 100).toFixed(0)} per walk` : '';
+        await sb.from('system_messages').insert({
+          recipient_user_id: cp.user_id,
+          body: `It's official — ${nu?.first_name || 'your new walker'} takes over your walks from here${rateStr}. Everything we've learned about your dog goes with them, and Tom is always a message away.`,
+          link_url: '/profile/',
+          link_label: 'View my bookings',
+        });
+      }
+      return json({ ok: true, reassigned: moved });
     }
 
     if (action === 'request_update') {

--- a/supabase/functions/stripe-api/index.ts
+++ b/supabase/functions/stripe-api/index.ts
@@ -18,10 +18,13 @@
 //   cover_reassign  - (admin) take over a covered cancelled booking (TRU-139)
 //   cover_fell_through - (admin) mark cover as failed; issue a manual credit + owner message
 //   credit_redeem   - (admin) mark a manual credit as applied
-//   requests_list   - (admin) open "can't find a carer" requests + unmet-search signal (TRU-121)
+//   requests_list   - (admin) live capture-flow leads by pipeline stage + weekly unmet-search signal (TRU-121/221)
 //   request_find_carers - (admin) candidate carers near a request (reuses search_carers)
-//   request_assign  - (admin) assign an existing carer -> creates a pending booking request
-//   request_update  - (admin) set a request's status + admin note (guest / onboarding path)
+//   request_assign  - (admin) assign an existing carer -> creates a priced pending booking request
+//   request_link_customer - (admin) link a registered account to a guest lead by email (TRU-224)
+//   founder_service_ensure - (admin) founder stop-gap provider profile + priced service row (TRU-224)
+//   request_create_series - (admin) lead -> pending_meet_greet series via admin_create_lead_series (TRU-224)
+//   request_update  - (admin) set a lead's pipeline status + admin note (TRU-221)
 //
 // Required function secrets (Supabase → Edge Functions → Secrets):
 //   STRIPE_SECRET_KEY   - sk_test_… (platform secret key)
@@ -218,11 +221,17 @@ Deno.serve(async (req) => {
       };
       let fee = 0;
       if (!covered) {
-        const { data: pp } = await sb.from('provider_profiles').select('stripe_account_id').eq('id', b.provider_id).single();
-        if (!pp?.stripe_account_id) return json({ error: 'Carer has no payout account' }, 400);
-        piBody['transfer_data[destination]'] = pp.stripe_account_id;
-        fee = Math.round((b.total_cents * PLATFORM_FEE_BPS) / 10000);
-        if (fee > 0) piBody['application_fee_amount'] = fee;
+        const { data: pp } = await sb.from('provider_profiles').select('stripe_account_id,user_id').eq('id', b.provider_id).single();
+        if (pp?.stripe_account_id) {
+          piBody['transfer_data[destination]'] = pp.stripe_account_id;
+          fee = Math.round((b.total_cents * PLATFORM_FEE_BPS) / 10000);
+          if (fee > 0) piBody['application_fee_amount'] = fee;
+        } else if (!pp?.user_id || !(await isAdmin(pp.user_id))) {
+          return json({ error: 'Carer has no payout account' }, 400);
+        }
+        // else: TRU-224 founder stop-gap walk — the provider profile belongs to an admin
+        // with no connected account; the platform retains the full amount (the TRU-139
+        // covered-walk money mechanics, applied to founder walks).
       }
       // No confirm — the client confirms with the Payment Element so a new card / 3DS works.
       const pi = await stripe('payment_intents', 'POST', piBody);
@@ -476,6 +485,15 @@ Deno.serve(async (req) => {
       const { data: us } = await sb.from('users').select('id,first_name,last_name,email').in('id', uIds.length ? uIds : NONE);
       const userBy = Object.fromEntries((us || []).map((u) => [u.id, u]));
 
+      // TRU-224: for guest leads, flag when an account already exists for the contact email
+      // so the console can offer one-click linking after the lead registers.
+      const guestEmails = [...new Set(rows.filter((r) => !r.customer_id && r.contact_email)
+        .map((r) => String(r.contact_email).toLowerCase()))];
+      const { data: matchUsers } = guestEmails.length
+        ? await sb.from('users').select('email').in('email', guestEmails)
+        : { data: [] as { email: string }[] };
+      const emailHasAccount = new Set((matchUsers || []).map((u) => String(u.email).toLowerCase()));
+
       // Passive signal — weekly unmet-search counts by suburb (TRU-222's rollup view),
       // last 8 weeks, biggest gaps first.
       const since = new Date(Date.now() - 56 * 864e5).toISOString().slice(0, 10);
@@ -497,6 +515,8 @@ Deno.serve(async (req) => {
             pet: r.pet_id ? (petName[r.pet_id] || 'Dog') : '',
             can_assign: !!(r.customer_id && r.pet_id),
             days_in_status: Math.floor((now - new Date(r.status_changed_at || r.created_at).getTime()) / 864e5),
+            account_exists: !!r.customer_id
+              || (r.contact_email ? emailHasAccount.has(String(r.contact_email).toLowerCase()) : false),
           };
         }),
         signal: signal || [],
@@ -548,13 +568,16 @@ Deno.serve(async (req) => {
       if (['transitioned', 'lost', 'closed'].includes(rq.status)) return json({ error: 'Request already resolved' }, 409);
       if (!rq.customer_id || !rq.pet_id) return json({ error: 'This request has no linked customer/pet to assign' }, 400);
 
-      const { data: svc } = await sb.from('provider_services').select('id,duration_mins').eq('id', serviceId).maybeSingle();
+      const { data: svc } = await sb.from('provider_services')
+        .select('id,duration_mins,price_cents,is_available').eq('id', serviceId).maybeSingle();
       if (!svc) return json({ error: 'Service not found' }, 404);
+      if (!svc.is_available || svc.price_cents == null) return json({ error: 'Service is unavailable or has no price' }, 400);
 
-      // Mirror the customer's single-booking insert (book/index.html): status 'pending',
-      // total_cents 0 (single bookings price on completion; series carry locked_price_cents).
-      // The carer still accepts and the customer still confirms — nothing is forced. The
-      // existing trg_email_booking_request trigger notifies the carer on insert.
+      // TRU-224 (£0 bug fix): price the booking from the service at assign time — the old
+      // total_cents: 0 insert was never repriced, so charge-on-completion (TRU-146) skipped
+      // it and assigned bookings were free. Single pet here (rq.pet_id), so no extra-pet fee
+      // — mirrors private.compute_service_price for a pet count of 1. The carer still
+      // accepts; trg_email_booking_request notifies them on insert.
       const ins = await sb.from('bookings').insert({
         customer_id: rq.customer_id,
         provider_id: providerId,
@@ -563,7 +586,7 @@ Deno.serve(async (req) => {
         status: 'pending',
         scheduled_at: scheduledAt,
         duration_mins: svc.duration_mins ?? null,
-        total_cents: 0,
+        total_cents: svc.price_cents,
       }).select('id').single();
       if (ins.error || !ins.data) return json({ error: 'Could not create booking: ' + (ins.error?.message || '') }, 500);
       const bookingId = ins.data.id;
@@ -591,6 +614,130 @@ Deno.serve(async (req) => {
         });
       }
       return json({ ok: true, booking_id: bookingId });
+    }
+
+    if (action === 'request_link_customer') {
+      // TRU-224: after the lead registers (confirmation email CTA / founder call), link
+      // their new account to the lead by email so the booking steps can run.
+      if (!(await isAdmin(user.id))) return json({ error: 'Not authorised' }, 403);
+      const reqId = String(payload.request_id || '');
+      const { data: rq } = await sb.from('carer_requests').select('id,status,customer_id,contact_email').eq('id', reqId).maybeSingle();
+      if (!rq) return json({ error: 'Request not found' }, 404);
+      const email = String(payload.customer_email || rq.contact_email || '').trim().toLowerCase();
+      if (!email) return json({ error: 'No email to match on' }, 400);
+      let customerId = rq.customer_id as string | null;
+      if (!customerId) {
+        const { data: u } = await sb.from('users').select('id').ilike('email', email).maybeSingle();
+        if (!u) return json({ error: `No account found for ${email}` }, 404);
+        const { data: cp } = await sb.from('customer_profiles').select('id').eq('user_id', u.id).maybeSingle();
+        if (!cp) return json({ error: 'That account has no customer profile' }, 404);
+        customerId = cp.id;
+      }
+      await sb.from('carer_requests').update({
+        customer_id: customerId,
+        converted_customer_id: customerId,
+      }).eq('id', reqId);
+      const { data: pets } = await sb.from('pets').select('id,name,breed').eq('customer_id', customerId);
+      return json({ ok: true, customer_id: customerId, pets: pets || [] });
+    }
+
+    if (action === 'founder_service_ensure') {
+      // TRU-224: get-or-create the calling admin's internal provider profile (the TRU-139
+      // cover_reassign pattern — inactive + unverified, never searchable) and upsert a
+      // provider_services row at the stop-gap rate for the lead's service type. Pricing
+      // then flows through the normal machinery (compute_service_price reads this row).
+      if (!(await isAdmin(user.id))) return json({ error: 'Not authorised' }, 403);
+      const serviceType = String(payload.service_type || 'dog_walking');
+      const durationMins = Math.max(15, Math.round(Number(payload.duration_mins ?? 30)) || 30);
+      const priceCents = Math.round(Number(payload.price_cents || 0));
+      if (!(priceCents > 0)) return json({ error: 'Set a stop-gap rate first' }, 400);
+
+      let { data: mypp } = await sb.from('provider_profiles').select('id').eq('user_id', user.id).maybeSingle();
+      if (!mypp) {
+        const ins = await sb.from('provider_profiles')
+          .insert({ user_id: user.id, is_active: false, is_verified: false, bio: 'Truffl founder stop-gap' })
+          .select('id').single();
+        if (ins.error || !ins.data) return json({ error: 'Could not create founder profile' }, 500);
+        mypp = ins.data;
+      }
+
+      // provider_services.provider_id references users.id (not provider_profiles.id).
+      const { data: existing } = await sb.from('provider_services')
+        .select('id').eq('provider_id', user.id).eq('service_type', serviceType)
+        .eq('duration_mins', durationMins).maybeSingle();
+      if (existing) {
+        await sb.from('provider_services').update({ price_cents: priceCents, is_available: true }).eq('id', existing.id);
+        return json({ ok: true, service_id: existing.id, provider_profile_id: mypp.id });
+      }
+      const svcIns = await sb.from('provider_services').insert({
+        provider_id: user.id,
+        service_type: serviceType,
+        duration_mins: durationMins,
+        price_cents: priceCents,
+        is_available: true,
+      }).select('id').single();
+      if (svcIns.error || !svcIns.data) return json({ error: 'Could not create service: ' + (svcIns.error?.message || '') }, 500);
+      return json({ ok: true, service_id: svcIns.data.id, provider_profile_id: mypp.id });
+    }
+
+    if (action === 'request_create_series') {
+      // TRU-224: create the lead's pending_meet_greet series (founder stop-gap or a real
+      // carer) via the service_role-only definer RPC — pricing and the M&G gate booking
+      // happen server-side in SQL, mirroring create_booking_series. From here the flow is
+      // all existing machinery: owner marks the M&G complete, proceeds (card saved via
+      // SetupIntent), the series activates and walks charge on completion.
+      if (!(await isAdmin(user.id))) return json({ error: 'Not authorised' }, 403);
+      const reqId = String(payload.request_id || '');
+      const serviceId = String(payload.service_id || '');
+      const mgAt = String(payload.mg_scheduled_at || '');
+      const startDate = String(payload.start_date || '');
+      const timeOfDay = String(payload.time_of_day || '');
+      const daysOfWeek = Array.isArray(payload.days_of_week) ? (payload.days_of_week as number[]) : [];
+      // series_frequency enum: daily | weekdays | specific_days (specific_days uses days_of_week, isodow 1–7)
+      const frequencyType = String(payload.frequency_type || 'specific_days');
+      const bookingKind = String(payload.booking_kind || 'recurring');
+      if (!['daily', 'weekdays', 'specific_days'].includes(frequencyType)) return json({ error: 'Invalid frequency' }, 400);
+      if (!reqId || !serviceId || !mgAt || !startDate || !timeOfDay) {
+        return json({ error: 'Missing service, meet & greet time, start date or walk time' }, 400);
+      }
+      if (frequencyType === 'specific_days' && !daysOfWeek.length) {
+        return json({ error: 'Pick at least one walk day' }, 400);
+      }
+      const { data: rq } = await sb.from('carer_requests').select('id,customer_id,pet_id').eq('id', reqId).maybeSingle();
+      if (!rq) return json({ error: 'Request not found' }, 404);
+      const customerId = rq.customer_id as string | null;
+      if (!customerId) return json({ error: 'Link the lead to an account first' }, 400);
+      const petId = String(payload.pet_id || rq.pet_id || '');
+      if (!petId) return json({ error: 'Pick a pet first (the owner must add one)' }, 400);
+
+      const { data: seriesId, error: rpcErr } = await sb.rpc('admin_create_lead_series', {
+        p_request_id: reqId,
+        p_customer_id: customerId,
+        p_service_id: serviceId,
+        p_pet_ids: [petId],
+        p_booking_kind: bookingKind,
+        p_frequency_type: frequencyType,
+        p_days_of_week: daysOfWeek,
+        p_time_of_day: timeOfDay,
+        p_window_end_time: payload.window_end_time ? String(payload.window_end_time) : null,
+        p_start_date: startDate,
+        p_end_date: payload.end_date ? String(payload.end_date) : null,
+        p_mg_scheduled_at: mgAt,
+      });
+      if (rpcErr) return json({ error: rpcErr.message }, 400);
+
+      // Tell the owner in-app; the M&G banner in messages + the proceed step in profile
+      // take it from here.
+      const { data: cp } = await sb.from('customer_profiles').select('user_id').eq('id', customerId).single();
+      if (cp?.user_id) {
+        await sb.from('system_messages').insert({
+          recipient_user_id: cp.user_id,
+          body: `Your first walks are set up — we've booked a free meet & greet so you can meet your walker before anything starts. Check your bookings for the time.`,
+          link_url: '/profile/',
+          link_label: 'View my bookings',
+        });
+      }
+      return json({ ok: true, series_id: seriesId });
     }
 
     if (action === 'request_update') {

--- a/supabase/migrations/20260717000000_tru224_lead_conversion.sql
+++ b/supabase/migrations/20260717000000_tru224_lead_conversion.sql
@@ -1,0 +1,115 @@
+-- TRU-224: convert a captured lead into an owner + first booking with the founder as carer.
+--
+-- The capture flow (TRU-216) ends with a lead record; this migration wires it into the real
+-- booking pipeline:
+--   • carer_requests.converted_customer_id / assigned_series_id link the lead to the owner
+--     account and the founder booking series, so the TRU-221 pipeline can follow through.
+--   • public.admin_create_lead_series is the server-side path the admin console uses to
+--     create the founder (or any carer's) pending_meet_greet series for a lead. It mirrors
+--     public.create_booking_series exactly (provider derived from the service, price via
+--     private.compute_service_price, M&G booking created atomically) but takes an explicit
+--     customer instead of auth.uid(), because the admin — not the owner — drives this step.
+--     EXECUTE is granted to service_role ONLY: it is called from the stripe-api edge function
+--     behind its users.is_admin gate, never from clients.
+--
+-- Payment stays exactly where TRU-144/146 put it: card captured at the M&G proceed step,
+-- charge on completion. Nothing here touches money.
+--
+-- Applied to the live DB via apply_migration (Supabase branching is broken on this repo);
+-- committed here for version control (see TRU-145). 14-digit unique prefix.
+
+alter table public.carer_requests
+  add column if not exists converted_customer_id uuid references public.customer_profiles(id) on delete set null,
+  add column if not exists assigned_series_id    uuid references public.booking_series(id) on delete set null;
+
+create or replace function public.admin_create_lead_series(
+  p_request_id      uuid,
+  p_customer_id     uuid,
+  p_service_id      uuid,
+  p_pet_ids         uuid[],
+  p_booking_kind    text,
+  p_frequency_type  public.series_frequency,
+  p_days_of_week    int[],
+  p_time_of_day     time,
+  p_window_end_time time        default null,
+  p_start_date      date        default null,
+  p_end_date        date        default null,
+  p_mg_scheduled_at timestamptz default null
+) returns uuid language plpgsql security definer set search_path = public as $$
+declare
+  v_provider_id uuid;
+  v_owned       int;
+  v_locked      int;
+  v_series_id   uuid;
+  v_mg_id       uuid;
+  v_status      text;
+begin
+  select status into v_status from public.carer_requests where id = p_request_id;
+  if v_status is null then
+    raise exception 'Lead % not found', p_request_id;
+  end if;
+  if v_status in ('transitioned', 'lost', 'closed') then
+    raise exception 'Lead % is already resolved (%)', p_request_id, v_status;
+  end if;
+
+  if p_pet_ids is null or array_length(p_pet_ids, 1) is null then
+    raise exception 'At least one pet is required';
+  end if;
+  select count(*) into v_owned
+    from public.pets where id = any(p_pet_ids) and customer_id = p_customer_id;
+  if v_owned <> cardinality(p_pet_ids) then
+    raise exception 'One or more pets do not belong to customer %', p_customer_id;
+  end if;
+
+  -- provider_services.provider_id is an auth.users.id; map it to provider_profiles.id.
+  select pp.id into v_provider_id
+    from public.provider_services ps
+    join public.provider_profiles pp on pp.user_id = ps.provider_id
+   where ps.id = p_service_id;
+  if v_provider_id is null then
+    raise exception 'Service % not found or has no provider profile', p_service_id;
+  end if;
+  v_locked := private.compute_service_price(p_service_id, cardinality(p_pet_ids));
+
+  insert into public.booking_series (
+    customer_id, provider_id, service_id, booking_kind,
+    frequency_type, days_of_week, time_of_day, window_end_time,
+    start_date, end_date, status, locked_price_cents
+  ) values (
+    p_customer_id, v_provider_id, p_service_id, coalesce(p_booking_kind, 'recurring'),
+    p_frequency_type, coalesce(p_days_of_week, '{}'::int[]), p_time_of_day, p_window_end_time,
+    p_start_date, p_end_date, 'pending_meet_greet'::public.series_status, v_locked
+  ) returning id into v_series_id;
+
+  insert into public.series_pets (series_id, pet_id)
+  select v_series_id, unnest(p_pet_ids);
+
+  -- The gate booking: free flagged M&G, same shape as create_booking_series's M&G branch.
+  insert into public.bookings (
+    customer_id, provider_id, pet_id, service_id, status,
+    scheduled_at, duration_mins, total_cents, is_meet_and_greet, series_id
+  ) values (
+    p_customer_id, v_provider_id, p_pet_ids[1], p_service_id, 'confirmed',
+    coalesce(p_mg_scheduled_at, (p_start_date::timestamp + time '12:00') at time zone 'Australia/Sydney'),
+    30, 0, true, v_series_id
+  ) returning id into v_mg_id;
+
+  insert into public.booking_pets (booking_id, pet_id)
+  select v_mg_id, unnest(p_pet_ids);
+
+  -- Wire the lead into the pipeline: it parks at meet_greet_booked (TRU-221 board) and
+  -- carries the links the follow-through needs.
+  update public.carer_requests set
+    status                = 'meet_greet_booked',
+    converted_customer_id = p_customer_id,
+    customer_id           = coalesce(customer_id, p_customer_id),
+    pet_id                = coalesce(pet_id, p_pet_ids[1]),
+    assigned_series_id    = v_series_id,
+    assigned_provider_id  = v_provider_id
+  where id = p_request_id;
+
+  return v_series_id;
+end; $$;
+
+revoke all on function public.admin_create_lead_series(uuid, uuid, uuid, uuid[], text, public.series_frequency, int[], time, time, date, date, timestamptz) from public, anon, authenticated;
+grant execute on function public.admin_create_lead_series(uuid, uuid, uuid, uuid[], text, public.series_frequency, int[], time, time, date, date, timestamptz) to service_role;

--- a/supabase/migrations/20260717000001_tru225_handover.sql
+++ b/supabase/migrations/20260717000001_tru225_handover.sql
@@ -1,0 +1,220 @@
+-- TRU-225: handover — nominate a permanent carer to take over a lead's booking series.
+--
+-- The product side of the GTM two-week rule: the founder walks as a stop-gap (TRU-224),
+-- then hands the series to a sourced permanent walker at THEIR listed rate. Builds on the
+-- TRU-139 reassignment pattern (original_provider_id preserves who was booked vs who
+-- walked) but runs founder → new carer, operates on the whole series' future bookings,
+-- and changes the price at transition.
+--
+--   • carer_requests.handover_* track the in-flight nomination.
+--   • admin_nominate_handover: validates the nominee (active, verified, Stripe payouts
+--     ready — a post-handover charge would otherwise die in charge-booking) and books the
+--     3-way M&G on the same series with the nominee as provider. Lead → meet_greet_booked.
+--   • admin_complete_handover: after the 3-way meet, atomically marks the handover M&G
+--     completed, repoints the series (provider/service/locked_price_cents → nominee's
+--     listed rate) so future materialisation is automatic, reassigns future pending/
+--     confirmed walks at the new rate with history preserved, and moves the lead to
+--     transitioned. NOTE the deliberate deviation from the owner-driven M&G flow: the
+--     messages-page "mark complete" banner only renders for pending_meet_greet series,
+--     and a handover series is already active — the founder is physically at the 3-way
+--     meet, so completion is the founder's console action.
+--   • trg_meet_greet_gate now requires the completed M&G to match the series' CURRENT
+--     provider. Defensive: after handover a series carries a completed M&G from the old
+--     provider, and any future re-arm to pending_meet_greet must not be satisfied by it.
+--     Backward compatible — every M&G booking is created with the series' provider.
+--
+-- Both RPCs are EXECUTE-granted to service_role only (called from stripe-api behind its
+-- users.is_admin gate). SECURITY DEFINER runs as postgres, so the TRU-171 price-guard
+-- triggers pass.
+--
+-- Applied to the live DB via apply_migration (Supabase branching is broken on this repo);
+-- committed here for version control (see TRU-145). 14-digit unique prefix.
+
+alter table public.carer_requests
+  add column if not exists handover_provider_id   uuid references public.provider_profiles(id) on delete set null,
+  add column if not exists handover_service_id    uuid references public.provider_services(id) on delete set null,
+  add column if not exists handover_mg_booking_id uuid references public.bookings(id) on delete set null;
+
+-- ── provider-matched meet & greet gate ────────────────────────────────────────
+create or replace function public.trg_meet_greet_gate()
+returns trigger language plpgsql security definer set search_path to 'public' as $function$
+begin
+  if OLD.status = 'pending_meet_greet' and NEW.status = 'active' then
+    if not exists (
+      select 1 from public.bookings b
+      where b.series_id = NEW.id
+        and b.is_meet_and_greet = true
+        and b.status = 'completed'
+        and b.provider_id = NEW.provider_id  -- TRU-225: the M&G must be with the current carer
+    ) then
+      raise exception 'Cannot activate series % before its meet & greet is completed', NEW.id
+        using errcode = 'check_violation';
+    end if;
+  end if;
+  return NEW;
+end;
+$function$;
+
+revoke all on function public.trg_meet_greet_gate() from public, anon, authenticated;
+
+-- ── nominate: book the 3-way M&G with the incoming carer ─────────────────────
+create or replace function public.admin_nominate_handover(
+  p_request_id          uuid,
+  p_provider_profile_id uuid,
+  p_service_id          uuid,
+  p_mg_scheduled_at     timestamptz
+) returns uuid language plpgsql security definer set search_path = public as $$
+declare
+  rq  public.carer_requests%rowtype;
+  s   public.booking_series%rowtype;
+  pp  public.provider_profiles%rowtype;
+  svc public.provider_services%rowtype;
+  cur_type text;
+  v_mg_id  uuid;
+begin
+  select * into rq from public.carer_requests where id = p_request_id;
+  if not found then raise exception 'Lead % not found', p_request_id; end if;
+  if rq.status in ('transitioned', 'lost', 'closed') then
+    raise exception 'Lead % is already resolved (%)', p_request_id, rq.status;
+  end if;
+  if rq.assigned_series_id is null then
+    raise exception 'Lead % has no booking series to hand over', p_request_id;
+  end if;
+
+  select * into s from public.booking_series where id = rq.assigned_series_id;
+  if not found then raise exception 'Series % not found', rq.assigned_series_id; end if;
+  if s.status <> 'active' then
+    raise exception 'Series % is not active (%) — handover applies to a running series', s.id, s.status;
+  end if;
+
+  select * into pp from public.provider_profiles where id = p_provider_profile_id;
+  if not found then raise exception 'Carer profile % not found', p_provider_profile_id; end if;
+  if not pp.is_active or not pp.is_verified then
+    raise exception 'Nominee must be an active, verified carer';
+  end if;
+  -- Hard requirement: without a payouts-ready connected account, the first post-handover
+  -- completion charge fails in charge-booking.
+  if pp.stripe_account_id is null or not coalesce(pp.payouts_enabled, false) then
+    raise exception 'Nominee has no payouts-ready Stripe account yet';
+  end if;
+
+  select * into svc from public.provider_services where id = p_service_id;
+  if not found then raise exception 'Service % not found', p_service_id; end if;
+  if svc.provider_id <> pp.user_id then
+    raise exception 'Service % does not belong to the nominee', p_service_id;
+  end if;
+  if not svc.is_available or svc.price_cents is null then
+    raise exception 'Nominee service is unavailable or has no price';
+  end if;
+  select ps.service_type into cur_type from public.provider_services ps where ps.id = s.service_id;
+  if cur_type is not null and svc.service_type <> cur_type then
+    raise exception 'Nominee service type (%) does not match the series (%)', svc.service_type, cur_type;
+  end if;
+
+  -- The 3-way M&G: same series, incoming carer as provider. Seeds the owner↔carer
+  -- conversation and, once completed, satisfies the provider-matched gate for the pair.
+  insert into public.bookings (
+    customer_id, provider_id, pet_id, service_id, status,
+    scheduled_at, duration_mins, total_cents, is_meet_and_greet, series_id
+  ) values (
+    s.customer_id, pp.id,
+    (select sp.pet_id from public.series_pets sp where sp.series_id = s.id limit 1),
+    p_service_id, 'confirmed', p_mg_scheduled_at, 30, 0, true, s.id
+  ) returning id into v_mg_id;
+
+  insert into public.booking_pets (booking_id, pet_id)
+  select v_mg_id, sp.pet_id from public.series_pets sp where sp.series_id = s.id;
+
+  update public.carer_requests set
+    handover_provider_id   = pp.id,
+    handover_service_id    = p_service_id,
+    handover_mg_booking_id = v_mg_id,
+    status                 = 'meet_greet_booked'
+  where id = p_request_id;
+
+  return v_mg_id;
+end; $$;
+
+revoke all on function public.admin_nominate_handover(uuid, uuid, uuid, timestamptz) from public, anon, authenticated;
+grant execute on function public.admin_nominate_handover(uuid, uuid, uuid, timestamptz) to service_role;
+
+-- ── complete: transition the series to the nominee at their listed rate ───────
+create or replace function public.admin_complete_handover(
+  p_request_id  uuid,
+  p_resolved_by uuid
+) returns integer language plpgsql security definer set search_path = public as $$
+declare
+  rq        public.carer_requests%rowtype;
+  s         public.booking_series%rowtype;
+  svc       public.provider_services%rowtype;
+  mg_status text;
+  v_pets    int;
+  v_price   int;
+  v_moved   int;
+begin
+  select * into rq from public.carer_requests where id = p_request_id;
+  if not found then raise exception 'Lead % not found', p_request_id; end if;
+  if rq.status in ('transitioned', 'lost', 'closed') then
+    raise exception 'Lead % is already resolved (%)', p_request_id, rq.status;
+  end if;
+  if rq.handover_provider_id is null or rq.handover_service_id is null or rq.handover_mg_booking_id is null then
+    raise exception 'Lead % has no nominated handover', p_request_id;
+  end if;
+
+  select status into mg_status from public.bookings where id = rq.handover_mg_booking_id;
+  if mg_status = 'cancelled' then
+    raise exception 'The 3-way meet & greet was cancelled — nominate again';
+  end if;
+  -- The founder is at the 3-way meet; completing the handover completes the M&G
+  -- (the owner-side banner only renders for pending_meet_greet series).
+  if mg_status <> 'completed' then
+    update public.bookings
+       set status = 'completed', completed_at = now(), updated_at = now()
+     where id = rq.handover_mg_booking_id;
+  end if;
+
+  select * into s from public.booking_series where id = rq.assigned_series_id;
+  if not found then raise exception 'Series % not found', rq.assigned_series_id; end if;
+
+  select * into svc from public.provider_services where id = rq.handover_service_id;
+  if not found or svc.price_cents is null then
+    raise exception 'Nominee service is missing or unpriced';
+  end if;
+  select count(*) into v_pets from public.series_pets where series_id = s.id;
+  v_price := svc.price_cents + greatest(0, v_pets - 1) * coalesce(svc.additional_pet_price_cents, 0);
+
+  -- Repoint the series: future materialisation (generate_series_bookings copies
+  -- provider_id + locked_price_cents) is automatically at the new carer's rate.
+  update public.booking_series set
+    provider_id        = rq.handover_provider_id,
+    service_id         = rq.handover_service_id,
+    locked_price_cents = v_price
+  where id = s.id;
+
+  -- Reassign future, not-yet-walked bookings at the new rate. Completed founder walks
+  -- keep provider/price history untouched (TRU-139 pattern via original_provider_id).
+  update public.bookings b set
+    original_provider_id = coalesce(b.original_provider_id, b.provider_id),
+    provider_id          = rq.handover_provider_id,
+    service_id           = rq.handover_service_id,
+    total_cents          = v_price,
+    duration_mins        = coalesce(svc.duration_mins, b.duration_mins),
+    updated_at           = now()
+  where b.series_id = s.id
+    and not coalesce(b.is_meet_and_greet, false)
+    and b.scheduled_at > now()
+    and b.status in ('pending', 'confirmed');
+  get diagnostics v_moved = row_count;
+
+  update public.carer_requests set
+    status               = 'transitioned',
+    assigned_provider_id = rq.handover_provider_id,
+    resolved_at          = now(),
+    resolved_by          = p_resolved_by
+  where id = p_request_id;
+
+  return v_moved;
+end; $$;
+
+revoke all on function public.admin_complete_handover(uuid, uuid) from public, anon, authenticated;
+grant execute on function public.admin_complete_handover(uuid, uuid) to service_role;

--- a/supabase/migrations/20260718000000_tru226_browse_capture.sql
+++ b/supabase/migrations/20260718000000_tru226_browse_capture.sql
@@ -1,0 +1,129 @@
+-- TRU-226: capture leads from the BOTTOM of a non-empty results list, flagged by source.
+--
+-- The TRU-216 capture flow only triggered on zero-result searches. An owner who scrolls a
+-- full list and thinks "still not it" is an equally valuable lead — but the flag matters:
+-- that lead exists DESPITE available carers (a fit/quality gap), not because of a supply
+-- gap. So:
+--   • carer_requests.capture_trigger records the source (named capture_trigger, not
+--     "trigger" — TRIGGER is a SQL keyword and unquoted use invites tooling papercuts):
+--       no_carers       — true area-zero (default; also all pre-existing rows)
+--       filtered_out    — carers exist but the owner's filters excluded them all
+--       browsed_unhappy — saw the list, clicked "Can't see an option that suits you?"
+--   • carer_requests.results_seen — how many carers the search returned (server-side
+--     count, pre client filters). Per-suburb supply-QUALITY signal for recruitment.
+--   • submit_carer_request replaced (dropped + recreated, never overloaded — PostgREST
+--     named-arg dispatch 300s on ambiguous overloads) with p_trigger + p_results_seen,
+--     both defaulted so the cached live page keeps working between migration and deploy.
+--
+-- Applied to the live DB via apply_migration (Supabase branching is broken on this repo);
+-- committed here for version control (see TRU-145). 14-digit unique prefix.
+
+alter table public.carer_requests
+  add column if not exists capture_trigger text not null default 'no_carers'
+    check (capture_trigger in ('no_carers','filtered_out','browsed_unhappy')),
+  add column if not exists results_seen int;
+
+drop function if exists public.submit_carer_request(text,text,date,boolean,text,text,text,boolean,uuid,text,text,text,jsonb,text,text,text,text,text,text[]);
+
+create function public.submit_carer_request(
+  p_suburb          text    default null,
+  p_service_type    text    default null,
+  p_wanted_date     date    default null,
+  p_recurring       boolean default false,
+  p_window_start    text    default null,
+  p_window_end      text    default null,
+  p_dog_size        text    default null,
+  p_puppy           boolean default false,
+  p_pet_id          uuid    default null,
+  p_contact_name    text    default null,
+  p_contact_email   text    default null,
+  p_note            text    default null,
+  p_search_params   jsonb   default null,
+  p_contact_phone   text    default null,
+  p_dog_name        text    default null,
+  p_dog_breed       text    default null,
+  p_dog_temperament text    default null,
+  p_frequency       text    default null,
+  p_preferred_times text[]  default null,
+  p_trigger         text    default 'no_carers',
+  p_results_seen    int     default null
+) returns uuid
+language plpgsql security definer set search_path = public as $$
+declare
+  v_customer_id uuid;
+  v_pet_id      uuid := null;
+  v_phone       text;
+  v_frequency   text;
+  v_trigger     text;
+  v_times       text[];
+  v_id          uuid;
+begin
+  select cp.id into v_customer_id
+  from public.customer_profiles cp
+  where cp.user_id = auth.uid();
+
+  -- The founder call is the product: every lead needs a phone number.
+  v_phone := nullif(trim(coalesce(p_contact_phone, '')), '');
+  if v_phone is null then
+    raise exception 'contact_phone is required';
+  end if;
+
+  -- Guests must also leave an email (confirmation email + account invite).
+  if v_customer_id is null and coalesce(trim(p_contact_email), '') = '' then
+    raise exception 'contact_email is required for guest requests';
+  end if;
+
+  -- Only accept a pet_id that actually belongs to the caller (defends the assign path).
+  if p_pet_id is not null and v_customer_id is not null then
+    select pt.id into v_pet_id
+    from public.pets pt
+    where pt.id = p_pet_id and pt.customer_id = v_customer_id;
+  end if;
+
+  -- Whitelist enumerated inputs rather than trusting the client.
+  v_frequency := nullif(trim(coalesce(p_frequency, '')), '');
+  if v_frequency is not null
+     and v_frequency not in ('one_off','weekly','few_per_week','daily') then
+    raise exception 'invalid frequency %', v_frequency;
+  end if;
+  v_trigger := coalesce(nullif(trim(coalesce(p_trigger, '')), ''), 'no_carers');
+  if v_trigger not in ('no_carers','filtered_out','browsed_unhappy') then
+    raise exception 'invalid trigger %', v_trigger;
+  end if;
+  v_times := (
+    select coalesce(array_agg(t), '{}')
+    from unnest(coalesce(p_preferred_times, '{}')) as t
+    where t in ('morning','midday','afternoon','evening')
+  );
+
+  insert into public.carer_requests (
+    customer_id, pet_id, contact_name, contact_email, contact_phone, suburb, service_type,
+    wanted_date, recurring, window_start, window_end, dog_size, puppy,
+    dog_name, dog_breed, dog_temperament_note, frequency, preferred_times,
+    capture_trigger, results_seen, note, search_params
+  ) values (
+    v_customer_id, v_pet_id,
+    nullif(trim(coalesce(p_contact_name, '')), ''),
+    nullif(trim(coalesce(p_contact_email, '')), ''),
+    v_phone,
+    nullif(trim(coalesce(p_suburb, '')), ''),
+    nullif(trim(coalesce(p_service_type, '')), ''),
+    p_wanted_date, coalesce(p_recurring, false),
+    nullif(trim(coalesce(p_window_start, '')), ''),
+    nullif(trim(coalesce(p_window_end, '')), ''),
+    nullif(trim(coalesce(p_dog_size, '')), ''),
+    coalesce(p_puppy, false),
+    nullif(trim(coalesce(p_dog_name, '')), ''),
+    nullif(trim(coalesce(p_dog_breed, '')), ''),
+    nullif(trim(coalesce(p_dog_temperament, '')), ''),
+    v_frequency, v_times,
+    v_trigger, p_results_seen,
+    nullif(trim(coalesce(p_note, '')), ''),
+    p_search_params
+  ) returning id into v_id;
+
+  return v_id;
+end; $$;
+
+revoke all on function public.submit_carer_request(text,text,date,boolean,text,text,text,boolean,uuid,text,text,text,jsonb,text,text,text,text,text,text[],text,int) from public;
+grant execute on function public.submit_carer_request(text,text,date,boolean,text,text,text,boolean,uuid,text,text,text,jsonb,text,text,text,text,text,text[],text,int) to anon, authenticated;


### PR DESCRIPTION
Recovery PR — no new code. PRs #106, #107, #108 and #109 were each merged into their **parent branch** instead of main (the stacked bases only retarget to main if each branch is deleted at merge — they weren't). Only #105 actually landed on main, which is why the deployed site is missing the admin pipeline board, the conversion/handover console, and the TRU-226 bottom-of-results CTA.

`claude/tru-225-handover` now carries the entire stack's content (#106 + #107 + #108 + #109, all individually reviewed and CI-green on their own PRs). This PR lands it on main in one go. The live DB and edge functions are already at this tip, so merging this only affects the site deploy + repo history.

After merge, the stale stack branches should be deleted (I'll do that) so this can't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)