### PR TITLE
TRU-227: add a terms of service page

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -728,6 +728,7 @@
       <a href="/about-us/">About</a>
       <a href="/trust-and-safety/">Trust &amp; safety</a> <a href="/how-we-vet/">How we vet</a>
       <a href="#">Contact</a>
+      <a href="/terms/">Terms</a>
       <a href="/privacy/">Privacy</a>
     </div>
     <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>

--- a/emails/components/TrufflEmailLayout.tsx
+++ b/emails/components/TrufflEmailLayout.tsx
@@ -94,6 +94,10 @@ export function TrufflEmailLayout({
                 Trust &amp; safety
               </Link>
               {'  ·  '}
+              <Link href={`${SITE_URL}/terms/`} style={footerLink}>
+                Terms
+              </Link>
+              {'  ·  '}
               <Link href={`${SITE_URL}/privacy/`} style={footerLink}>
                 Privacy
               </Link>

--- a/how-we-vet/index.html
+++ b/how-we-vet/index.html
@@ -138,6 +138,7 @@
       <a href="/trust-and-safety/">Trust &amp; safety</a>
       <a href="/how-we-vet/">How we vet</a>
       <a href="mailto:hello@trufflpets.com">Contact</a>
+      <a href="/terms/">Terms</a>
       <a href="/privacy/">Privacy</a>
     </div>
     <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>

--- a/index.html
+++ b/index.html
@@ -919,6 +919,7 @@
       <a href="/about-us/">About</a>
       <a href="/trust-and-safety/">Trust &amp; safety</a> <a href="/how-we-vet/">How we vet</a>
       <a href="#">Contact</a>
+      <a href="/terms/">Terms</a>
       <a href="/privacy/">Privacy</a>
     </div>
     <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>

--- a/login/index.html
+++ b/login/index.html
@@ -123,6 +123,8 @@
   .text-link { color: var(--terracotta); font-size: 0.82rem; font-weight: 500; text-decoration: none; }
   .text-link:hover { text-decoration: underline; }
   .field-hint { font-size: 0.78rem; color: var(--text-muted); margin-top: 4px; }
+  .consent-note { font-size: 0.78rem; color: var(--text-muted); line-height: 1.5; margin-top: 18px; }
+  .consent-note a { color: var(--terracotta); text-decoration: underline; }
 
   .btn-row { display: flex; gap: 12px; margin-top: 1.5rem; }
   .btn {
@@ -404,6 +406,7 @@
         <div class="field"><label>Phone number</label><input type="tel" id="cPhone" placeholder="0412 345 678"></div>
         <div class="field"><label>Password</label><input type="password" id="cPassword" placeholder="At least 8 characters"><div class="field-hint">Minimum 8 characters</div></div>
         <div class="field"><label>Confirm password</label><input type="password" id="cPasswordConfirm" placeholder="Re-enter your password"></div>
+        <div class="consent-note">By continuing you agree to our <a href="/terms/" target="_blank" rel="noopener">Terms of service</a> and <a href="/privacy/" target="_blank" rel="noopener">Privacy policy</a>.</div>
         <div class="btn-row"><button class="btn btn-primary" onclick="custStep1()">Continue</button></div>
       </div>
     </div>
@@ -513,6 +516,7 @@
         <div class="field"><label>Phone number</label><input type="tel" id="pPhone" placeholder="0412 345 678"></div>
         <div class="field"><label>Password</label><input type="password" id="pPassword" placeholder="At least 8 characters"><div class="field-hint">Minimum 8 characters</div></div>
         <div class="field"><label>Confirm password</label><input type="password" id="pPasswordConfirm" placeholder="Re-enter your password"></div>
+        <div class="consent-note">By continuing you agree to our <a href="/terms/" target="_blank" rel="noopener">Terms of service</a> and <a href="/privacy/" target="_blank" rel="noopener">Privacy policy</a>.</div>
         <div class="btn-row"><button class="btn btn-primary" onclick="provStep1()">Continue</button></div>
       </div>
     </div>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -264,6 +264,7 @@
       <a href="/trust-and-safety/">Trust &amp; safety</a>
       <a href="/how-we-vet/">How we vet</a>
       <a href="mailto:hello@trufflpets.com">Contact</a>
+      <a href="/terms/">Terms</a>
       <a href="/privacy/">Privacy</a>
     </div>
     <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>

--- a/register/index.html
+++ b/register/index.html
@@ -262,6 +262,13 @@
     color: var(--text-muted);
     margin-top: 4px;
   }
+  .consent-note {
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    line-height: 1.5;
+    margin-top: 18px;
+  }
+  .consent-note a { color: var(--terracotta); text-decoration: underline; }
 
   /* ─── Service-area mode toggle (TRU-157, mirrors the profile editor) ─── */
   .sa-seg { display: flex; padding: 3px; background: var(--cream); border: 1px solid var(--border); border-radius: 999px; margin: 4px 0 10px; max-width: 320px; }
@@ -510,6 +517,8 @@
         <label>Confirm password</label>
         <input type="password" id="passwordConfirm" placeholder="Re-enter your password" required>
       </div>
+
+      <div class="consent-note">By continuing you agree to our <a href="/terms/" target="_blank" rel="noopener">Terms of service</a> and <a href="/privacy/" target="_blank" rel="noopener">Privacy policy</a>.</div>
 
       <div class="btn-row">
         <button class="btn btn-primary" onclick="submitStep1()">Continue</button>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -4,6 +4,7 @@
   <url><loc>https://trufflpets.com/about-us/</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://trufflpets.com/register/</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://trufflpets.com/search/</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://trufflpets.com/terms/</loc><changefreq>yearly</changefreq><priority>0.3</priority></url>
   <url><loc>https://trufflpets.com/privacy/</loc><changefreq>yearly</changefreq><priority>0.3</priority></url>
 
   <url><loc>https://trufflpets.com/trust-and-safety/</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>

--- a/supabase/functions/send-notification/index.ts
+++ b/supabase/functions/send-notification/index.ts
@@ -77,7 +77,7 @@ function layout(opts: { preview: string; heading: string; body: string; cta?: { 
   <tr><td style="padding:18px 0;"><hr style="border:none;border-top:1px solid ${C.border};margin:0;"></td></tr>
   <tr><td style="text-align:center;">
     <p style="font-size:13px;color:${C.textMid};margin:0 0 6px;"><a href="${SITE}" style="color:${C.terracottaDark};text-decoration:none;">Truffl Pets</a> · Sydney's trusted pet care</p>
-    <p style="font-size:12px;color:${C.textLight};margin:0 0 6px;"><a href="${SITE}/trust-and-safety/" style="color:${C.terracottaDark};text-decoration:none;">Trust &amp; safety</a> &nbsp;·&nbsp; <a href="${SITE}/privacy/" style="color:${C.terracottaDark};text-decoration:none;">Privacy</a></p>
+    <p style="font-size:12px;color:${C.textLight};margin:0 0 6px;"><a href="${SITE}/trust-and-safety/" style="color:${C.terracottaDark};text-decoration:none;">Trust &amp; safety</a> &nbsp;·&nbsp; <a href="${SITE}/terms/" style="color:${C.terracottaDark};text-decoration:none;">Terms</a> &nbsp;·&nbsp; <a href="${SITE}/privacy/" style="color:${C.terracottaDark};text-decoration:none;">Privacy</a></p>
     <p style="font-size:12px;color:${C.textLight};margin:0;">© Truffl Pets · Sydney, NSW</p>
   </td></tr>
 </table></body></html>`;

--- a/terms/index.html
+++ b/terms/index.html
@@ -1,0 +1,293 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-T2CPSDBJ1L"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-T2CPSDBJ1L');
+</script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="canonical" href="https://trufflpets.com/terms/">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Truffl Pets">
+<meta property="og:title" content="Terms of service — Truffl Pets">
+<meta property="og:description" content="The terms that apply when you use Truffl Pets to book or provide pet care.">
+<meta property="og:url" content="https://trufflpets.com/terms/">
+<meta property="og:image" content="https://trufflpets.com/dog-hero.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Terms of service — Truffl Pets">
+<meta name="twitter:description" content="The terms that apply when you use Truffl Pets to book or provide pet care.">
+<meta name="twitter:image" content="https://trufflpets.com/dog-hero.png">
+  <title>Terms of service — Truffl Pets</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <meta name="description" content="The terms that apply when you use Truffl Pets to book or provide pet care.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --cream: #F7F3EE; --warm: #EDE7DC; --sage: #C8D5C0; --sage-dark: #8A9E82;
+      --blush: #E8D5CC; --terracotta: #C4866A; --terracotta-dark: #B8795C;
+      --brown: #5C4033; --brown-deep: #3A2E28; --text: #3A2E28; --text-mid: #7A6860;
+      --text-light: #A8978E; --border: rgba(92,64,51,0.12);
+    }
+    html { font-size: 16px; scroll-behavior: smooth; }
+    body { font-family: 'DM Sans', sans-serif; background: var(--cream); color: var(--text); line-height: 1.65; -webkit-font-smoothing: antialiased; }
+    a { text-decoration: none; color: inherit; }
+    nav { background: var(--cream); padding: 0 56px; height: 82px; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid var(--border); position: sticky; top: 0; z-index: 100; gap: 24px; flex-wrap: wrap; }
+    .nav-left { display: flex; align-items: center; gap: 32px; }
+    .nav-links { display: flex; gap: 28px; font-size: 13px; color: var(--text-mid); }
+    .nav-links a { transition: color 0.2s; }
+    .nav-links a:hover, .nav-links a.active { color: var(--text); }
+    .nav-links a.active { font-weight: 500; }
+    .nav-actions { display: flex; gap: 24px; align-items: center; font-size: 13px; color: var(--text-mid); }
+    .nav-actions a:hover { color: var(--text); }
+    .btn-primary { background: var(--terracotta); color: #fff; padding: 11px 22px; border-radius: 999px; font-size: 13px; font-weight: 500; transition: background 0.2s, transform 0.2s; }
+    .btn-primary:hover { background: var(--terracotta-dark); transform: translateY(-1px); }
+    .article { max-width: 720px; margin: 0 auto; padding: 40px 24px 24px; }
+    .crumb { font-size: 13px; color: var(--text-mid); margin-bottom: 26px; display: inline-flex; align-items: center; gap: 7px; }
+    .crumb:hover { color: var(--terracotta); }
+    .article h1 { font-family: 'Cormorant Garamond', serif; font-weight: 500; font-size: 2.5rem; line-height: 1.12; color: var(--brown); margin-bottom: 10px; }
+    .updated { font-size: 0.85rem; color: var(--text-light); margin-bottom: 22px; }
+    .lead { font-size: 1.08rem; color: var(--text-mid); margin-bottom: 30px; }
+    .article h2 { font-family: 'Cormorant Garamond', serif; font-weight: 500; font-size: 1.6rem; color: var(--brown); margin: 34px 0 12px; }
+    .article h3 { font-size: 1rem; font-weight: 600; color: var(--text); margin: 22px 0 8px; }
+    .article p { margin-bottom: 14px; color: var(--text); }
+    .article ul { list-style: none; margin: 0 0 16px; padding: 0; }
+    .article li { position: relative; padding-left: 26px; margin-bottom: 10px; color: var(--text); }
+    .article li::before { content: ''; position: absolute; left: 6px; top: 11px; width: 7px; height: 7px; border-radius: 50%; background: var(--terracotta); }
+    .article li strong { color: var(--brown); }
+    .article a.inline { color: var(--terracotta); border-bottom: 1px solid rgba(196,134,106,0.4); }
+    .note { background: #fff; border: 1px solid var(--border); border-left: 3px solid var(--sage-dark); border-radius: 12px; padding: 18px 20px; margin: 22px 0; }
+    .note p:last-child { margin-bottom: 0; }
+    .toc { background: #fff; border: 1px solid var(--border); border-radius: 14px; padding: 20px 24px; margin: 28px 0 8px; }
+    .toc-title { font-size: 0.8rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-light); margin-bottom: 12px; }
+    .toc ol { list-style: none; margin: 0; padding: 0; columns: 2; column-gap: 32px; }
+    .toc li { padding-left: 0; margin-bottom: 8px; font-size: 0.92rem; }
+    .toc li::before { display: none; }
+    .toc a { color: var(--text-mid); }
+    .toc a:hover { color: var(--terracotta); }
+    footer { background: var(--brown-deep); color: var(--text-light); padding: 40px 56px; display: flex; align-items: center; justify-content: space-between; gap: 20px; flex-wrap: wrap; margin-top: 48px; }
+    .footer-links { display: flex; gap: 24px; font-size: 13px; color: var(--text-light); flex-wrap: wrap; }
+    .footer-links a:hover { color: #fff; }
+    .footer-copy { font-size: 12px; color: var(--text-light); opacity: 0.7; }
+    @media (max-width: 860px) { nav { padding: 0 20px; } .nav-links { display: none; } .article h1 { font-size: 2rem; } .toc ol { columns: 1; } footer { padding: 32px 20px; } }
+  </style>
+</head>
+<body>
+  <nav>
+    <div class="nav-left">
+      <a href="/" class="nav-logo" aria-label="Truffl Pets home">
+        <svg width="150" height="48" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <circle cx="20" cy="5.5" r="6" fill="none" stroke="#C4866A" stroke-width="2.5"/>
+          <circle cx="20" cy="5.5" r="2.8" fill="#F7F3EE"/>
+          <rect x="16.5" y="10.5" width="7" height="9" rx="3" fill="#C4866A"/>
+          <circle cx="20" cy="33" r="20" fill="#C4866A"/>
+          <text x="20" y="35.5" font-family="'Cormorant Garamond', Georgia, serif" font-size="14" font-style="italic" fill="#F7F3EE" text-anchor="middle" letter-spacing="-0.3">truffl</text>
+          <text x="52" y="30" font-family="'Cormorant Garamond', Georgia, serif" font-size="32" font-style="italic" fill="#5C4033" letter-spacing="-0.5">truffl</text>
+          <text x="52" y="50" font-family="'DM Sans', sans-serif" font-size="12" font-weight="600" fill="#B0A090" letter-spacing="4">PETS</text>
+        </svg>
+      </a>
+      <div class="nav-links">
+        <a href="/">Home</a>
+        <a href="/about-us/">About</a>
+        <a href="/trust-and-safety/">Trust &amp; safety</a>
+        <a href="/#how">How it works</a>
+      </div>
+    </div>
+    <div class="nav-actions">
+      <a href="/login/">Sign in</a>
+      <a href="/search/" class="btn-primary">Book a carer</a>
+    </div>
+  </nav>
+
+  <article class="article">
+    <a class="crumb" href="/"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg> Home</a>
+    <h1>Terms of service</h1>
+    <p class="updated">Last updated: 29 July 2026</p>
+    <p class="lead">These terms are the agreement between you and Truffl Pets. They apply whenever you use our website or apps — whether you are an owner booking care for your pet, or a carer offering it. Please read them; by using Truffl you are agreeing to them.</p>
+
+    <div class="note">
+      <p>Truffl Pets (ABN 14 690 054 980) operates the Truffl platform from Sydney, NSW. In these terms, <strong>"Truffl"</strong>, <strong>"we"</strong> and <strong>"us"</strong> mean Truffl Pets; <strong>"you"</strong> means you as an owner or a carer. How we handle your personal information is covered separately in our <a class="inline" href="/privacy/">Privacy policy</a>.</p>
+    </div>
+
+    <div class="toc">
+      <div class="toc-title">On this page</div>
+      <ol>
+        <li><a href="#about">1. About these terms</a></li>
+        <li><a href="#eligibility">2. Who can use Truffl</a></li>
+        <li><a href="#account">3. Your account</a></li>
+        <li><a href="#marketplace">4. What Truffl is</a></li>
+        <li><a href="#bookings">5. Bookings &amp; cancellations</a></li>
+        <li><a href="#payments">6. Payments &amp; fees</a></li>
+        <li><a href="#responsibilities">7. Your responsibilities</a></li>
+        <li><a href="#on-platform">8. Keeping bookings on Truffl</a></li>
+        <li><a href="#cover">9. Cover &amp; insurance</a></li>
+        <li><a href="#content">10. Reviews, photos &amp; content</a></li>
+        <li><a href="#termination">11. Suspending or closing an account</a></li>
+        <li><a href="#liability">12. Liability</a></li>
+        <li><a href="#changes">13. Changes to these terms</a></li>
+        <li><a href="#contact">14. Contact &amp; governing law</a></li>
+      </ol>
+    </div>
+
+    <h2 id="about">1. About these terms</h2>
+    <p>These terms apply to your use of Truffl — the website at trufflpets.com, our iOS and Android apps, and the services we provide through them. By creating an account, booking care, or accepting a booking, you agree to be bound by them.</p>
+    <p>Some parts of Truffl have their own additional guidance that forms part of these terms where it applies to you: our <a class="inline" href="/carer-guidelines/">carer guidelines</a> for carers, and our <a class="inline" href="/trust-and-safety/">trust &amp; safety</a> guidance for owners. Where the specifics shown to you in the app at the time of a booking — such as the price or the cancellation window for that booking — differ from the general description here, what you were shown at the time applies.</p>
+
+    <h2 id="eligibility">2. Who can use Truffl</h2>
+    <ul>
+      <li>You must be <strong>at least 18 years old</strong> and able to enter into a binding agreement.</li>
+      <li>You must provide accurate information about yourself, and keep it up to date.</li>
+      <li>Carers must be legally entitled to work in Australia and must complete our vetting before they can be booked.</li>
+      <li>You may not use Truffl if we have previously suspended or removed your account.</li>
+    </ul>
+
+    <h2 id="account">3. Your account</h2>
+    <p>You are responsible for your account and for anything that happens through it. Keep your password to yourself, and tell us promptly if you think someone else has access to it.</p>
+    <p>One person, one account. Don't impersonate anyone, don't create an account on someone else's behalf without their authority, and don't share your account with others.</p>
+
+    <h2 id="marketplace">4. What Truffl is — and what it isn't</h2>
+    <p>Truffl is a <strong>marketplace</strong>. We help owners find and book carers, we handle payments and messaging, and we vet the carers who appear on the platform. We do not provide pet care ourselves.</p>
+    <div class="note">
+      <p><strong>Carers are independent.</strong> Carers on Truffl are independent providers, not our employees, agents or partners. When you book, the agreement to provide care is between the owner and the carer. Truffl is not a party to it.</p>
+    </div>
+    <p>What that means in practice:</p>
+    <ul>
+      <li>Carers decide their own rates, availability and the services they offer, and use their own judgement in how they provide care.</li>
+      <li>We vet carers before they can be booked — every carer is interviewed, ID-verified and assessed in person — but vetting reduces risk, it cannot eliminate it. It is not a guarantee of any carer's conduct or of a particular outcome.</li>
+      <li>We are not responsible for the acts or omissions of any owner or carer.</li>
+      <li>Meeting a carer before you book, at a meet &amp; greet, is the single best check you can make. We strongly encourage it.</li>
+    </ul>
+
+    <h2 id="bookings">5. Bookings, meet &amp; greets and cancellations</h2>
+    <p>When an owner requests a booking and a carer accepts it, a booking is formed between them on the terms shown in the app — the service, the times, the pets involved and the price.</p>
+
+    <h3>Meet &amp; greets</h3>
+    <p>Some carers require a meet &amp; greet before accepting ongoing work. This is a short, no-obligation introduction so that everyone — including the dog — can decide whether it is a good fit. Either side can decide not to proceed afterwards.</p>
+
+    <h3>Cancellations</h3>
+    <ul>
+      <li>The cancellation window that applies to a booking is shown to you at the time you book, and in the booking itself. Please check it there — it is what applies.</li>
+      <li>Cancel as early as you reasonably can. Late cancellations leave a carer with an unfillable gap, or an owner without care at short notice.</li>
+      <li>If a carer cancels a booking you have arranged, we will help you find a replacement where we can. Where you have turned on backup cover, we may arrange a Truffl backup carer in line with the consent you gave when you enabled it.</li>
+      <li>We may cancel a booking ourselves if we believe it is unsafe, fraudulent, or in breach of these terms.</li>
+    </ul>
+
+    <h2 id="payments">6. Payments and fees</h2>
+    <ul>
+      <li><strong>Payments are processed by Stripe.</strong> Your card details go directly to Stripe and are never stored on, and never pass through, Truffl's systems.</li>
+      <li><strong>You are charged after the service is done</strong>, not up front — so you pay for care that has actually happened.</li>
+      <li>Prices are set by the carer and shown to you before you confirm. The price you are shown at booking is the price that applies to that booking.</li>
+      <li>Any Truffl platform fee is disclosed to you at the time of booking. Carers are shown their commission, if any, before accepting.</li>
+      <li>Carers are paid out through their own Stripe account. Carers are responsible for their own tax, including GST where it applies, and for their own ABN and record-keeping.</li>
+      <li>If a payment fails, we may retry it and will contact you. Unpaid completed bookings remain payable.</li>
+      <li>Refunds are handled case by case — contact us and we will work it out with you and the carer.</li>
+    </ul>
+
+    <h2 id="responsibilities">7. Your responsibilities</h2>
+
+    <h3>If you're an owner</h3>
+    <ul>
+      <li>Give accurate and complete information about your pet — temperament, health, medication, routine, and anything a carer needs to keep themselves and your pet safe. <strong>Tell the carer about any history of aggression or biting.</strong> This one matters most.</li>
+      <li>Make sure your pet is up to date on vaccinations and appropriately registered, and that your dog is safe to be handled and walked by someone new.</li>
+      <li>Provide the access your carer needs — keys, gates, leads, harnesses — and make sure your home is safe to enter for the arranged visit.</li>
+      <li><strong>Urgent veterinary care is your responsibility to authorise and to pay for.</strong> Make sure we and your carer have a way to reach you, and tell your carer what you want done if they can't.</li>
+    </ul>
+
+    <h3>If you're a carer</h3>
+    <ul>
+      <li>Only accept bookings you can genuinely do, and turn up when you said you would.</li>
+      <li>Follow the owner's instructions for the pet, and our <a class="inline" href="/carer-guidelines/">carer guidelines</a>, which set out the standards we expect on every booking.</li>
+      <li>Treat every home you enter with care, and use access details only for the booking they were given for.</li>
+      <li>Keep location tracking on for the duration of a walk so the owner can follow along, and share the updates the booking calls for.</li>
+      <li>Tell the owner promptly if anything goes wrong, and tell us if it's serious.</li>
+      <li>Keep your vetting information current, and tell us if anything changes that affects your eligibility.</li>
+    </ul>
+
+    <h3>Everyone</h3>
+    <p>Don't use Truffl to do anything unlawful, to harass or discriminate against anyone, to misrepresent yourself, or to interfere with how the platform works.</p>
+
+    <h2 id="on-platform">8. Keeping bookings on Truffl</h2>
+    <p>Book, message and pay through Truffl. Taking a booking off the platform is a breach of these terms, and it removes the protections that make Truffl worth using — for both sides:</p>
+    <ul>
+      <li>No payment protection, and no record of what was agreed if there's a dispute.</li>
+      <li>No GPS tracking, no photo updates, and no booking history.</li>
+      <li>No support from us, and no access to any Truffl cover.</li>
+    </ul>
+    <p>Arranging payment outside Truffl to avoid fees, or moving an introduced booking off-platform, may result in your account being suspended or closed.</p>
+
+    <h2 id="cover">9. Cover and insurance</h2>
+    <!-- PLACEHOLDER (cover): inherited from TRU-15 — confirm the cover's proper name, what it
+         includes, its limits and its conditions before launch, then replace this section.
+         Until then this section must not promise any cover. Matching placeholders exist in
+         trust-and-safety/if-something-goes-wrong/, carer-guidelines/vetting-and-cover/ and
+         carer-guidelines/emergencies-and-safety/. -->
+    <p>Where Truffl cover applies to a booking, the cover, its limits and its conditions will be described to you in the app and in our trust &amp; safety guidance. Cover, where offered, applies only to bookings arranged and paid for through Truffl.</p>
+    <p>Truffl cover is not a substitute for insurance, and it does not replace an owner's responsibility for their pet's veterinary costs. Owners should hold their own pet insurance if they want that protection. Carers are responsible for holding any insurance appropriate to the work they choose to take on.</p>
+
+    <h2 id="content">10. Reviews, photos and content</h2>
+    <ul>
+      <li>Reviews must be honest and based on a real booking. Don't post reviews you were paid for, reviews of yourself, or reviews intended to mislead.</li>
+      <li>Photos a carer takes during a booking are shared with the owner as part of the service. Carers should not publish photos of an owner's pet, home or property elsewhere without the owner's permission.</li>
+      <li>You keep ownership of what you upload. You give us permission to host and display it as needed to run Truffl.</li>
+      <li>We may remove content that is unlawful, abusive, misleading, or in breach of these terms.</li>
+    </ul>
+
+    <h2 id="termination">11. Suspending or closing an account</h2>
+    <p>You can stop using Truffl at any time. To close your account, contact us and we will take care of it — see our <a class="inline" href="/privacy/#rights">Privacy policy</a> for what happens to your information when you do.</p>
+    <p>We may suspend or close an account if someone breaches these terms, if we have genuine concerns about the safety of a person or an animal, if we are required to by law, or if an account is being used fraudulently. Where it is reasonable and safe to do so, we will tell you why.</p>
+    <p>Closing an account does not cancel bookings that have already happened, or remove an obligation to pay for care that has already been provided.</p>
+
+    <h2 id="liability">12. Liability</h2>
+    <div class="note">
+      <p>Nothing in these terms excludes, restricts or modifies any guarantee, right or remedy you have under the <em>Australian Consumer Law</em> that cannot lawfully be excluded. Where we are permitted to limit our liability for a service, we limit it to re-supplying the service or paying the cost of having it re-supplied.</p>
+    </div>
+    <p>Subject to that:</p>
+    <ul>
+      <li>Truffl provides the platform, not the care. We are not liable for the acts or omissions of owners or carers, or for the outcome of any booking between them.</li>
+      <li>We do not guarantee that Truffl will be uninterrupted or error-free, or that live tracking will always be available — it depends on the carer's device, its battery and mobile network coverage.</li>
+      <li>We are not liable for loss that was not reasonably foreseeable, or for indirect or consequential loss.</li>
+      <li>Owners and carers each remain responsible for their own conduct, and for any loss they cause the other.</li>
+    </ul>
+
+    <h2 id="changes">13. Changes to these terms</h2>
+    <p>We may update these terms as Truffl evolves or as the law changes. When we make material changes we will update the date at the top of this page and, where appropriate, let you know in the app or by email. Your continued use of Truffl after a change means you accept the updated terms.</p>
+
+    <h2 id="contact">14. Contact and governing law</h2>
+    <p>If something has gone wrong, or you want to raise a concern about a booking or a person, please tell us — we would much rather hear about it early. See <a class="inline" href="/trust-and-safety/reporting-a-concern/">reporting a concern</a>.</p>
+    <ul>
+      <li><strong>Email:</strong> <a class="inline" href="mailto:hello@trufflpets.com">hello@trufflpets.com</a></li>
+      <li><strong>Business:</strong> Truffl Pets · ABN 14 690 054 980 · Sydney, NSW</li>
+    </ul>
+    <p>These terms are governed by the laws of New South Wales, Australia, and you and we submit to the non-exclusive jurisdiction of the courts of that state.</p>
+
+    <p style="margin-top:28px;">See also our <a class="inline" href="/privacy/">Privacy policy</a>, our <a class="inline" href="/trust-and-safety/">Trust &amp; safety</a> guidance and <a class="inline" href="/how-we-vet/">how we vet every carer</a>.</p>
+  </article>
+
+  <footer>
+    <a href="/" aria-label="Truffl Pets home">
+      <svg width="130" height="40" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="20" cy="33" r="20" fill="#C4866A" opacity="0.6"/>
+        <text x="20" y="38" font-family="'Cormorant Garamond', Georgia, serif" font-size="14" font-style="italic" fill="#F7F3EE" text-anchor="middle">truffl</text>
+        <text x="52" y="30" font-family="'Cormorant Garamond', Georgia, serif" font-size="32" font-style="italic" fill="#A8978E" letter-spacing="-0.5">truffl</text>
+      </svg>
+    </a>
+    <div class="footer-links">
+      <a href="/register/">For carers</a>
+      <a href="/about-us/">About</a>
+      <a href="/trust-and-safety/">Trust &amp; safety</a>
+      <a href="/how-we-vet/">How we vet</a>
+      <a href="mailto:hello@trufflpets.com">Contact</a>
+      <a href="/terms/">Terms</a>
+      <a href="/privacy/">Privacy</a>
+    </div>
+    <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>
+  </footer>
+</body>
+</html>

--- a/trust-and-safety/choosing-your-carer/index.html
+++ b/trust-and-safety/choosing-your-carer/index.html
@@ -134,6 +134,7 @@
       <a href="/about-us/">About</a>
       <a href="/trust-and-safety/">Trust &amp; safety</a>
       <a href="#">Contact</a>
+      <a href="/terms/">Terms</a>
       <a href="/privacy/">Privacy</a>
     </div>
     <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>

--- a/trust-and-safety/following-along-with-gps/index.html
+++ b/trust-and-safety/following-along-with-gps/index.html
@@ -115,6 +115,7 @@
       <a href="/about-us/">About</a>
       <a href="/trust-and-safety/">Trust &amp; safety</a>
       <a href="#">Contact</a>
+      <a href="/terms/">Terms</a>
       <a href="/privacy/">Privacy</a>
     </div>
     <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>

--- a/trust-and-safety/getting-ready/index.html
+++ b/trust-and-safety/getting-ready/index.html
@@ -130,6 +130,7 @@
       <a href="/about-us/">About</a>
       <a href="/trust-and-safety/">Trust &amp; safety</a>
       <a href="#">Contact</a>
+      <a href="/terms/">Terms</a>
       <a href="/privacy/">Privacy</a>
     </div>
     <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>

--- a/trust-and-safety/if-something-goes-wrong/index.html
+++ b/trust-and-safety/if-something-goes-wrong/index.html
@@ -139,6 +139,7 @@
       <a href="/about-us/">About</a>
       <a href="/trust-and-safety/">Trust &amp; safety</a>
       <a href="#">Contact</a>
+      <a href="/terms/">Terms</a>
       <a href="/privacy/">Privacy</a>
     </div>
     <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>

--- a/trust-and-safety/index.html
+++ b/trust-and-safety/index.html
@@ -175,6 +175,7 @@
       <a href="/about-us/">About</a>
       <a href="/trust-and-safety/">Trust &amp; safety</a>
       <a href="#">Contact</a>
+      <a href="/terms/">Terms</a>
       <a href="/privacy/">Privacy</a>
     </div>
     <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>

--- a/trust-and-safety/keeping-it-on-truffl/index.html
+++ b/trust-and-safety/keeping-it-on-truffl/index.html
@@ -115,6 +115,7 @@
       <a href="/about-us/">About</a>
       <a href="/trust-and-safety/">Trust &amp; safety</a>
       <a href="#">Contact</a>
+      <a href="/terms/">Terms</a>
       <a href="/privacy/">Privacy</a>
     </div>
     <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>

--- a/trust-and-safety/reporting-a-concern/index.html
+++ b/trust-and-safety/reporting-a-concern/index.html
@@ -117,6 +117,7 @@
       <a href="/about-us/">About</a>
       <a href="/trust-and-safety/">Trust &amp; safety</a>
       <a href="#">Contact</a>
+      <a href="/terms/">Terms</a>
       <a href="/privacy/">Privacy</a>
     </div>
     <div class="footer-copy">© 2025 Truffl Pets · Sydney, NSW</div>


### PR DESCRIPTION
Both app stores require a terms-of-service URL. There was no terms page anywhere in the repo — `/privacy/` existed, nothing else.

This also closes a dangling reference: `carer-guidelines/your-commitments/` already tells carers that taking work off-platform "is against our terms", pointing at a document that didn't exist. Section 8 is now its target.

## The page

`terms/index.html` clones the `privacy/index.html` public legal shell — same tokens, `.article` width, `.toc`, `.note`, variant-B footer — so it reads as part of the same set rather than a bolt-on. It uses the **newer 7-element logo SVG** from `trust-and-safety/`; `privacy/` has drifted to an older 4-element one and there was no reason to propagate that.

**Facts are taken from what the site already commits to publicly, not invented:** charge-after-service, Stripe as processor, in-person vetting, 18+, ABN 14 690 054 980, and — deliberately — the cancellation window being *whatever the booking itself shows*, rather than hardcoding a number here that could drift out of sync with the app.

Two sections worth a close read:

- **§9 Cover and insurance** carries a `PLACEHOLDER (cover)` comment matching the three that already exist elsewhere, and **promises nothing** — cover terms are still blocked on TRU-15. It says cover applies only to on-platform bookings and is not a substitute for insurance, which is safe to say today.
- **§12 Liability** carries the Australian Consumer Law carve-out. Those guarantees can't lawfully be excluded, so the section limits liability only to the extent permitted and says so up front.

## Wire-up

- `Terms` link added to **all 11 footers** that exist (the other 21 pages have no footer).
- `sitemap.xml` entry alongside privacy's.
- **Both** email footers — the React layout and the inline HTML in `send-notification`, which is where production email actually renders.
- **Signup consent line — none existed anywhere before.** Added at **step 1** of all three signup entry points (`register/`, plus the customer and provider flows in `login/`), because that's where `signUp()` actually creates the account. Putting it on the final "Complete signup" button would have been wrong — the account already exists by then.

## Verification

- All **14 TOC anchors resolve**, all 14 `<h2 id>` are in the TOC, no orphans either way
- No horizontal overflow at desktop or 375px; the 860px breakpoint collapses the TOC to one column and hides `.nav-links`
- Consent note renders above each button with the correct app-palette tokens and both links
- CI checks pass locally: inline-JS across **32 pages**, `deno check` on the modified edge function, and `sitemap.xml` parses

## ⚠️ Needs a legal read

I am not a lawyer. This is a good-faith draft in the site's established voice, consistent with what `/privacy/` already commits to publicly — but it should get a real review before launch, particularly §4 (marketplace / independent contractors), §9 (cover) and §12 (liability).

## Note

§11 currently says to contact us to close an account, matching what `/privacy/` §7 says today. **TRU-228** (in-app account deletion) will change that line to point at the in-app route. The two PRs are independent and can merge in either order — §11 is accurate either way.