### PR TITLE
Homepage: add the Dog daycare service tile

### DIFF
--- a/index.html
+++ b/index.html
@@ -807,6 +807,15 @@
         <div class="svc-desc">In-home visits so your dog stays comfortable in their own environment while you're away.</div>
         <div class="svc-price">From $40 / visit</div>
       </a>
+      <a href="/search/" class="svc-card">
+        <div class="svc-num">04</div>
+        <div class="svc-icon">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#7A6860" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3.5"/><path d="M12 4v1.5M12 18.5V20M4 12h1.5M18.5 12H20M6.3 6.3l1 1M16.7 16.7l1 1M6.3 17.7l1-1M16.7 7.3l1-1"/></svg>
+        </div>
+        <div class="svc-name">Dog daycare</div>
+        <div class="svc-desc">A full day of company and play at your carer's place while you're at work, with photo updates.</div>
+        <div class="svc-price">From $50 / day</div>
+      </a>
     </div>
   </section>
 


### PR DESCRIPTION
Adds back a fourth service tile, this time for **Dog daycare**.

### Why the grid looked off

`.services-grid` is `grid-template-columns: repeat(4, 1fr)` and `.svc-card:nth-child(4)` still has its own background — both left behind when `532d0e2` ("Drop cat services for dogs-only MVP", TRU-68) removed the Cat sitting card. So the row has been rendering three cards in a four-column grid, with an empty column on the right, ever since. This fills it rather than reflowing the grid.

### Why daycare is the right fourth

`dog_daycare` is already a first-class service type everywhere else in the app:

- `search/` service filter — "Dog daycare · During work hours"
- homepage + `about-us/` search popover chips, and the "Daycare in Inner West" suggestion
- `register/` and `dashboard/` provider service pickers
- `admin/` and `messages/` label maps
- the homepage's own `og:description` and LocalBusiness schema already say "walking, boarding, sitting and daycare"

The services showcase was the one customer-facing surface that didn't list it.

Reuses the existing `dog-daycare` sun icon from the search picker, and the `#7A6860` stroke colour the old fourth card used against the `#E8E0D5` background.

### Two things to check before merge

**1. The price is a guess.** I set `From $50 / day`. There's no live rate to derive it from (see below), and the other three tiles are marketing floors rather than computed minimums — every one sits above the real minimum in `provider_services`:

| Tile | Says | Actual min live |
|---|---|---|
| Dog walking | From $28 / walk | $24 |
| Dog boarding | From $55 / night | $50 |
| Dog sitting | From $40 / visit | $30 |
| Dog daycare | From $50 / day | *no rows* |

$50 slots below boarding's overnight rate and above sitting, which is the right shape for a full day — but it's my number, not yours. Change it if you have one in mind.

**2. No carer currently offers daycare.** `provider_services` has zero `dog_daycare` rows, available or otherwise. So the tile advertises a service that can't be booked today. It's not a dead end — the card links to `/search/` unfiltered, same as the other three, so nobody lands on an empty result from clicking it, and if they do filter to daycare the TRU-121 "can't find a carer" request form catches them. Worth knowing it's a demand signal rather than live inventory.

### Verified

Served locally: four cards, equal 280px widths and equal heights on one row at desktop, clean 2×2 at the 900px breakpoint (previously 2 + 1 orphan), single column below 600px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)