### PR TITLE
TRU-120: Email QA sweep, plain-text alternatives, and a brand-token drift guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,60 @@ jobs:
           done
           exit $status
 
+  email-tokens:
+    name: Email brand tokens in sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      # TRU-120: production transactional email renders in the edge function, not from
+      # the React Email workspace (nothing imports renderEmail — see emails/RUNBOOK.md),
+      # so the brand tokens exist in two runtimes that can't share a module. They had
+      # already drifted once (the edge function's body font lost 'DM Sans'). Keep them
+      # honest here instead of introducing a build step into a no-build repo.
+      - name: Compare emails/lib/theme.ts with _shared/email-theme.ts
+        run: |
+          python3 - <<'PY'
+          import pathlib, re, sys
+
+          FILES = {
+              'emails/lib/theme.ts': pathlib.Path('emails/lib/theme.ts'),
+              'supabase/functions/_shared/email-theme.ts': pathlib.Path('supabase/functions/_shared/email-theme.ts'),
+          }
+
+          def tokens(path):
+              src = path.read_text(encoding='utf-8')
+              colors = dict(re.findall(r"(\w+):\s*'(#[0-9A-Fa-f]{6})'", src))
+              fonts = {}
+              for name in ('fontHeading', 'fontBody'):
+                  m = re.search(rf'export const {name}\s*=\s*([\s\S]*?);', src)
+                  if not m:
+                      print(f'::error file={path}::missing export {name}')
+                      sys.exit(1)
+                  # Collapse the line break the formatter puts after `=`.
+                  fonts[name] = ' '.join(m.group(1).split())
+              return colors, fonts
+
+          (ca, fa), (cb, fb) = (tokens(p) for p in FILES.values())
+          a_name, b_name = FILES.keys()
+          failed = False
+
+          for key in sorted(set(ca) | set(cb)):
+              va, vb = ca.get(key), cb.get(key)
+              if va != vb:
+                  print(f'::error::colour "{key}" differs — {a_name}={va!r} vs {b_name}={vb!r}')
+                  failed = True
+
+          for key in ('fontHeading', 'fontBody'):
+              if fa[key] != fb[key]:
+                  print(f'::error::{key} differs\n  {a_name}: {fa[key]}\n  {b_name}: {fb[key]}')
+                  failed = True
+
+          if failed:
+              print('\nEmail brand tokens have drifted. Update both files so they match.')
+              sys.exit(1)
+          print(f'ok   {len(ca)} colours + 2 font stacks identical in both files')
+          PY
+
   migrations:
     name: Migration filename sanity
     runs-on: ubuntu-latest

--- a/emails/README.md
+++ b/emails/README.md
@@ -21,9 +21,33 @@ shared layout in use.
   palette, typography, button, footer) plus `Heading` / `Paragraph` / `Details`
   content helpers. Every template imports this.
 - `lib/theme.ts` — brand colour + font tokens (mirrors the marketing palette).
-- `lib/render.ts` — `renderEmail(element)` → HTML string for the send call
-  (Resend / Supabase auth / the sending Edge Function in TRU-118).
+- `lib/render.ts` — `renderEmail(element)` → HTML string. Used when exporting
+  auth-email HTML to paste into Supabase; **not** used by the sending pipeline.
 - `emails/` — individual templates (one default-exported component each).
+- `RUNBOOK.md` — how production email actually sends, the DNS/deliverability
+  picture, and how to run the QA sweep. **Read this before QA'ing anything.**
+
+## What this workspace is (and isn't) used for
+
+It is the design surface and the source of the **auth** email HTML (TRU-119).
+
+It is **not** what sends your transactional email. The pipeline built in TRU-118
+renders its own branded HTML inline inside
+`supabase/functions/send-notification/index.ts` — a Deno port of the layout below —
+because edge functions can't import this npm/React workspace. Nothing in
+`supabase/` imports `renderEmail`.
+
+Two practical consequences:
+
+1. **Previewing a template here does not QA production email.** Use the sweep in
+   `RUNBOOK.md`, which sends through the real path.
+2. **Brand tokens exist twice** — here in `lib/theme.ts` and in
+   `supabase/functions/_shared/email-theme.ts`. Change one, change the other; the
+   CI job "Email brand tokens in sync" fails the build if they diverge.
+
+Four production emails (`payment_failed`, `cover_cancellation`, and both
+`carer_request` messages) have no React template here at all — they exist only in
+the edge function.
 
 ## Fonts
 
@@ -42,10 +66,16 @@ const html = await renderEmail(<BookingConfirmed /* props */ />);
 // pass { plainText: true } for the text/plain alternative
 ```
 
-## Next
+## Status
 
-- TRU-117 — the 5 transactional templates on top of this layout.
-- TRU-119 — auth email rebrand (paste rendered HTML into Supabase auth template
-  fields, keeping Supabase's `{{ .ConfirmationURL }}` etc.).
-- TRU-118 — sending pipeline (Supabase webhook → Edge Function → Resend) that
-  calls `renderEmail`.
+Shipped: TRU-116 (this layout), TRU-117 (the 5 transactional templates),
+TRU-118 (sending pipeline — note it renders inline, see above), TRU-119 (auth
+email rebrand), TRU-120 (plain-text alternatives, token drift guard, QA sweep).
+
+Open follow-ups:
+
+- React templates for the four emails that currently exist only as inline HTML in
+  the edge function.
+- Auth email HTML is still pasted into the Supabase dashboard by hand — unversioned
+  and invisible to CI (`RUNBOOK.md` → "Still manual").
+- TRU-115 — point Supabase custom SMTP at Resend (dashboard task).

--- a/emails/RUNBOOK.md
+++ b/emails/RUNBOOK.md
@@ -1,0 +1,117 @@
+# Email runbook (TRU-120)
+
+Operational reference for Truffl's email: where it actually sends from, how to QA
+it, and what's still manual. None of this was written down before — it had to be
+read off live DNS and the deployed function.
+
+## Where email actually renders — read this first
+
+There are **two** rendering paths and they are not the same code:
+
+| | Renders | Used for |
+|---|---|---|
+| `supabase/functions/send-notification/index.ts` | inline `layout()` / `p()` / `detailsTable()` helpers | **all production transactional email** |
+| `emails/` (React Email) | `components/TrufflEmailLayout.tsx` | design preview + the **auth** email HTML that gets pasted into Supabase |
+
+Nothing imports `emails/lib/render.ts` — `renderEmail` has zero callers. So
+**QA'ing the React previews checks HTML that never ships.** Always QA via the
+sweep below, which sends through the production path.
+
+Brand tokens therefore live in two runtimes that can't share a module:
+`emails/lib/theme.ts` and `supabase/functions/_shared/email-theme.ts`. They had
+already drifted once (the edge function's body font had lost `'DM Sans'`). CI job
+**"Email brand tokens in sync"** fails the build if they stop matching — if you
+change a colour or font, change both files.
+
+## Sending setup (verified live)
+
+- **Provider:** Resend. `FROM = Truffl Pets <notifications@trufflpets.com>`,
+  `REPLY_TO = support@trufflpets.com` (both in `index.ts`).
+- **Free tier:** 3,000/month, **100/day**. A full QA sweep is ~10 emails, so
+  don't loop it. `sendEmail()` retries only on HTTP 429, 4 attempts, linear backoff.
+- **Every message now ships `html` + `text`** (TRU-120). The text part is derived
+  from the HTML by `_shared/email-text.ts`.
+
+### DNS (nameservers: Porkbun — *not* Cloudflare)
+
+| Record | Value | Purpose |
+|---|---|---|
+| `MX trufflpets.com` | `1 smtp.google.com` | **Inbound** → Google Workspace. This is why `support@` reaches the founder inbox. |
+| `TXT trufflpets.com` | `v=spf1 include:_spf.porkbun.com ~all` | Apex SPF. Does **not** list Resend — correct, see below. |
+| `TXT resend._domainkey.trufflpets.com` | `p=MIGfMA0…` | Resend DKIM, signs `d=trufflpets.com`. |
+| `TXT send.trufflpets.com` | `v=spf1 include:amazonses.com ~all` | SPF for the **Return-Path** domain. |
+| `MX send.trufflpets.com` | `10 feedback-smtp.ap-northeast-1.amazonses.com` | Bounce/complaint handling. |
+| `TXT _dmarc.trufflpets.com` | `v=DMARC1; p=none;` | Monitor only, **no reporting address**. |
+
+Why the apex SPF doesn't mention Resend, and why that's fine: Resend sends with a
+Return-Path on `send.trufflpets.com`, so SPF is evaluated against *that* domain
+(→ `amazonses.com`, passes). DMARC then aligns via **DKIM**, which signs for the
+apex and matches the `From:` header domain. So SPF, DKIM and DMARC all pass.
+
+**Recommended next (Tom's DNS):** add a reporting address so failures are visible
+before tightening policy —
+`v=DMARC1; p=none; rua=mailto:dmarc@trufflpets.com; fo=1` — then consider
+`p=quarantine` once reports look clean for a few weeks.
+
+## Running the QA sweep
+
+Fires **every** production message body at one address, rendered by the real
+production code. It reuses existing rows and **writes nothing**, so there is no
+test data to clean up afterwards.
+
+Recipients are allowlisted: the address must belong to a `users.is_admin = true`
+user, or appear in the optional `QA_EMAIL_ALLOWLIST` function secret
+(comma-separated). Anything else returns 400 — so a leaked `WEBHOOK_SECRET`
+still can't turn this into an open relay. Subjects are prefixed `[QA]`.
+
+From the SQL editor (no secret handling — it reads the config row):
+
+```sql
+select net.http_post(
+  url     := (select function_url from private.email_config where id = 1),
+  headers := jsonb_build_object(
+               'Content-Type', 'application/json',
+               'x-webhook-secret', (select webhook_secret from private.email_config where id = 1)
+             ),
+  body    := jsonb_build_object('type', 'preview', 'to', 'you@example.com'),
+  -- REQUIRED: the sweep sends ~10 emails sequentially and takes 10-15s.
+  -- pg_net's default timeout is 5s, so without this the call is recorded as a
+  -- client-side timeout even though the function ran fine and the mail went out.
+  timeout_milliseconds := 60000
+);
+-- then, ~15s later (pg_net only writes the response after the calling txn commits):
+select status_code, content from net._http_response order by created desc limit 1;
+```
+
+The response reports `sent`, `allOk`, and a `skipped` list. HTTP **200 is only
+returned when every send succeeded**; a partial failure returns 502 with the
+per-message detail. A type is skipped when no source row exists yet (e.g.
+`cover_cancellation` before any walk has gone through the cover flow) — that's
+expected, not a failure.
+
+Because the sweep sends one message per production body, it costs ~10 of the
+100/day Resend allowance. Don't loop it.
+
+### What to check in each client (Gmail, Outlook, Apple Mail)
+
+- Layout holds; wordmark, terracotta button and cream background render.
+- **Headings fall back to Georgia** — Gmail strips web fonts, so Cormorant
+  Garamond will not load. That's by design; it must still look right.
+- Details tables align; CTA button is tappable on mobile width.
+- Message lands in the **primary inbox**, not Promotions/Spam.
+- View source → confirm a `text/plain` part exists alongside the HTML.
+- Received headers → `spf=pass`, `dkim=pass`, `dmarc=pass`.
+
+## Still manual (not code)
+
+- **TRU-115 — Supabase custom SMTP → Resend.** Dashboard-only; `supabase/config.toml`
+  has no `[auth]` block to change. In Supabase → Project Settings → Authentication →
+  SMTP Settings: host `smtp.resend.com`, port `465`, username `resend`, password =
+  a Resend API key, sender `notifications@trufflpets.com`, sender name `Truffl Pets`.
+  Without this, auth email uses Supabase's built-in sender, which is rate-limited to
+  a couple of emails an hour and only delivers to team addresses — unusable in production.
+- **Auth email templates** are exported from `emails/` and pasted by hand into
+  Supabase → Authentication → Email Templates (TRU-119). They are **not** versioned
+  or covered by CI; re-paste after any layout change. Supabase's `{{ .ConfirmationURL }}`
+  style variables must survive the paste intact.
+- **DMARC `rua=` / `p=quarantine`** — see above.

--- a/supabase/functions/_shared/email-text.ts
+++ b/supabase/functions/_shared/email-text.ts
@@ -1,0 +1,70 @@
+// Plain-text alternative for outgoing email (TRU-120).
+//
+// Every production email was sending `html` only. A missing text/plain part is a
+// real spam-score signal (and the only thing plain-text clients and some
+// accessibility tooling can read), so sendEmail() now derives one from the same
+// HTML it ships.
+//
+// This is a deliberately small converter, not a general-purpose one: it only has
+// to handle the markup our own layout()/p()/detailsTable() helpers emit —
+// headings, paragraphs, a details table, a CTA button, and the footer links.
+
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: '&', lt: '<', gt: '>', quot: '"', apos: "'",
+  nbsp: ' ', mdash: '—', ndash: '–', middot: '·', hellip: '…',
+  lsquo: '‘', rsquo: '’', ldquo: '“', rdquo: '”',
+  copy: '©', reg: '®', trade: '™', pound: '£', euro: '€', deg: '°',
+};
+
+function decode(s: string): string {
+  return s.replace(/&(#x[0-9A-Fa-f]+|#\d+|[A-Za-z][A-Za-z0-9]*);/g, (m, body: string) => {
+    if (body[0] === '#') {
+      const code = body[1] === 'x' || body[1] === 'X'
+        ? parseInt(body.slice(2), 16)
+        : parseInt(body.slice(1), 10);
+      return Number.isFinite(code) && code > 0 ? String.fromCodePoint(code) : m;
+    }
+    return NAMED_ENTITIES[body.toLowerCase()] ?? m; // leave anything unknown as-is
+  });
+}
+
+// Strip tags to a SPACE, not to nothing: the layout puts the wordmark in two
+// adjacent <span>s, which would otherwise read as "trufflPETS".
+function stripTags(s: string): string {
+  return s.replace(/<[^>]+>/g, ' ');
+}
+
+export function htmlToText(html: string): string {
+  let s = html;
+
+  // Drop anything that has no readable text content.
+  s = s.replace(/<!DOCTYPE[^>]*>/gi, '');
+  s = s.replace(/<(head|style|script|title)\b[^>]*>[\s\S]*?<\/\1>/gi, '');
+  // The preview-text div is hidden in clients; it would read as a duplicate heading.
+  s = s.replace(/<div style="display:none[^"]*"[^>]*>[\s\S]*?<\/div>/gi, '');
+
+  // Keep links as "label (url)" so the CTA is still actionable in plain text.
+  s = s.replace(
+    /<a\b[^>]*href="([^"]*)"[^>]*>([\s\S]*?)<\/a>/gi,
+    (_m, href: string, label: string) => {
+      const text = decode(stripTags(label)).replace(/\s+/g, ' ').trim();
+      const url = decode(href).trim();
+      if (!url || url === text) return text;
+      return text ? `${text} (${url})` : url;
+    },
+  );
+
+  // Table rows become "label: value" lines; other block ends become newlines.
+  s = s.replace(/<\/t[dh]>\s*<t[dh]\b[^>]*>/gi, ': ');
+  s = s.replace(/<\/(tr|p|h[1-6]|div|table|li)>/gi, '\n');
+  s = s.replace(/<br\s*\/?>/gi, '\n');
+  s = s.replace(/<hr\s*\/?>/gi, '\n---\n');
+
+  s = decode(stripTags(s));
+
+  // Tidy whitespace: collapse runs of spaces, trim each line, cap blank lines.
+  s = s.split('\n').map((line) => line.replace(/[^\S\n]+/g, ' ').trim()).join('\n');
+  s = s.replace(/\n{3,}/g, '\n\n').trim();
+
+  return s;
+}

--- a/supabase/functions/_shared/email-theme.ts
+++ b/supabase/functions/_shared/email-theme.ts
@@ -1,0 +1,36 @@
+// Truffl Pets email brand tokens — the Deno-side source of truth (TRU-120).
+//
+// Production transactional email is rendered by send-notification's own layout()
+// helpers, NOT by the React Email workspace in emails/ (nothing imports
+// renderEmail — see emails/RUNBOOK.md). That leaves two places defining the
+// brand, and they had already drifted: the edge function's body font stack was
+// missing 'DM Sans'. This module is the single place the edge function reads
+// tokens from, and CI (.github/workflows/ci.yml, "Email brand tokens in sync")
+// fails the build if these values stop matching emails/lib/theme.ts.
+//
+// Keep in lockstep with emails/lib/theme.ts. If you change a token, change both.
+
+export const colors = {
+  cream: '#F7F3EE',
+  warm: '#EDE7DC',
+  sage: '#C8D5C0',
+  sageDark: '#8A9E82',
+  blush: '#E8D5CC',
+  terracotta: '#C4866A',
+  terracottaDark: '#B8795C',
+  brown: '#5C4033',
+  brownDeep: '#3A2E28',
+  text: '#3A2E28',
+  textMid: '#7A6860',
+  textLight: '#A8978E',
+  border: '#E7DFD6', // solid equivalent of rgba(92,64,51,0.12) for email clients
+  white: '#FFFFFF',
+} as const;
+
+// Heading: brand serif, falling back to Georgia (a near-universal serif).
+export const fontHeading =
+  "'Cormorant Garamond', Georgia, 'Times New Roman', serif";
+
+// Body: brand sans, falling back to a robust system sans stack.
+export const fontBody =
+  "'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif";

--- a/supabase/functions/send-notification/index.ts
+++ b/supabase/functions/send-notification/index.ts
@@ -10,11 +10,16 @@
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { timingSafeEqual } from '../_shared/secret.ts';
+import { colors, fontBody, fontHeading } from '../_shared/email-theme.ts';
+import { htmlToText } from '../_shared/email-text.ts';
 
 const RESEND_API_KEY = Deno.env.get('RESEND_API_KEY')!;
 const WEBHOOK_SECRET = Deno.env.get('WEBHOOK_SECRET')!;
 const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
 const SERVICE_ROLE = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+// TRU-120: extra addresses the QA sweep may send to, beyond site admins.
+// Comma-separated; unset in normal operation.
+const QA_EMAIL_ALLOWLIST = Deno.env.get('QA_EMAIL_ALLOWLIST') ?? '';
 
 const FROM = 'Truffl Pets <notifications@trufflpets.com>';
 const REPLY_TO = 'support@trufflpets.com'; // TRU-114 forwarding
@@ -45,10 +50,12 @@ function fmtWhen(iso: string | null, mins?: number | null): string {
 }
 
 // ── Branded layout (Deno port of TrufflEmailLayout; keep visually in sync) ──
+// Tokens come from _shared/email-theme.ts, which CI keeps identical to
+// emails/lib/theme.ts — see that file's header (TRU-120).
 function layout(opts: { preview: string; heading: string; body: string; cta?: { label: string; href: string }; footnote?: string }): string {
-  const C = { cream: '#F7F3EE', white: '#FFFFFF', border: '#E7DFD6', brown: '#5C4033', terracotta: '#C4866A', terracottaDark: '#B8795C', text: '#3A2E28', textMid: '#7A6860', textLight: '#A8978E' };
-  const headingFont = "'Cormorant Garamond', Georgia, 'Times New Roman', serif";
-  const bodyFont = "-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif";
+  const C = colors;
+  const headingFont = fontHeading;
+  const bodyFont = fontBody;
   return `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
 <body style="margin:0;padding:24px 0;background:${C.cream};font-family:${bodyFont};">
 <div style="display:none;max-height:0;overflow:hidden;opacity:0;">${esc(opts.preview)}</div>
@@ -419,13 +426,105 @@ async function buildMessages(type: string, payload: Record<string, unknown>) {
   return out;
 }
 
+// ── TRU-120: QA sweep ──
+// Fires every production message body at one allowlisted address so the
+// cross-client / deliverability pass can be done in a single sweep.
+//
+// Deliberately NOT a set of hand-written preview templates: it calls the real
+// buildMessages() against rows that already exist and only overrides the
+// recipient. That way the sweep exercises the true production renderer AND the
+// real data resolution — a preview with its own copy of the bodies would drift
+// from production and QA the wrong HTML, which is the whole trap this ticket
+// exists to avoid. It writes nothing, so there is no test data to clean up.
+
+async function previewAllowed(to: string): Promise<boolean> {
+  const addr = to.trim().toLowerCase();
+  if (!addr) return false;
+  if (QA_EMAIL_ALLOWLIST.split(',').map((a) => a.trim().toLowerCase()).filter(Boolean).includes(addr)) {
+    return true;
+  }
+  const { data } = await sb.from('users').select('email').eq('is_admin', true);
+  return (data ?? []).some((u: { email: string | null }) => (u.email ?? '').toLowerCase() === addr);
+}
+
+// Find one representative row per event type. Anything with no suitable row is
+// reported as skipped rather than failing the sweep.
+async function previewSources(): Promise<{ type: string; payload: Record<string, unknown> }[]> {
+  const out: { type: string; payload: Record<string, unknown> }[] = [];
+
+  const { data: booking } = await sb.from('bookings')
+    .select('id').eq('is_meet_and_greet', false).order('created_at', { ascending: false }).limit(1).maybeSingle();
+  if (booking) {
+    out.push({ type: 'booking_request', payload: { booking_id: booking.id } });
+    out.push({ type: 'booking_confirmed', payload: { booking_id: booking.id } });
+    out.push({ type: 'payment_failed', payload: { booking_id: booking.id } });
+  }
+
+  // Cover alerts need a booking that actually went through the cover flow.
+  const { data: covered } = await sb.from('bookings')
+    .select('id').neq('cover_status', 'none').order('created_at', { ascending: false }).limit(1).maybeSingle();
+  if (covered) out.push({ type: 'cover_cancellation', payload: { booking_id: covered.id } });
+
+  const { data: walk } = await sb.from('walk_sessions')
+    .select('id').order('created_at', { ascending: false }).limit(1).maybeSingle();
+  if (walk) {
+    out.push({ type: 'walk_started', payload: { walk_session_id: walk.id } });
+    out.push({ type: 'walk_completed', payload: { walk_session_id: walk.id } });
+  }
+
+  const { data: message } = await sb.from('messages')
+    .select('id').order('created_at', { ascending: false }).limit(1).maybeSingle();
+  if (message) out.push({ type: 'new_message', payload: { message_id: message.id } });
+
+  const { data: lead } = await sb.from('carer_requests')
+    .select('id').order('created_at', { ascending: false }).limit(1).maybeSingle();
+  if (lead) out.push({ type: 'carer_request', payload: { request_id: lead.id } });
+
+  return out;
+}
+
+async function runPreviewSweep(to: string) {
+  const sources = await previewSources();
+  const results: { type: string; subject: string; ok: boolean; status?: number; error?: unknown }[] = [];
+  const skipped: string[] = [];
+
+  for (const src of sources) {
+    let messages;
+    try {
+      messages = await buildMessages(src.type, src.payload);
+    } catch (e) {
+      skipped.push(`${src.type} (${String((e as Error)?.message || e)})`);
+      continue;
+    }
+    if (!messages.length) { skipped.push(`${src.type} (no recipients resolved)`); continue; }
+    for (const m of messages) {
+      // Recipient forced to the QA address; [QA] prefix so a sweep is never
+      // mistaken for real mail landing in an admin inbox.
+      const r = await sendEmail({ ...m, to, subject: `[QA] ${m.subject}` });
+      results.push({ type: src.type, subject: m.subject, ok: r.ok, status: r.status, error: r.error ?? undefined });
+    }
+  }
+
+  const expected = ['booking_request', 'booking_confirmed', 'payment_failed', 'cover_cancellation',
+    'walk_started', 'walk_completed', 'new_message', 'carer_request'];
+  for (const t of expected) {
+    if (!sources.some((s) => s.type === t) && !skipped.some((s) => s.startsWith(t))) {
+      skipped.push(`${t} (no source row in the database)`);
+    }
+  }
+
+  return { to, sent: results.length, allOk: results.every((r) => r.ok), skipped, results };
+}
+
 // ── Resend send with retry on 429 ──
 async function sendEmail(msg: { to: string; subject: string; html: string; replyTo?: string }) {
   for (let attempt = 0; attempt < 4; attempt++) {
     const res = await fetch('https://api.resend.com/emails', {
       method: 'POST',
       headers: { Authorization: `Bearer ${RESEND_API_KEY}`, 'Content-Type': 'application/json' },
-      body: JSON.stringify({ from: FROM, reply_to: msg.replyTo || REPLY_TO, to: msg.to, subject: msg.subject, html: msg.html }),
+      // TRU-120: always ship a text/plain alternative alongside the HTML —
+      // html-only mail scores worse with spam filters.
+      body: JSON.stringify({ from: FROM, reply_to: msg.replyTo || REPLY_TO, to: msg.to, subject: msg.subject, html: msg.html, text: htmlToText(msg.html) }),
     });
     if (res.status !== 429) {
       const data = await res.json().catch(() => ({}));
@@ -446,6 +545,20 @@ Deno.serve(async (req) => {
 
   const type = String(payload.type || '');
   try {
+    // TRU-120 QA sweep. Guarded by the shared secret above AND an address
+    // allowlist, so a leaked secret still can't turn this into an open relay.
+    if (type === 'preview') {
+      const to = String(payload.to || '');
+      if (!(await previewAllowed(to))) {
+        return new Response(JSON.stringify({ error: 'Recipient not allowlisted for QA previews' }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } });
+      }
+      const summary = await runPreviewSweep(to);
+      return new Response(JSON.stringify(summary), {
+        status: summary.allOk ? 200 : 502, headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
     const messages = await buildMessages(type, payload);
     if (!messages.length) {
       return new Response(JSON.stringify({ skipped: true, type }), { status: 200, headers: { 'Content-Type': 'application/json' } });


### PR DESCRIPTION
Single PR off `main` (no stack this time).

The capture flow is live and its value depends entirely on email arriving — the founder alert fast enough for a same-day call, the lead confirmation in the **primary** inbox. Auditing that leg before QA'ing it turned up three things that would have made a naive pass invalid.

## What the audit found

1. **QA'ing the wrong HTML.** Production transactional email renders from inline `layout()`/`p()`/`detailsTable()` helpers inside `send-notification`. The `emails/` React Email workspace is **not wired into the pipeline** — `renderEmail` has zero callers anywhere in `supabase/`. So previewing templates in `emails/` checks HTML that never ships.
2. **Brand tokens hardcoded twice and already drifting** — the edge function's body font stack had lost `'DM Sans'` relative to `emails/lib/theme.ts`.
3. **No `text/plain` alternative on any send** — `sendEmail()` posted `html` only, a real spam-score cost.

## Changes

- **`_shared/email-theme.ts`** — single Deno-side token module (fixes the live font drift); `layout()` reads from it. New CI job **"Email brand tokens in sync"** fails the build if it and `emails/lib/theme.ts` diverge. Proven locally: passes clean, catches the original `'DM Sans'` drift, catches a colour change, passes again after revert.
- **`_shared/email-text.ts`** — `htmlToText()` scoped to the markup our layout emits: links kept as `label (url)` so the CTA stays actionable, table rows as `label: value`, hidden preview div dropped, numeric + named entities decoded, adjacent `<span>`s spaced (otherwise the wordmark reads `trufflPETS`). Every send now ships `text` alongside `html`.
- **QA sweep — `type: 'preview'`** — fires every production message body at one address. Crucially it calls the **real `buildMessages()`** against rows that already exist and only overrides the recipient, so it exercises the true renderer *and* the real data resolution. A preview with its own copy of the bodies would reintroduce exactly the drift this ticket is about. It **writes nothing**, so there's no test data to clean up.
  Security: guarded by the existing `x-webhook-secret` **and** an address allowlist (`users.is_admin` or the optional `QA_EMAIL_ALLOWLIST` secret) — a leaked secret still can't turn it into an open relay. Subjects prefixed `[QA]`.
- **`emails/RUNBOOK.md`** (new) — operational knowledge that was nowhere in the repo: real DNS topology (Porkbun nameservers, Google Workspace MX, Resend apex DKIM with `send.trufflpets.com` as Return-Path — which is *why* the apex SPF needn't list Resend and everything still aligns), how to run the sweep, what to check per client, the 100/day cap, the TRU-115 dashboard steps, and the DMARC `rua=`/`p=quarantine` recommendation.
- **`emails/README.md`** corrected — it claimed the TRU-118 pipeline "calls `renderEmail`" (it doesn't) and listed TRU-117/118/119 as "Next" though all three shipped.

## Verified live
- `deno check` clean on all 5 edge functions; deployed **send-notification v12**.
- Sweep via pg_net → **200 in 11.5s**, covering all **10** production message bodies (every source row type exists). 200 is only returned when `allOk` — i.e. every send succeeded.
- Allowlist guard → **400** for a non-allowlisted recipient, as designed.
- Gotcha found and documented: pg_net's default 5s timeout fires client-side on a ~12s sweep even though the function completes — the runbook's SQL sets `timeout_milliseconds := 60000`.
- Temp QA table dropped; no test rows anywhere.

## What's left for Tom (this is the actual ticket)
The sweep is sitting in **tom_farmery@hotmail.co.uk** (the only `is_admin` address) — that covers the **Outlook** leg. For **Gmail** and **Apple Mail**, add those addresses to a `QA_EMAIL_ALLOWLIST` function secret (comma-separated) and re-run the SQL in the runbook, or make them admins.

Per client, check: layout holds; headings fall back to **Georgia** (Gmail strips web fonts — by design, must still look right); details tables align; CTA tappable on mobile; lands in **primary**, not Promotions/Spam; view-source shows a `text/plain` part; headers show `spf=pass dkim=pass dmarc=pass`. Tell me what's off and I'll fix and re-sweep.

## Follow-ups (flagged on TRU-112, not done here)
React templates for the four bodies that exist only as inline HTML (`payment_failed`, `cover_cancellation`, both `carer_request`); versioning the hand-pasted auth-email HTML; DMARC enforcement (your DNS).

Linear: TRU-120. Also closes out TRU-114 — its Cloudflare Email Routing premise is moot (DNS is Porkbun, inbound already goes to Google Workspace, and you've confirmed `support@` reaches you).

🤖 Generated with [Claude Code](https://claude.com/claude-code)