### PR TITLE
TRU-58: sign Android release builds

### DIFF
--- a/MOBILE.md
+++ b/MOBILE.md
@@ -66,6 +66,49 @@ The app should boot straight into the live Truffl site.
 - Offline behaviour: with no network, the bundled `www/index.html` fallback shows
   a retry; reconnecting returns to the live site.
 
+## Android release signing (TRU-58)
+
+Play rejects unsigned artifacts. The signing config is wired up, but the keystore
+itself is deliberately **not** in the repo — `android/.gitignore` blocks `*.jks`,
+`*.keystore` and `keystore.properties`.
+
+> **Losing this keystore means you can never update the app on Play under the same
+> listing again.** Back it up somewhere durable (password manager / encrypted backup),
+> not just on this Mac.
+
+```bash
+# 1. Generate the release key. Keep the .jks OUTSIDE the repo.
+keytool -genkeypair -v \
+  -keystore ~/truffl-release.jks \
+  -alias truffl -keyalg RSA -keysize 2048 -validity 10000
+
+# 2. Point the build at it
+cp android/keystore.properties.example android/keystore.properties
+#    then edit it: storeFile (absolute path), storePassword, keyAlias, keyPassword
+
+# 3. Build the artifact Play wants (AAB, not APK)
+cd android && ./gradlew :app:bundleRelease
+#    → android/app/build/outputs/bundle/release/app-release.aab
+
+# 4. Confirm it really is signed
+jarsigner -verify -certs app/build/outputs/bundle/release/app-release.aab
+#    "jar verified." — the self-signed warnings are expected and fine
+```
+
+For an APK instead (`./gradlew :app:assembleRelease`), verify with
+`$ANDROID_HOME/build-tools/<ver>/apksigner verify --print-certs <apk>`.
+
+Without `keystore.properties` the signing config is skipped rather than failing, so a
+clean checkout and CI still build normally — `assembleRelease` just produces an
+unsigned artifact, as it did before.
+
+`versionCode` must increase on **every** upload to Play, even when re-uploading the
+same `versionName`. Bump it in `android/app/build.gradle` alongside iOS's
+`CURRENT_PROJECT_VERSION`.
+
+If Gradle can't find a JDK, Android Studio ships one:
+`export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`.
+
 ## Notes / follow-ups
 
 - **Bundle ID / app name** (`com.trufflpets.app`, "Truffl Pets") are placeholders

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -52,10 +52,11 @@ captures/
 # Comment next line if keeping position of elements in Navigation Editor is relevant for you
 .idea/navEditor.xml
 
-# Keystore files
-# Uncomment the following lines if you do not want to check your keystore files in.
-#*.jks
-#*.keystore
+# Keystore files — never commit these. Losing the release key means you can no
+# longer update the app on Play under the same listing (TRU-58).
+*.jks
+*.keystore
+keystore.properties
 
 # External native build folder generated in Android Studio 2.2 and later
 .externalNativeBuild

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,5 +1,20 @@
 apply plugin: 'com.android.application'
 
+// Release signing (TRU-58). Play rejects unsigned artifacts, but the keystore and its
+// passwords must never enter the repo — so they live in android/keystore.properties,
+// which is gitignored. See keystore.properties.example and the signing section of
+// MOBILE.md for how to generate one.
+//
+// When that file is absent (a clean checkout, or CI) we skip the signing config
+// entirely rather than failing: debug builds and `assembleDebug` still work, and
+// `assembleRelease` produces an unsigned artifact exactly as it did before.
+def keystorePropertiesFile = rootProject.file('keystore.properties')
+def keystoreProperties = new Properties()
+def hasReleaseKeystore = keystorePropertiesFile.exists()
+if (hasReleaseKeystore) {
+    keystorePropertiesFile.withInputStream { keystoreProperties.load(it) }
+}
+
 android {
     namespace = "com.trufflpets.app"
     compileSdk = rootProject.ext.compileSdkVersion
@@ -7,8 +22,10 @@ android {
         applicationId "com.trufflpets.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
+        // versionCode must increase on every upload to Play, even for a re-upload of
+        // the same versionName. 1 is correct for the first submission.
         versionCode 1
-        versionName "1.0"
+        versionName "1.0.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.
@@ -16,8 +33,21 @@ android {
             ignoreAssetsPattern = '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'
         }
     }
+    signingConfigs {
+        if (hasReleaseKeystore) {
+            release {
+                storeFile file(keystoreProperties['storeFile'])
+                storePassword keystoreProperties['storePassword']
+                keyAlias keystoreProperties['keyAlias']
+                keyPassword keystoreProperties['keyPassword']
+            }
+        }
+    }
     buildTypes {
         release {
+            if (hasReleaseKeystore) {
+                signingConfig signingConfigs.release
+            }
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }

--- a/android/keystore.properties.example
+++ b/android/keystore.properties.example
@@ -1,0 +1,11 @@
+# Copy to android/keystore.properties (gitignored) and fill in.
+# Only needed to produce a SIGNED release build — debug builds and a clean
+# checkout work fine without it. See the signing section of MOBILE.md.
+#
+# storeFile is resolved relative to android/app/, so an absolute path outside
+# the repo is the safest choice — the keystore itself must never be committed.
+
+storeFile=/absolute/path/to/truffl-release.jks
+storePassword=
+keyAlias=truffl
+keyPassword=


### PR DESCRIPTION
`android/app/build.gradle` had **no `signingConfigs` at all**, so release artifacts came out unsigned and Play would reject them. Separately, `android/.gitignore`'s `*.jks` and `*.keystore` lines were both commented out — so a keystore dropped into the repo would have been committed.

## What this does

- Adds a release `signingConfig` sourced from `android/keystore.properties`, which is gitignored. A committed `keystore.properties.example` documents the format.
- **Degrades gracefully.** When `keystore.properties` is absent — clean checkout, CI, anyone who just cloned — the signing config is skipped rather than failing. `assembleDebug` works, and `assembleRelease` produces an unsigned artifact exactly as before. Nobody is forced to hold the release key to build.
- Uncomments `*.jks` / `*.keystore` in `.gitignore` and adds `keystore.properties`.
- `versionName` → `1.0.0`, matching iOS `MARKETING_VERSION`. `versionCode` stays `1` — that's genuinely correct for a first submission — with a comment about the must-increase-on-every-upload rule.
- `MOBILE.md` gains a signing runbook: keystore generation, wiring, building the AAB, and verifying the signature.

## Verification

Both legs actually run, not assumed:

| Leg | Result |
|---|---|
| `assembleDebug`, no `keystore.properties` present | ✅ builds (graceful degradation) |
| `assembleRelease` with a throwaway key | ✅ `apksigner verify` → **APK Signature Scheme v2**, cert DN matches |
| `bundleRelease` with a throwaway key | ✅ `jarsigner -verify` → `jar verified.` |
| `git check-ignore` on `keystore.properties`, `*.jks`, `*.keystore` | ✅ all three ignored |

The throwaway keystore and its properties file were deleted after verification; neither is in the diff.

> ⚠️ **Tom generates the real keystore** — see the new MOBILE.md section. Losing it means the app can never be updated on Play under the same listing again, so back it up somewhere durable, not just on the Mac.

## Note

The prior audit flagged `targetSdkVersion` as a scaffold default needing attention. It's already `36` (`android/variables.gradle`) and meets current Play requirements — no change needed.