### PR TITLE
TRU-228: in-app account deletion

### DIFF
--- a/privacy/index.html
+++ b/privacy/index.html
@@ -105,7 +105,7 @@
   <article class="article">
     <a class="crumb" href="/"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg> Home</a>
     <h1>Privacy policy</h1>
-    <p class="updated">Last updated: 4 July 2026</p>
+    <p class="updated">Last updated: 29 July 2026</p>
     <p class="lead">Truffl Pets connects pet owners with vetted local carers in Sydney. This policy explains what personal information we collect, how we use it, who we share it with, and the choices and rights you have. It applies to our website, our mobile apps, and the services we provide through them.</p>
 
     <div class="note">
@@ -222,16 +222,31 @@
       <li><strong>Payment and transaction records</strong> are kept for up to seven years, as Australian tax and financial record-keeping laws require.</li>
       <li><strong>Walk routes, messages and booking history</strong> are kept while your account is active so you and your carer can refer back to them.</li>
     </ul>
-    <p>When information is no longer needed for these purposes, we delete it or de-identify it. If you close your account, you can ask us to delete your personal information, subject to any records we are required to keep.</p>
+    <p>When information is no longer needed for these purposes, we delete it or de-identify it. You can <a class="inline" href="#deletion">delete your account yourself at any time</a>, which removes your personal information immediately, subject to any records we are required to keep.</p>
 
     <h2 id="rights">7. Your rights &amp; choices</h2>
     <p>You can:</p>
     <ul>
       <li><strong>Access and correct</strong> most of your account, pet and profile information directly in Truffl.</li>
+      <li><strong>Delete your account</strong> yourself, at any time — see <a class="inline" href="#deletion">deleting your account</a> below.</li>
       <li><strong>Request a copy</strong> of the personal information we hold about you, or ask us to correct or delete it, by contacting us.</li>
       <li><strong>Manage notifications</strong> and, on mobile, control location permissions through your device settings.</li>
       <li><strong>Control analytics cookies</strong> through your browser settings or available opt-out tools.</li>
     </ul>
+
+    <h3 id="deletion">Deleting your account</h3>
+    <p>Go to <strong>Profile → My account → Delete account</strong>, on the website or in the app, and confirm. It takes effect immediately and cannot be undone. If you would rather we did it for you, email <a class="inline" href="mailto:privacy@trufflpets.com">privacy@trufflpets.com</a>.</p>
+    <p>When you delete your account we <strong>remove</strong>:</p>
+    <ul>
+      <li>Your name, email address and phone number, and your profile photo.</li>
+      <li>Your address, emergency contact and precise location.</li>
+      <li>Your pets' names, breeds, microchip numbers, vet details, medical and behaviour notes, and their photos.</li>
+      <li>Walk routes (GPS), the content of your messages, walk photos and check-in photos.</li>
+      <li>Your home access details for backup cover, and your notifications.</li>
+    </ul>
+    <p>We <strong>keep</strong>, with your personal details stripped out, the record that a booking happened — its date, duration, distance and amount — along with payment records and any reviews. We do this for two reasons: Australian tax and financial record-keeping laws require us to keep transaction records for up to seven years, and every booking involves another person, whose own history of the walks they did or received should not disappear along with your account.</p>
+    <p>Deleting your account does not by itself close your payment account with Stripe. If you would like us to remove your saved card details from Stripe as well, please ask us.</p>
+    <p>You cannot delete your account while you have a booking still scheduled, or a completed booking that has not yet been settled. Cancel or settle those first, and we will explain which ones are outstanding when you try.</p>
     <p>We will respond to privacy requests within a reasonable time. If you are not satisfied with how we handle a request, you can contact the Office of the Australian Information Commissioner (OAIC) at <a class="inline" href="https://www.oaic.gov.au" target="_blank" rel="noopener">oaic.gov.au</a>.</p>
 
     <h2 id="children">8. Children</h2>

--- a/profile/index.html
+++ b/profile/index.html
@@ -1068,6 +1068,9 @@ function renderAccountTab() {
     <hr class="section-divider">
     <div class="section-heading">Backup cover</div>
     ${backupCoverHtml()}
+    <hr class="section-divider">
+    <div class="section-heading">Delete account</div>
+    ${deleteAccountHtml()}
     <button class="sign-out-btn" onclick="signOut()">Sign out</button>
   `;
   renderAvatar();
@@ -1181,6 +1184,9 @@ function renderProviderProfile() {
     <hr class="section-divider">
     <div class="section-heading">Service area</div>
     ${serviceAreaHtml()}
+    <hr class="section-divider">
+    <div class="section-heading">Delete account</div>
+    ${deleteAccountHtml()}
     <button class="sign-out-btn" onclick="signOut()">Sign out</button>
   `;
   renderAvatar();
@@ -1531,6 +1537,118 @@ async function uploadPetPhoto(input, petId) {
 function signOut() {
   localStorage.removeItem('truffl_session');
   window.location.href = '/';
+}
+
+/* ── Delete account (TRU-228) ──────────────────────────────────────────────────
+   Required by both stores: Apple guideline 5.1.1(v) wants deletion initiated AND
+   completed in-app. Rendered for both roles — a carer needs this as much as an owner.
+
+   Deliberately NOT a bare confirm(): this is irreversible, and a native dialog is both
+   too weak a speed bump and ugly in the app WebView. We reuse mgOverlay() and ask the
+   user to type DELETE, which the edge function also requires.                        */
+function deleteAccountHtml() {
+  return `
+    <div class="cover-card">
+      <p>Deleting your account is <b>permanent</b>. Your name, contact details, pet
+      details, photos, walk routes and message history are removed.</p>
+      <p>Records of bookings that already happened are kept, without your personal
+      details, because we're required to keep payment records — see our
+      <a href="/privacy/#rights" target="_blank" rel="noopener" style="color:var(--terracotta);">privacy policy</a>.</p>
+      <div class="bc-actions">
+        <button class="btn-ghost danger" onclick="openDeleteAccount()">Delete my account</button>
+      </div>
+    </div>
+  `;
+}
+
+async function openDeleteAccount() {
+  mgOverlay(`
+    <h2 style="margin-top:0;">Delete your account?</h2>
+    <p style="font-size:0.9rem;">Checking whether anything needs settling first…</p>
+    <div id="delMsg" class="msg"></div>
+  `);
+
+  // Pre-flight. Advisory only — the server re-checks inside the transaction — but it
+  // means we explain the blocker instead of failing at the last step.
+  let blockers;
+  try {
+    blockers = await sbRpc('account_deletion_blockers', {});
+  } catch (e) {
+    document.querySelector('#mgOverlay .form-card').innerHTML = `
+      <h2 style="margin-top:0;">Delete your account?</h2>
+      <p style="font-size:0.9rem;">We couldn't check your account just now: ${e.message}</p>
+      <div style="display:flex;gap:10px;justify-content:flex-end;">
+        <button class="btn-ghost" onclick="closeMgOverlay()">Close</button>
+      </div>`;
+    return;
+  }
+
+  const reasons = [];
+  if (blockers.future_bookings > 0) {
+    reasons.push(`${blockers.future_bookings} booking${blockers.future_bookings === 1 ? '' : 's'} still scheduled — please cancel ${blockers.future_bookings === 1 ? 'it' : 'them'} first, so nobody is left without care.`);
+  }
+  if (blockers.unpaid_completed > 0) {
+    reasons.push(`${blockers.unpaid_completed} completed booking${blockers.unpaid_completed === 1 ? '' : 's'} still to settle. Please contact us and we'll sort it out.`);
+  }
+
+  if (reasons.length) {
+    document.querySelector('#mgOverlay .form-card').innerHTML = `
+      <h2 style="margin-top:0;">Not just yet</h2>
+      <p style="font-size:0.9rem;">Before you can delete your account:</p>
+      <ul style="font-size:0.9rem;line-height:1.6;padding-left:1.1rem;margin:0 0 1rem;">
+        ${reasons.map(r => `<li>${r}</li>`).join('')}
+      </ul>
+      <div style="display:flex;gap:10px;justify-content:flex-end;">
+        <button class="btn-ghost" onclick="closeMgOverlay()">Close</button>
+      </div>`;
+    return;
+  }
+
+  document.querySelector('#mgOverlay .form-card').innerHTML = `
+    <h2 style="margin-top:0;">Delete your account?</h2>
+    <p style="font-size:0.9rem;">This cannot be undone. Your personal details, pets, photos,
+    walk routes and messages are removed, and you'll be signed out immediately.</p>
+    <p style="font-size:0.9rem;">Type <b>DELETE</b> to confirm.</p>
+    <div class="cover-field">
+      <input type="text" id="delConfirm" autocomplete="off" autocapitalize="characters" placeholder="DELETE">
+    </div>
+    <div id="delMsg" class="msg"></div>
+    <div style="display:flex;gap:10px;justify-content:flex-end;margin-top:1rem;">
+      <button class="btn-ghost" onclick="closeMgOverlay()">Keep my account</button>
+      <button class="btn-ghost danger" id="delGo" onclick="confirmDeleteAccount()">Delete permanently</button>
+    </div>`;
+  document.getElementById('delConfirm').focus();
+}
+
+async function confirmDeleteAccount() {
+  const box = document.getElementById('delConfirm');
+  const msg = document.getElementById('delMsg');
+  const btn = document.getElementById('delGo');
+  const typed = (box.value || '').trim().toUpperCase();
+
+  if (typed !== 'DELETE') {
+    msg.textContent = 'Please type DELETE to confirm.';
+    msg.className = 'msg error';
+    return;
+  }
+
+  btn.disabled = true;
+  btn.textContent = 'Deleting…';
+  msg.className = 'msg';
+  msg.textContent = '';
+
+  try {
+    await sbFn('delete-account', { confirm: 'DELETE' });
+    // The auth user is gone, so the stored session is dead — clear it before leaving or
+    // session.js will keep trying to refresh a token that no longer exists.
+    localStorage.removeItem('truffl_session');
+    window.location.href = '/?deleted=1';
+  } catch (e) {
+    btn.disabled = false;
+    btn.textContent = 'Delete permanently';
+    msg.textContent = e.message;
+    msg.className = 'msg error';
+  }
 }
 
 /* ── Unread message badges (customer header + per-booking-card) ── */

--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -1,0 +1,100 @@
+// TRU-228: in-app account deletion.
+//
+// Apple guideline 5.1.1(v) requires deletion to be initiated AND completed in-app.
+// This is the only thing that can complete it: the sweep needs the service role, and
+// deleting the auth user needs the admin API — neither is safe to expose to a browser.
+//
+// verify_jwt is DISABLED, same reason as stripe-api and geo-api: the browser CORS
+// preflight (OPTIONS) carries no JWT, so the platform gate would reject it and the call
+// would never reach us. We authenticate in-function via auth.getUser instead.
+//
+// ORDER MATTERS AND IS NOT INTERCHANGEABLE. public.users has NO foreign key to
+// auth.users (both ids are populated by the handle_new_user trigger), so deleting the
+// auth user first would orphan the entire public graph with no way to find it again:
+//   1. admin_delete_account()   — anonymise + purge, and re-check the blockers
+//   2. storage objects           — the actual files, not just the DB rows
+//   3. auth.admin.deleteUser()   — last, and only if 1 and 2 succeeded
+//
+// If step 1 raises (future bookings, unsettled payments), we return 409 and the account
+// is left completely untouched — the function is a no-op on the failure path.
+//
+// Required secrets: SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY are injected automatically.
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { corsHeaders } from '../_shared/cors.ts';
+
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
+const SERVICE_ROLE = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+
+const sb = createClient(SUPABASE_URL, SERVICE_ROLE, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+// Both buckets key objects by the owner's auth uid: `${authUid}/avatar_…`,
+// `${authUid}/pet_…`, and the same prefix for walk photos.
+const BUCKETS = ['profile-photos', 'walk-photos'];
+
+/** Remove every object under `<userId>/` in a bucket. Returns how many were removed. */
+async function purgeBucket(bucket: string, userId: string): Promise<number> {
+  const { data, error } = await sb.storage.from(bucket).list(userId, { limit: 1000 });
+  if (error || !data || data.length === 0) return 0;
+
+  const paths = data.map((f) => `${userId}/${f.name}`);
+  const { error: rmErr } = await sb.storage.from(bucket).remove(paths);
+  if (rmErr) throw new Error(`storage cleanup failed for ${bucket}: ${rmErr.message}`);
+  return paths.length;
+}
+
+Deno.serve(async (req) => {
+  const CORS = corsHeaders(req);
+  const json = (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), { status, headers: { ...CORS, 'Content-Type': 'application/json' } });
+
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: CORS });
+  if (req.method !== 'POST') return json({ error: 'Method not allowed' }, 405);
+
+  // Identify the caller from their Supabase JWT (users.id === auth.uid()).
+  const jwt = (req.headers.get('Authorization') || '').replace(/^Bearer\s+/i, '');
+  const { data: { user }, error: uerr } = await sb.auth.getUser(jwt);
+  if (uerr || !user) return json({ error: 'Not authenticated' }, 401);
+
+  let payload: Record<string, unknown> = {};
+  try { payload = await req.json(); } catch { /* empty body ok */ }
+
+  // A deliberate speed bump. The UI asks the user to type DELETE; requiring it here too
+  // means a stray POST to this endpoint cannot wipe an account by accident.
+  if (String(payload.confirm || '').trim().toUpperCase() !== 'DELETE') {
+    return json({ error: 'Confirmation phrase missing' }, 400);
+  }
+
+  // 1. The sweep. Raises on blockers, in which case nothing has been changed.
+  const { data: sweep, error: sweepErr } = await sb.rpc('admin_delete_account', { p_user_id: user.id });
+  if (sweepErr) {
+    const msg = sweepErr.message || 'Deletion failed';
+    // Blocker messages are written to be shown to the user as-is.
+    const isBlocked = /^Cannot delete:/i.test(msg);
+    return json({ error: msg, blocked: isBlocked }, isBlocked ? 409 : 500);
+  }
+
+  // 2. Storage. After the sweep (which already nulled the URLs pointing here) and before
+  //    the auth user is deleted, so a failure here still leaves a recoverable account.
+  let filesRemoved = 0;
+  try {
+    for (const bucket of BUCKETS) filesRemoved += await purgeBucket(bucket, user.id);
+  } catch (e) {
+    return json({ error: (e as Error).message }, 500);
+  }
+
+  // 3. The auth user, last. Past this point the account cannot sign in again.
+  const { error: delErr } = await sb.auth.admin.deleteUser(user.id);
+  if (delErr) {
+    // The public-side data is already anonymised and the user is delisted, so this is
+    // not a security hole — but the login still works, so it must be surfaced loudly.
+    return json({
+      error: 'Your data was removed but the login could not be closed. Please contact support@trufflpets.com.',
+      detail: delErr.message,
+    }, 500);
+  }
+
+  return json({ ok: true, ...(sweep as Record<string, unknown>), files_removed: filesRemoved });
+});

--- a/supabase/migrations/20260729000000_tru228_account_deletion.sql
+++ b/supabase/migrations/20260729000000_tru228_account_deletion.sql
@@ -1,0 +1,271 @@
+-- TRU-228: in-app account deletion.
+--
+-- Apple guideline 5.1.1(v) requires account deletion to be initiated AND completed
+-- in-app; Play requires an in-app route plus a web-accessible deletion URL. Neither
+-- existed — there was no deletion or deactivation code anywhere in the codebase.
+--
+-- WHY ANONYMISE RATHER THAN DELETE. This is forced by the schema, not a preference:
+--   * messages.sender_id is ON DELETE RESTRICT, and reviews.customer_id/provider_id
+--     and booking_series.customer_id/provider_id are too. A hard delete of a
+--     public.users or *_profiles row fails outright on those.
+--   * privacy/ section 6 publicly commits to keeping payment and transaction records
+--     for seven years, and those live denormalised on bookings (total_cents,
+--     stripe_payment_intent_id, charged_at, refunded_at...). Deleting the booking row
+--     would break that commitment.
+--   * A booking has two parties. A carer's record of the walks they completed should
+--     not evaporate because an owner closed their account, and vice versa.
+-- So we strip the identity and keep the skeleton.
+--
+-- KEEP THE LEDGER, DROP THE TRAIL. The retain/purge split is deliberately expressed as
+-- one contiguous block below so an item can be moved across the line in one place.
+--   RETAIN (de-identified): bookings, booking_series, walk_sessions, reviews,
+--     customer_credits.
+--   PURGE: gps_pings route geometry, message bodies, walk/booking update text+photos,
+--     private.backup_access, notifications, system_messages, precise location geography.
+-- This matches privacy/ section 6 as written ("walk routes, messages and booking
+-- history are kept while your account is active"), so no policy rewrite is needed.
+--
+-- NOT DONE, DELIBERATELY: Stripe is left untouched. A deleted owner's Stripe Customer
+-- and saved card remain at Stripe, and carers' Connect accounts persist — payout and
+-- AU tax obligations outlive the app account. customer_profiles.stripe_customer_id and
+-- provider_profiles.stripe_account_id are therefore retained; they are also the only
+-- link back to the financial records we are required to keep. Raised with Tom and left
+-- out by choice, not oversight.
+--
+-- ORDERING NOTE for the caller: public.users has NO foreign key to auth.users (both
+-- ids are populated by the handle_new_user trigger). Deleting the auth user first
+-- would orphan the entire public graph, so the delete-account edge function calls the
+-- sweep FIRST and only then calls auth.admin.deleteUser().
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 1. Pre-flight: what would stop this account being deleted?
+--    Client-callable so the profile page can explain the blockers before the user
+--    commits to anything irreversible. Advisory only — the sweep re-checks.
+-- ─────────────────────────────────────────────────────────────────────────────
+create or replace function public.account_deletion_blockers()
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_cp_id   uuid;
+  v_pp_id   uuid;
+  v_future  integer := 0;
+  v_owed    integer := 0;
+begin
+  if v_user_id is null then
+    raise exception 'Not authenticated';
+  end if;
+
+  select id into v_cp_id from public.customer_profiles where user_id = v_user_id;
+  select id into v_pp_id from public.provider_profiles where user_id = v_user_id;
+
+  -- Still-live commitments to the other party. ends_at is null on older rows, so fall
+  -- back to scheduled_at.
+  select count(*) into v_future
+  from public.bookings b
+  where b.status in ('pending', 'confirmed')
+    and coalesce(b.ends_at, b.scheduled_at) > now()
+    and ( (v_cp_id is not null and b.customer_id = v_cp_id)
+       or (v_pp_id is not null and b.provider_id = v_pp_id) );
+
+  -- Money not yet settled either way: an owner must not be able to delete their way
+  -- out of a charge, and a carer should be paid before they go.
+  select count(*) into v_owed
+  from public.bookings b
+  where b.status = 'completed'
+    and coalesce(b.payment_status, 'unpaid') in ('unpaid', 'failed', 'processing')
+    and ( (v_cp_id is not null and b.customer_id = v_cp_id)
+       or (v_pp_id is not null and b.provider_id = v_pp_id) );
+
+  return jsonb_build_object(
+    'future_bookings',  v_future,
+    'unpaid_completed', v_owed,
+    'can_delete',       (v_future = 0 and v_owed = 0)
+  );
+end;
+$$;
+
+revoke all on function public.account_deletion_blockers() from public, anon;
+grant execute on function public.account_deletion_blockers() to authenticated;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 2. The sweep. service_role only — same discipline as admin_create_lead_series:
+--    it lives in public because PostgREST (and therefore the edge function's
+--    sb.rpc()) only sees exposed schemas, but EXECUTE is revoked from every client
+--    role so it is unreachable from a browser.
+-- ─────────────────────────────────────────────────────────────────────────────
+create or replace function public.admin_delete_account(p_user_id uuid)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_cp_id  uuid;
+  v_pp_id  uuid;
+  v_email  text;
+  v_future integer;
+  v_owed   integer;
+  -- users.email is UNIQUE, so the placeholder must be too. Use the WHOLE user id —
+  -- it is the primary key, so it is unique by construction. Do not truncate it: a
+  -- shortened prefix can collide, and the collision surfaces as a hard failure that
+  -- makes the second user's account undeletable.
+  v_tag    text := replace(p_user_id::text, '-', '');
+  v_pings  integer := 0;
+  v_msgs   integer := 0;
+  -- Every walk session this user was party to, on either side of the booking.
+  v_sessions uuid[];
+begin
+  select email into v_email from public.users where id = p_user_id;
+  if v_email is null then
+    raise exception 'No such user: %', p_user_id;
+  end if;
+
+  select id into v_cp_id from public.customer_profiles where user_id = p_user_id;
+  select id into v_pp_id from public.provider_profiles where user_id = p_user_id;
+
+  -- Re-check the blockers here, inside the transaction. The pre-flight the UI ran is
+  -- advisory; state can change between the two calls, and this function is the only
+  -- thing standing between a client request and irreversible data loss.
+  select count(*) into v_future
+  from public.bookings b
+  where b.status in ('pending', 'confirmed')
+    and coalesce(b.ends_at, b.scheduled_at) > now()
+    and ( (v_cp_id is not null and b.customer_id = v_cp_id)
+       or (v_pp_id is not null and b.provider_id = v_pp_id) );
+  if v_future > 0 then
+    raise exception 'Cannot delete: % future booking(s) still scheduled', v_future;
+  end if;
+
+  select count(*) into v_owed
+  from public.bookings b
+  where b.status = 'completed'
+    and coalesce(b.payment_status, 'unpaid') in ('unpaid', 'failed', 'processing')
+    and ( (v_cp_id is not null and b.customer_id = v_cp_id)
+       or (v_pp_id is not null and b.provider_id = v_pp_id) );
+  if v_owed > 0 then
+    raise exception 'Cannot delete: % completed booking(s) not yet settled', v_owed;
+  end if;
+
+  -- ── Delist first ───────────────────────────────────────────────────────────
+  -- Before anything else, so a carer disappears from search and can't be booked
+  -- while the rest of the sweep runs. is_active gates the public RLS read policy,
+  -- provider_search_view and search_carers.
+  if v_pp_id is not null then
+    update public.provider_profiles
+       set is_active = false, updated_at = now()
+     where id = v_pp_id;
+    update public.provider_services set is_available = false where provider_id = p_user_id;
+  end if;
+
+  -- ── PURGE: the trail ───────────────────────────────────────────────────────
+  -- Resolve the sessions once. Membership is by EITHER side of the booking, not just
+  -- walk_sessions.provider_id: when an owner leaves, the route and the update photos
+  -- are the carer's rows but they are *about* the owner's dog and home.
+  select array_agg(ws.id) into v_sessions
+    from public.walk_sessions ws
+    left join public.bookings b on b.id = ws.booking_id
+   where ws.provider_id = p_user_id
+      or (v_cp_id is not null and b.customer_id = v_cp_id)
+      or (v_pp_id is not null and b.provider_id = v_pp_id);
+
+  -- Route geometry goes when either party leaves; the walk_sessions row (when, how
+  -- long, how far) survives so the other party keeps their record of the walk.
+  delete from public.gps_pings where walk_session_id = any(v_sessions);
+  get diagnostics v_pings = row_count;
+
+  -- Own message bodies only — never the other party's side of the conversation.
+  update public.messages set body = '[deleted]' where sender_id = p_user_id;
+  get diagnostics v_msgs = row_count;
+
+  -- Free-text and photo pointers. The storage objects themselves are removed by the
+  -- edge function; nulling the URL stops a dangling link.
+  update public.walk_updates
+     set message = null, photo_url = null
+   where provider_id = p_user_id
+      or walk_session_id = any(v_sessions);
+
+  -- booking_updates.photo_url is NOT NULL — these rows ARE the photo check-in, so a
+  -- blanked row would be meaningless, and attempting to null it aborts the whole
+  -- deletion. Delete them instead; the booking's own status and completed_at already
+  -- record that the visit happened.
+  delete from public.booking_updates bu
+   where bu.provider_user_id = p_user_id
+      or (v_cp_id is not null and bu.booking_id in (select id from public.bookings where customer_id = v_cp_id));
+
+  -- Personal, addressed to this user, and of no value to anyone else.
+  delete from public.notifications  where user_id = p_user_id;
+  delete from public.system_messages where recipient_user_id = p_user_id;
+
+  -- Home access details. privacy/ section 6 already promises these go immediately on
+  -- opt-out; closing the account is at least as strong a signal.
+  if v_cp_id is not null then
+    delete from private.backup_access where customer_id = v_cp_id;
+  end if;
+
+  -- No FK on this column, so it would silently dangle rather than cascade.
+  update public.search_misses set customer_id = null where customer_id = v_cp_id;
+
+  -- ── ANONYMISE: the identity ────────────────────────────────────────────────
+  if v_cp_id is not null then
+    update public.customer_profiles
+       set address = null, suburb = null, postcode = null,
+           emergency_contact = null, emergency_phone = null,
+           location = null,                      -- precise geography
+           backup_cover_enabled = false,
+           updated_at = now()
+     where id = v_cp_id;
+
+    -- Pets are identifying (name, microchip, vet) and their photos are being removed.
+    update public.pets
+       set name = 'Pet', breed = null, microchip_no = null,
+           vet_name = null, vet_phone = null,
+           medical_notes = null, behaviour_notes = null,
+           photo_url = null, is_active = false
+     where customer_id = v_cp_id;
+  end if;
+
+  if v_pp_id is not null then
+    update public.provider_profiles
+       set bio = null, suburb = null, postcode = null, abn = null,
+           location = null, service_area = null,  -- precise geography
+           updated_at = now()
+     where id = v_pp_id;
+  end if;
+
+  -- Lead capture. customer_id is nullable by design (search is public), so guest leads
+  -- have no user key at all — match on the email address as well or they survive.
+  update public.carer_requests
+     set contact_name = 'Deleted user', contact_email = null, contact_phone = null,
+         note = null, dog_name = null, dog_breed = null, dog_temperament_note = null,
+         search_params = null
+   where (v_cp_id is not null and (customer_id = v_cp_id or converted_customer_id = v_cp_id))
+      or lower(contact_email) = lower(v_email);
+
+  update public.users
+     set first_name = 'Deleted',
+         last_name  = 'user',
+         email      = 'deleted+' || v_tag || '@trufflpets.com',
+         phone      = null,
+         avatar_url = null,
+         is_active  = false,
+         is_admin   = false,
+         updated_at = now()
+   where id = p_user_id;
+
+  return jsonb_build_object(
+    'user_id',            p_user_id,
+    'gps_pings_deleted',  v_pings,
+    'messages_redacted',  v_msgs,
+    'had_customer_profile', v_cp_id is not null,
+    'had_provider_profile', v_pp_id is not null
+  );
+end;
+$$;
+
+-- TRU-153 discipline: a definer function must never be reachable by a client role.
+revoke all on function public.admin_delete_account(uuid) from public, anon, authenticated;
+grant execute on function public.admin_delete_account(uuid) to service_role;


### PR DESCRIPTION
Apple guideline 5.1.1(v) requires deletion to be **initiated and completed** in-app; Play requires an in-app route **plus** a web-accessible deletion URL. Neither existed — there was no deletion or deactivation code anywhere in the codebase.

## Why anonymise instead of delete

This is forced by the schema, not a preference:

- `messages.sender_id` is `ON DELETE RESTRICT`, and so are `reviews.customer_id/provider_id` and `booking_series.*`. A hard delete of a `users` or `*_profiles` row **fails outright**.
- `privacy/` §6 publicly commits to keeping payment records for **seven years**, and those live denormalised on `bookings`.
- A booking has two parties. A carer's record of the walks they completed shouldn't evaporate because an owner left.

Also worth knowing: `public.users` has **no FK to `auth.users`** — both ids come from the `handle_new_user` trigger. So the edge function's ordering is not interchangeable: sweep first, `auth.admin.deleteUser()` **last**. The reverse orphans the entire public graph with no way to find it again.

## Keep the ledger, drop the trail

| Retained (de-identified) | Purged |
|---|---|
| `bookings` — dates, amounts, `stripe_payment_intent_id` | `gps_pings` route geometry |
| `booking_series`, `walk_sessions` (when/duration/distance) | message bodies (own only) |
| `reviews`, `customer_credits` | walk + booking update text and photos |
| | `backup_access`, notifications, system messages |
| | precise `location` geography, storage objects |

This matches `privacy/` §6 **as already written** ("walk routes, messages and booking history are kept *while your account is active*"), so no policy rewrite was needed — only an addition to §7, which doubles as Play's required deletion URL at `/privacy/#deletion`.

Blocked on future confirmed bookings and completed-but-unsettled ones, so deletion can't strand the other party or dodge a charge. `provider_profiles.is_active = false` is the first write, delisting a carer immediately.

## Three real bugs, caught by testing

Verifying against a throwaway two-party scenario found three defects I'd otherwise have shipped:

1. **`walk_updates` only purged when the deleting user was the carer.** When an *owner* left, those rows belong to the carer but are photos of the owner's dog and home — and their storage objects were being deleted, so the `photo_url` would dangle. Session membership is now resolved once, by either side of the booking.
2. **`booking_updates.photo_url` is `NOT NULL`.** Blanking it raised and **aborted the entire deletion**. Those rows *are* the photo check-in, so they're deleted instead; the booking's own `status`/`completed_at` still records the visit.
3. **The anonymised email was built from a truncated uuid.** `users.email` is `UNIQUE`, so two users sharing a 12-char prefix would collide — making the second account permanently undeletable. Now uses the whole primary key, unique by construction.

## Verification

- **Blockers:** future booking → refused; completed-unpaid → refused; unauthenticated pre-flight → raises. Each blocked attempt mutated **nothing**.
- **The sweep, both roles:** identity anonymised, pets/PII/GPS/photos gone — while the **counterparty's messages and review survived**, and `bookings` money columns were **byte-for-byte unchanged**. Carer path additionally delisted and made services unbookable.
- **Live end-to-end** through the deployed function (via `pg_net`, since the sandbox blocks `*.supabase.co`): real signup → `401` with no/garbage JWT, `400` without the typed confirmation, `200` with it — after which the `auth.users` row **and its refresh tokens** are gone and the public row is anonymised.
- Grants confirmed: `admin_delete_account` is **service_role only** (no `anon`, no `authenticated`); `account_deletion_blockers` is `authenticated`.
- All test data removed — the DB is back to its original 29 users with no residue.

Migration applied to live and committed. Function deployed as `delete-account` v1 with `verify_jwt: false` (same in-function `auth.getUser` pattern as `stripe-api`, for the same CORS-preflight reason).

## Needs your eyes

⚠️ **I can't drive signed-in UI** (no password entry), so the profile-page flow — the typed-DELETE modal at both role call sites — needs testing by you before launch. The server side behind it is fully verified.

## Notes

- **Stripe is untouched by choice** (you opted out of detaching it): a deleted owner's saved card stays at Stripe, and carers' Connect accounts persist — defensible, since payout and AU tax obligations outlive the app account. `privacy/` §7 now says so plainly and invites people to ask. Easy to add later.
- The live DB has an extra intermediate migration version from iterating on this; the single committed file is the correct final state and replays cleanly on a fresh DB. Folds into the `schema_migrations` repair already scoped on TRU-177.
- TRU-227's `terms/` §11 says to contact us to close an account. Still true, but once both merge it's worth pointing it at the in-app route — one-line follow-up.