### PR TITLE
Declutter the header nav: drop the on-page anchor links

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -444,9 +444,7 @@
       <div class="nav-links">
         <a href="/">Home</a>
         <a href="/about-us/" class="active">About</a>
-        <a href="/#services">Services</a>
         <a href="/trust-and-safety/">Trust &amp; safety</a> <a href="/how-we-vet/">How we vet</a>
-        <a href="/#how">How it works</a>
       </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -330,10 +330,7 @@
         </svg>
       </a>
       <div class="nav-links">
-        <a href="#services">Services</a>
         <a href="/about-us/">About</a>
-        <a href="#why">Our carers</a>
-        <a href="#how">How it works</a>
         <a href="/trust-and-safety/">Trust &amp; safety</a> <a href="/how-we-vet/">How we vet</a>
       </div>
     </div>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -93,7 +93,6 @@
         <a href="/">Home</a>
         <a href="/about-us/">About</a>
         <a href="/trust-and-safety/">Trust &amp; safety</a>
-        <a href="/#how">How it works</a>
       </div>
     </div>
     <div class="nav-actions">

--- a/trust-and-safety/choosing-your-carer/index.html
+++ b/trust-and-safety/choosing-your-carer/index.html
@@ -79,7 +79,6 @@
         <a href="/">Home</a>
         <a href="/about-us/">About</a>
         <a href="/trust-and-safety/" class="active">Trust &amp; safety</a>
-        <a href="/#how">How it works</a>
       </div>
     </div>
     <div class="nav-actions">

--- a/trust-and-safety/following-along-with-gps/index.html
+++ b/trust-and-safety/following-along-with-gps/index.html
@@ -72,7 +72,6 @@
         <a href="/">Home</a>
         <a href="/about-us/">About</a>
         <a href="/trust-and-safety/" class="active">Trust &amp; safety</a>
-        <a href="/#how">How it works</a>
       </div>
     </div>
     <div class="nav-actions">

--- a/trust-and-safety/getting-ready/index.html
+++ b/trust-and-safety/getting-ready/index.html
@@ -74,7 +74,6 @@
         <a href="/">Home</a>
         <a href="/about-us/">About</a>
         <a href="/trust-and-safety/" class="active">Trust &amp; safety</a>
-        <a href="/#how">How it works</a>
       </div>
     </div>
     <div class="nav-actions">

--- a/trust-and-safety/if-something-goes-wrong/index.html
+++ b/trust-and-safety/if-something-goes-wrong/index.html
@@ -78,7 +78,6 @@
         <a href="/">Home</a>
         <a href="/about-us/">About</a>
         <a href="/trust-and-safety/" class="active">Trust &amp; safety</a>
-        <a href="/#how">How it works</a>
       </div>
     </div>
     <div class="nav-actions">

--- a/trust-and-safety/index.html
+++ b/trust-and-safety/index.html
@@ -99,7 +99,6 @@
         <a href="/">Home</a>
         <a href="/about-us/">About</a>
         <a href="/trust-and-safety/" class="active">Trust &amp; safety</a>
-        <a href="/#how">How it works</a>
       </div>
     </div>
     <div class="nav-actions">

--- a/trust-and-safety/keeping-it-on-truffl/index.html
+++ b/trust-and-safety/keeping-it-on-truffl/index.html
@@ -72,7 +72,6 @@
         <a href="/">Home</a>
         <a href="/about-us/">About</a>
         <a href="/trust-and-safety/" class="active">Trust &amp; safety</a>
-        <a href="/#how">How it works</a>
       </div>
     </div>
     <div class="nav-actions">

--- a/trust-and-safety/reporting-a-concern/index.html
+++ b/trust-and-safety/reporting-a-concern/index.html
@@ -72,7 +72,6 @@
         <a href="/">Home</a>
         <a href="/about-us/">About</a>
         <a href="/trust-and-safety/" class="active">Trust &amp; safety</a>
-        <a href="/#how">How it works</a>
       </div>
     </div>
     <div class="nav-actions">


### PR DESCRIPTION
The top bar had grown to six items on the homepage, and three of them — **Services**, **Our carers**, **How it works** — were anchors to sections further down the same page, not destinations of their own. Removed, leaving only real pages.

### Before / after

| | Homepage nav |
|---|---|
| Before | Services · About · Our carers · How it works · Trust & safety · How we vet |
| After | About · Trust & safety · How we vet |

Applied to every header nav that carried one of these, so the nav is consistent site-wide:

- `index.html` — dropped `#services`, `#why`, `#how`
- `about-us/` — dropped `/#services`, `/#how`
- `privacy/`, `trust-and-safety/` and its 6 subpages — dropped `/#how`

`how-we-vet/` and `search/` had none and are untouched. 13 lines deleted, nothing added.

### The sections are still reachable

The three sections are unchanged and still on the homepage. `#how` also keeps a direct entry point — the hero's **How Truffl works** button — verified live: clicking it still lands the section at the top of the viewport.

### A wrap bug this improves but does not fix

`nav` is `height: 82px` with `flex-wrap: wrap`, so as soon as the row overflows, *Sign in / Book a carer* wraps to a second line that **spills out of the fixed-height bar and over the hero**. Measured on the running page:

| Viewport | Before | After |
|---|---|---|
| 1180px | wrapped (nav-left 719px) | single row (nav-left 436px) |
| 1100px | wrapped | still wrapped |

So the breakage moves from ~1180px down to somewhere under 1100px — better, but small laptops and iPad landscape still hit it. Genuine fix is a separate call (drop the fixed height, or hide `.nav-links` at a higher breakpoint than the current mobile one); flagging rather than deciding it here.

### Verified

Served locally, checked at 1440 / 1180 / 1100 / 1024, no console errors, homepage and about-us navs read back correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)