### PR TITLE
TRU-57: build the iOS walk tracker, add camera/photo usage strings

### DIFF
--- a/MOBILE.md
+++ b/MOBILE.md
@@ -71,8 +71,21 @@ The app should boot straight into the live Truffl site.
 - **Bundle ID / app name** (`com.trufflpets.app`, "Truffl Pets") are placeholders
   pending **TRU-128**. Change `appId`/`appName` in `capacitor.config.json`, then
   `npx cap sync`, before any store submission.
-- **Background geolocation** on `/walk/` is **TRU-56** (separate plugin + native
-  permission setup) — out of scope here.
+- **Background geolocation** on `/walk/` is **TRU-56**, and is implemented natively on
+  both platforms rather than via a third-party plugin: `WalkTrackerPlugin` /
+  `WalkTrackingService` on Android, `TrufflWalkTracker.swift` on iOS. Both POST fixes
+  straight to `gps_pings` so tracking survives the JS being suspended.
+  `@capacitor-community/background-geolocation` was declared in `package.json` but linked
+  in neither build (absent from `CapApp-SPM/Package.swift` and `capacitor.settings.gradle`,
+  and `capacitor.build.gradle`'s dependency block was empty) — it was dead weight and has
+  been removed.
+- **Adding a native Swift file to the iOS target:** `npx cap sync` does *not* add source
+  files to `project.pbxproj`. A `.swift` file dropped into `ios/App/App/` will sit there
+  uncompiled and its plugin will be `undefined` in the WebView, failing silently. It needs
+  four entries in `project.pbxproj`: a `PBXFileReference`, a `PBXBuildFile`, membership of
+  the `App` `PBXGroup`, and the build-file ref in `PBXSourcesBuildPhase`. Adding the file
+  through Xcode's UI does all four. This is exactly how `TrufflWalkTracker.swift` came to
+  be committed but never built.
 - **Universal/App Links** (cold-opening a tapped `https://trufflpets.com/...` link
   from outside the app into the app) need an `apple-app-site-association` file and
   Android `assetlinks.json` hosted on the domain, plus associated-domains/intent

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		4D22ABE92AF431CB00220026 /* CapApp-SPM in Frameworks */ = {isa = PBXBuildFile; productRef = 4D22ABE82AF431CB00220026 /* CapApp-SPM */; };
 		50379B232058CBB4000EE86E /* capacitor.config.json in Resources */ = {isa = PBXBuildFile; fileRef = 50379B222058CBB4000EE86E /* capacitor.config.json */; };
 		504EC3081FED79650016851F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC3071FED79650016851F /* AppDelegate.swift */; };
+		7F5C3A1D2E4B00A1B2C30002 /* TrufflWalkTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F5C3A1D2E4B00A1B2C30001 /* TrufflWalkTracker.swift */; };
 		504EC30D1FED79650016851F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC30B1FED79650016851F /* Main.storyboard */; };
 		504EC30F1FED79650016851F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 504EC30E1FED79650016851F /* Assets.xcassets */; };
 		504EC3121FED79650016851F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC3101FED79650016851F /* LaunchScreen.storyboard */; };
@@ -22,6 +23,7 @@
 		50379B222058CBB4000EE86E /* capacitor.config.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = capacitor.config.json; sourceTree = "<group>"; };
 		504EC3041FED79650016851F /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		504EC3071FED79650016851F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		7F5C3A1D2E4B00A1B2C30001 /* TrufflWalkTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrufflWalkTracker.swift; sourceTree = "<group>"; };
 		504EC30C1FED79650016851F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		504EC30E1FED79650016851F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		504EC3111FED79650016851F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -64,6 +66,7 @@
 			children = (
 				50379B222058CBB4000EE86E /* capacitor.config.json */,
 				504EC3071FED79650016851F /* AppDelegate.swift */,
+				7F5C3A1D2E4B00A1B2C30001 /* TrufflWalkTracker.swift */,
 				504EC30B1FED79650016851F /* Main.storyboard */,
 				504EC30E1FED79650016851F /* Assets.xcassets */,
 				504EC3101FED79650016851F /* LaunchScreen.storyboard */,
@@ -156,6 +159,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				504EC3081FED79650016851F /* AppDelegate.swift in Sources */,
+				7F5C3A1D2E4B00A1B2C30002 /* TrufflWalkTracker.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -303,7 +307,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.trufflpets.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -325,7 +329,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.trufflpets.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -55,5 +55,9 @@
 	<array>
 		<string>location</string>
 	</array>
+	<key>NSCameraUsageDescription</key>
+	<string>Truffl uses your camera so you can take photos during a walk and add pictures to your profile and your pets.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Truffl needs access to your photos so you can choose an existing picture for your profile, your pets, or a walk update.</string>
 </dict>
 </plist>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,22 +8,12 @@
       "name": "truffl-pets-app",
       "version": "1.0.0",
       "dependencies": {
-        "@capacitor-community/background-geolocation": "^1.2.26",
         "@capacitor/android": "^8.4.2",
         "@capacitor/core": "^8.4.2",
         "@capacitor/ios": "^8.4.2"
       },
       "devDependencies": {
         "@capacitor/cli": "^8.4.2"
-      }
-    },
-    "node_modules/@capacitor-community/background-geolocation": {
-      "version": "1.2.26",
-      "resolved": "https://registry.npmjs.org/@capacitor-community/background-geolocation/-/background-geolocation-1.2.26.tgz",
-      "integrity": "sha512-kuva8VQ6zM+uIKgHUJTP87IYbmGKhX7DZw62JYfGZ888h4Xr5zeN+UTR6KBRHQVrGBpzSfbv+6/HQVuHYa7W5A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@capacitor/core": ">=3.0.0"
       }
     },
     "node_modules/@capacitor/android": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "run:android": "cap run android"
   },
   "dependencies": {
-    "@capacitor-community/background-geolocation": "^1.2.26",
     "@capacitor/android": "^8.4.2",
     "@capacitor/core": "^8.4.2",
     "@capacitor/ios": "^8.4.2"


### PR DESCRIPTION
Fixes two defects that make the iOS app materially broken today, plus release hygiene. Part of TRU-57 (submission itself stays blocked on TRU-127 / TRU-128).

## 1. The walk tracker never compiled

`ios/App/App/TrufflWalkTracker.swift` was committed but never added to the Xcode target — no `PBXFileReference`, no `PBXBuildFile`, and `PBXSourcesBuildPhase` contained only `AppDelegate.swift`.

So the class never compiled, `window.Capacitor.Plugins.TrufflWalkTracker` was `undefined`, and the `if(T)` guards in `walk/index.html` silently no-opped. **iOS recorded zero background GPS despite TRU-56 reading as Done** — and that native capability is the only thing justifying a WebView wrapper against Apple guideline 4.2.

This adds the four `project.pbxproj` entries the file needs (file reference, build file, `App` group membership, sources build phase).

**Verified by actually building it** for the iOS Simulator:

- `TrufflWalkTracker.o` is now produced — it never was before
- the `TrufflWalkTracker` ObjC class is present in the built binary's classlist with its instance methods, so Capacitor's runtime can discover it via `@objc(TrufflWalkTracker)` / `CAPBridgedPlugin`
- app installs and launches clean into the live site

⚠️ **Simulator GPS is synthetic — real background-GPS behaviour still needs a physical iPhone**, same caveat as TRU-56 carried. This PR proves the plugin is built and registered, not that it produces good fixes on a real device.

## 2. Missing camera / photo-library usage strings

No `NSCameraUsageDescription` or `NSPhotoLibraryUsageDescription` in `Info.plist`. `walk/index.html` and `dashboard/index.html` use `<input type="file" accept="image/*" capture="environment">`, which asks WKWebView for the camera directly — so this was a **guaranteed crash on first photo**, not a theoretical risk. `profile/` uses the library picker.

`NSPhotoLibraryAddUsageDescription` is deliberately not added — nothing writes to the library.

## 3. Release hygiene

- `MARKETING_VERSION` off the `1.0` scaffold default.
- Dropped `@capacitor-community/background-geolocation`. It was linked in **neither** build — absent from `CapApp-SPM/Package.swift` and `capacitor.settings.gradle`, and `capacitor.build.gradle`'s dependency block is empty — because both platforms use hand-rolled trackers (`TrufflWalkTracker.swift`, `WalkTrackerPlugin`/`WalkTrackingService`) instead. Dead weight.
- `MOBILE.md`: documents that `cap sync` does **not** add Swift files to the target, which is the trap that produced this bug.

## Notes

- `npx cap sync ios` wants to bump `capacitor-swift-pm` 8.4.1 → 8.4.2 (matching `@capacitor/ios ^8.4.2`). **Left out of this PR** — the sandbox can't fetch the 8.4.2 xcframework, so it couldn't be build-verified, and an unverifiable native dependency bump doesn't belong in a PR whose point is that the native build works. Worth doing separately on a machine that can fetch it.
- The prior audit flagged `targetSdkVersion` as a scaffold default; it's already `36` and meets current Play requirements. Not an issue.